### PR TITLE
export error type from the old address lib

### DIFF
--- a/cardano-legacy-address/Cargo.toml
+++ b/cardano-legacy-address/Cargo.toml
@@ -10,6 +10,7 @@ description = """
 Support for the useful part of legacy cardano address.
 """
 keywords = [ "Cardano", "Wallet", "Crypto" ]
+edition = "2018"
 
 [build-dependencies]
 

--- a/cardano-legacy-address/src/address.rs
+++ b/cardano-legacy-address/src/address.rs
@@ -9,8 +9,8 @@
 //! to binary makes an `Addr`
 //!
 
-use base58;
-use cbor;
+use crate::base58;
+use crate::cbor;
 use cbor_event::{self, de::Deserializer, se::Serializer};
 use cryptoxide::blake2b::Blake2b;
 use cryptoxide::digest::Digest;

--- a/cardano-legacy-address/src/address.rs
+++ b/cardano-legacy-address/src/address.rs
@@ -263,6 +263,27 @@ pub enum ParseExtendedAddrError {
     EncodingError(cbor_event::Error),
     Base58Error(base58::Error),
 }
+
+impl fmt::Display for ParseExtendedAddrError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ParseExtendedAddrError::*;
+        match self {
+            EncodingError(_error) => f.write_str("encoding error"),
+            Base58Error(_error) => f.write_str("base58 error"),
+        }
+    }
+}
+
+impl std::error::Error for ParseExtendedAddrError {
+    fn source<'a>(&'a self) -> Option<&'a (dyn std::error::Error + 'static)> {
+        use ParseExtendedAddrError::*;
+        match self {
+            EncodingError(ref error) => Some(error),
+            Base58Error(ref error) => Some(error),
+        }
+    }
+}
+
 impl ::std::str::FromStr for ExtendedAddr {
     type Err = ParseExtendedAddrError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/cardano-legacy-address/src/cbor.rs
+++ b/cardano-legacy-address/src/cbor.rs
@@ -3,8 +3,8 @@
 pub mod util {
     //! CBor util and other stuff
 
+    use crate::crc32::crc32;
     use cbor_event::{self, de::Deserializer, se::Serializer, Len};
-    use crc32::crc32;
 
     pub fn encode_with_crc32_<T, W>(t: &T, s: &mut Serializer<W>) -> cbor_event::Result<()>
     where

--- a/cardano-legacy-address/src/lib.rs
+++ b/cardano-legacy-address/src/lib.rs
@@ -19,4 +19,4 @@ mod base58;
 mod cbor;
 mod crc32;
 
-pub use address::{Addr, ExtendedAddr};
+pub use address::{Addr, ExtendedAddr, ParseExtendedAddrError};


### PR DESCRIPTION
and add edition 2018 on the way too as it is easy to add