### PR TITLE
network: PushHeaders and BlockEvent to request missing blocks

### DIFF
--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -76,14 +76,14 @@ pub trait BlockService: P2pService {
     // implementation to produce a server-streamed response.
     //type GetHeadersFuture: Future<Item = Self::GetHeadersStream, Error = Error>;
 
-    /// The type of asynchronous futures returned by method `block_subscription`.
-    ///
-    /// The future resolves to a stream of blocks sent by the remote node
-    /// and the identifier of the node in the network.
-    type BlockSubscriptionFuture: Future<
-        Item = (Self::BlockSubscription, Self::NodeId),
-        Error = Error,
-    >;
+    /// The type of asynchronous futures returned by method `push_headers`.
+    type PushHeadersFuture: Future<Item = (), Error = Error>;
+
+    /// The outbound counterpart of `pull_headers`, called in response to a
+    /// `BlockEvent::Missing` solicitation.
+    fn push_headers<S>(&mut self, headers: S) -> Self::PushHeadersFuture
+    where
+        S: Stream<Item = <Self::Block as HasHeader>::Header> + Send + 'static;
 
     /// The type of asynchronous futures returned by method `upload_blocks`.
     type UploadBlocksFuture: Future<Item = (), Error = Error>;
@@ -94,6 +94,15 @@ pub trait BlockService: P2pService {
     fn upload_blocks<S>(&mut self, blocks: S) -> Self::UploadBlocksFuture
     where
         S: Stream<Item = Self::Block> + Send + 'static;
+
+    /// The type of asynchronous futures returned by method `block_subscription`.
+    ///
+    /// The future resolves to a stream of blocks sent by the remote node
+    /// and the identifier of the node in the network.
+    type BlockSubscriptionFuture: Future<
+        Item = (Self::BlockSubscription, Self::NodeId),
+        Error = Error,
+    >;
 
     /// The type of an asynchronous stream that provides notifications
     /// of blocks created or accepted by the remote node.

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -76,11 +76,14 @@ pub trait BlockService: P2pService {
     /// implementation to produce a server-streamed response.
     type GetHeadersFuture: Future<Item = Self::GetHeadersStream, Error = Error> + Send + 'static;
 
+    /// The type of asynchronous futures returned by method `push_headers`.
+    type PushHeadersFuture: Future<Item = (), Error = Error> + Send + 'static;
+
     /// The type of asynchronous futures returned by method `on_uploaded_block`.
     type OnUploadedBlockFuture: Future<Item = (), Error = Error> + Send + 'static;
 
-    /// The type of an asynchronous stream that retrieves headers of new
-    /// blocks as they are created.
+    /// The type of asynchronous stream that lets the client receive
+    /// new block announcements and solicitation requests from the service.
     type BlockSubscription: Stream<Item = BlockEvent<Self::Block>, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by method `block_subscription`.
@@ -111,8 +114,8 @@ pub trait BlockService: P2pService {
     /// to the server's tip.
     fn pull_blocks_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullBlocksToTipFuture;
 
-    /// Get block headers, walking forward in a range between any of the given
-    /// starting points, and the ending point.
+    /// Get block headers, walking the chain forward in a range between any
+    /// of the given starting points, and the ending point.
     fn pull_headers(
         &mut self,
         from: &[Self::BlockId],
@@ -122,6 +125,12 @@ pub trait BlockService: P2pService {
     /// Stream block headers from either of the given starting points
     /// to the server's tip.
     fn pull_headers_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullHeadersFuture;
+
+    /// The outbound counterpart of `pull_headers`, called in response to a
+    /// `BlockEvent::Missing` solicitation.
+    fn push_headers<In>(&mut self, headers: In) -> Self::PushHeadersFuture
+    where
+        In: Stream<Item = Self::Header, Error = Error> + Send + 'static;
 
     /// Called when the client connection uploads a block.
     fn on_uploaded_block(&mut self, block: Self::Block) -> Self::OnUploadedBlockFuture;
@@ -133,7 +142,8 @@ pub trait BlockService: P2pService {
     /// announcements.
     ///
     /// Returns a future resolving to an asynchronous stream
-    /// that will be used by this node to send block announcements.
+    /// that will be used by this node to send block announcements
+    /// and solicitations.
     fn block_subscription<In>(
         &mut self,
         subscriber: Self::NodeId,

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -114,8 +114,11 @@ pub trait BlockService: P2pService {
     /// to the server's tip.
     fn pull_blocks_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullBlocksToTipFuture;
 
-    /// Get block headers, walking the chain forward in a range between any
-    /// of the given starting points, and the ending point.
+    /// Get block headers, walking the chain forward in a range between the
+    /// latest among the given starting points, and the given ending point.
+    /// If none of the starting points are found in the chain, or if the
+    /// ending point is not found, the future will fail with a `NotFound`
+    /// error.
     fn pull_headers(
         &mut self,
         from: &[Self::BlockId],
@@ -127,7 +130,10 @@ pub trait BlockService: P2pService {
     fn pull_headers_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullHeadersFuture;
 
     /// The outbound counterpart of `pull_headers`, called in response to a
-    /// `BlockEvent::Missing` solicitation.
+    /// `BlockEvent::Missing` solicitation. A client may report that
+    /// the solicitation does not refer to blocks found in the local blockchain
+    /// by making the `push_headers` call and failing the outbound stream with
+    /// a `NotFound` error.
     fn push_headers<In>(&mut self, headers: In) -> Self::PushHeadersFuture
     where
         In: Stream<Item = Self::Header, Error = Error> + Send + 'static;

--- a/network-core/src/subscription.rs
+++ b/network-core/src/subscription.rs
@@ -6,8 +6,9 @@ pub enum BlockEvent<B>
 where
     B: Block + HasHeader,
 {
-    Announce(<B as HasHeader>::Header),
-    Solicit(Vec<<B as Block>::Id>),
+    Announce(B::Header),
+    Solicit(Vec<B::Id>),
+    Missing { from: Vec<B::Id>, to: B::Id },
 }
 
 impl<B> Debug for BlockEvent<B>
@@ -20,6 +21,11 @@ where
         match self {
             BlockEvent::Announce(header) => f.debug_tuple("Announce").field(header).finish(),
             BlockEvent::Solicit(ids) => f.debug_tuple("Solicit").field(ids).finish(),
+            BlockEvent::Missing { from, to } => f
+                .debug_struct("Missing")
+                .field("from", from)
+                .field("to", to)
+                .finish(),
         }
     }
 }

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -25,6 +25,7 @@ message MessageIds {
 }
 
 // Request message for method PullHeaders.
+// This message can also be send by the service as a BlockEvent variant.
 message PullHeadersRequest {
   // The identifiers of blocks to consider as the
   // starting point, in order of appearance.
@@ -39,6 +40,9 @@ message PullBlocksToTipRequest {
   // starting point, in order of appearance.
   repeated bytes from = 1;
 }
+
+// Response message for method PushHeaders.
+message PushHeadersResponse {}
 
 // Response message for method UploadBlocks.
 message UploadBlocksResponse {}
@@ -73,9 +77,12 @@ message BlockEvent {
   oneof item {
     // Announcement of a new block, carrying the block's header.
     Header announce = 1;
-    // Solicitation to upload identified blocks with a method call
-    // UploadBlocks.
+    // Solicitation to upload identified blocks with an UploadBlocks
+    // method call.
     BlockIds solicit = 2;
+    // Solicitation to push the chain of block headers with a PushHeaders
+    // method call.
+    PullHeadersRequest missing = 3;
   }
 }
 
@@ -101,7 +108,12 @@ service Node {
 
   rpc PullBlocksToTip(PullBlocksToTipRequest) returns (stream Block);
 
-  // Uploads blocks to the service in response to a solicitation item
+  // Sends headers of blocks to the service in response to a `missing`
+  // item received from the BlockSubscription response stream.
+  // The headers are streamed the in chronological order of the chain.
+  rpc PushHeaders(stream Header) returns (PushHeadersResponse);
+
+  // Uploads blocks to the service in response to a `solicit` item
   // received from the BlockSubscription response stream.
   rpc UploadBlocks(stream Block) returns (UploadBlocksResponse);
 

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -425,6 +425,10 @@ where
         Self::GetMessagesStream,
         <<T as Node>::ContentService as ContentService>::GetMessagesFuture,
     >;
+    type PushHeadersFuture = ResponseFuture<
+        gen::node::PushHeadersResponse,
+        <T::BlockService as BlockService>::PushHeadersFuture,
+    >;
     type UploadBlocksFuture = UploadBlocksFuture<T, Streaming<gen::node::Block>>;
     type BlockSubscriptionStream = ResponseStream<
         gen::node::BlockEvent,
@@ -524,6 +528,15 @@ where
             }
         };
         ResponseFuture::new(service.get_messages(&tx_ids))
+    }
+
+    fn push_headers(
+        &mut self,
+        req: Request<Streaming<gen::node::Header>>,
+    ) -> Self::PushHeadersFuture {
+        let service = try_get_service!(self.inner.block_service());
+        let stream = RequestStream::new(req.into_inner());
+        ResponseFuture::new(service.push_headers(stream))
     }
 
     fn upload_blocks(


### PR DESCRIPTION
These additions to the protocol enable retrieval of chain from the gRPC client upon solicitation from the service.