### PR TITLE
use rand_core and rand_os instead of rand

### DIFF
--- a/chain-crypto/Cargo.toml
+++ b/chain-crypto/Cargo.toml
@@ -14,17 +14,17 @@ ed25519-dalek = "1.0.0-pre.1"
 sha2 = "^0.8"
 digest = "^0.8"
 generic-array = "^0.12"
-rand = "0.6"
 rand_core = "0.3"
+rand_chacha = { version = "0.1", optional = true }
 ed25519-bip32 = "0.1"
-quickcheck = {version = "0.8", optional = true }
-rand_chacha = {version = "0.1", optional = true }
+quickcheck = { version = "0.8", optional = true }
 cfg-if = "0.1"
 
 [dev-dependencies]
 quickcheck = "0.8"
 quickcheck_macros = "0.8"
 rand_chacha = "0.1"
+rand_os = "0.1"
 
 [features]
 with-bench = []

--- a/chain-crypto/src/algorithms/ed25519.rs
+++ b/chain-crypto/src/algorithms/ed25519.rs
@@ -3,7 +3,7 @@ use crate::key::{
 };
 use crate::sign::{SignatureError, SigningAlgorithm, Verification, VerificationAlgorithm};
 use cryptoxide::ed25519;
-use rand::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
 
 use ed25519_bip32::XPub;
 

--- a/chain-crypto/src/algorithms/ed25519_derive.rs
+++ b/chain-crypto/src/algorithms/ed25519_derive.rs
@@ -5,7 +5,7 @@ use crate::sign::{SignatureError, SigningAlgorithm, Verification, VerificationAl
 
 use ed25519_bip32 as i;
 use ed25519_bip32::{XPrv, XPub, XPRV_SIZE, XPUB_SIZE};
-use rand::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
 
 /// Ed25519 BIP32 Signature algorithm
 pub struct Ed25519Bip32;

--- a/chain-crypto/src/algorithms/ed25519_extended.rs
+++ b/chain-crypto/src/algorithms/ed25519_extended.rs
@@ -4,7 +4,7 @@ use crate::sign::SigningAlgorithm;
 use super::ed25519 as ei;
 
 use cryptoxide::ed25519;
-use rand::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
 
 use ed25519_bip32::{XPrv, XPRV_SIZE};
 

--- a/chain-crypto/src/algorithms/sumed25519/mod.rs
+++ b/chain-crypto/src/algorithms/sumed25519/mod.rs
@@ -8,7 +8,7 @@ use crate::evolving::{EvolvingStatus, KeyEvolvingAlgorithm};
 use crate::kes::KeyEvolvingSignatureAlgorithm;
 use crate::key::{AsymmetricKey, AsymmetricPublicKey, PublicKeyError, SecretKeyError};
 use crate::sign::{SignatureError, SigningAlgorithm, Verification, VerificationAlgorithm};
-use rand::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
 
 // MMM sum scheme instanciated over the Ed25519 signature system
 // and a specific depth of 12

--- a/chain-crypto/src/algorithms/vrf/dleq.rs
+++ b/chain-crypto/src/algorithms/vrf/dleq.rs
@@ -87,7 +87,7 @@ pub fn verify(dleq: &DLEQ, proof: &Proof) -> bool {
 mod tests {
     use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
     use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
-    use rand::rngs::OsRng;
+    use rand_os::OsRng;
     use sha2::Sha512;
 
     use super::{generate, verify, DLEQ};

--- a/chain-crypto/src/algorithms/vrf/mod.rs
+++ b/chain-crypto/src/algorithms/vrf/mod.rs
@@ -5,7 +5,7 @@ use crate::key::{
     AsymmetricKey, AsymmetricPublicKey, PublicKeyError, SecretKeyError, SecretKeySizeStatic,
 };
 use crate::vrf::{VRFVerification, VerifiableRandomFunction};
-use rand::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
 
 /// VRF
 pub struct Curve25519_2HashDH;

--- a/chain-crypto/src/algorithms/vrf/vrf.rs
+++ b/chain-crypto/src/algorithms/vrf/vrf.rs
@@ -257,7 +257,7 @@ fn make_message_hash_point(data: &[u8]) -> Point {
 #[cfg(test)]
 mod tests {
     use super::SecretKey;
-    use rand_os::OsRng;
+    use rand_os::{rand_core::RngCore, OsRng};
 
     #[test]
     fn it_works() {
@@ -270,11 +270,11 @@ mod tests {
 
         let mut b1 = [0u8; 10];
         for i in b1.iter_mut() {
-            *i = rand::random()
+            *i = csprng.next_u32() as u8;
         }
         let mut b2 = [0u8; 10];
         for i in b2.iter_mut() {
-            *i = rand::random()
+            *i = csprng.next_u32() as u8;
         }
 
         let proof = sk.evaluate_simple(&mut csprng, &b1[..]);

--- a/chain-crypto/src/algorithms/vrf/vrf.rs
+++ b/chain-crypto/src/algorithms/vrf/vrf.rs
@@ -7,7 +7,7 @@ use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::ristretto::RistrettoPoint;
 pub use curve25519_dalek::scalar::Scalar;
-use rand::{CryptoRng, Rng};
+use rand_core::{CryptoRng, RngCore};
 use sha2::Digest;
 use sha2::Sha512;
 use std::hash::{Hash, Hasher};
@@ -64,7 +64,7 @@ pub const PUBLIC_SIZE: usize = 32;
 
 impl SecretKey {
     /// Create a new random secret key
-    pub fn random<T: Rng + CryptoRng>(mut rng: T) -> Self {
+    pub fn random<T: RngCore + CryptoRng>(mut rng: T) -> Self {
         let sk = Scalar::random(&mut rng);
         let pk = RISTRETTO_BASEPOINT_POINT * sk;
         SecretKey {
@@ -125,7 +125,7 @@ impl SecretKey {
         proof
     }
 
-    pub fn proove_simple<T: Rng + CryptoRng>(
+    pub fn proove_simple<T: RngCore + CryptoRng>(
         &self,
         rng: &mut T,
         m_point: Point,
@@ -144,7 +144,7 @@ impl SecretKey {
         self.proove(r, m_point, output)
     }
 
-    pub fn evaluate_simple<T: Rng + CryptoRng>(
+    pub fn evaluate_simple<T: RngCore + CryptoRng>(
         &self,
         rng: &mut T,
         input: &[u8],
@@ -257,7 +257,7 @@ fn make_message_hash_point(data: &[u8]) -> Point {
 #[cfg(test)]
 mod tests {
     use super::SecretKey;
-    use rand::rngs::OsRng;
+    use rand_os::OsRng;
 
     #[test]
     fn it_works() {

--- a/chain-crypto/src/algorithms/vrf/vrf.rs
+++ b/chain-crypto/src/algorithms/vrf/vrf.rs
@@ -293,7 +293,7 @@ mod tests {
 #[cfg(feature = "with-bench")]
 mod bench {
     use super::{PublicKey, SecretKey};
-    use rand::OsRng;
+    use rand_os::OsRng;
     use test::Bencher;
 
     fn common() -> (OsRng, SecretKey, PublicKey, [u8; 10], [u8; 10]) {
@@ -306,11 +306,11 @@ mod bench {
 
         let mut b1 = [0u8; 10];
         for i in b1.iter_mut() {
-            *i = rand::random()
+            *i = csprng.next_u32() as u8;
         }
         let mut b2 = [0u8; 10];
         for i in b2.iter_mut() {
-            *i = rand::random()
+            *i = csprng.next_u32() as u8;
         }
 
         (csprng, sk, pk, b1, b2)

--- a/chain-crypto/src/asymlock.rs
+++ b/chain-crypto/src/asymlock.rs
@@ -107,11 +107,11 @@ pub fn decrypt(
 #[cfg(test)]
 mod test {
     use super::*;
-    use rand;
+    use rand_os::OsRng;
 
     #[test]
     pub fn it_works() {
-        let mut r = rand::thread_rng();
+        let mut r = OsRng::new().unwrap();
 
         // create a random keypair
         let sk_receiver = Scalar::random(&mut r);

--- a/chain-crypto/src/asymlock.rs
+++ b/chain-crypto/src/asymlock.rs
@@ -107,6 +107,7 @@ pub fn decrypt(
 #[cfg(test)]
 mod test {
     use super::*;
+    use rand;
 
     #[test]
     pub fn it_works() {

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -1,6 +1,6 @@
 use crate::bech32::{self, Bech32};
 use crate::hex;
-use rand::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
 use std::fmt;
 use std::hash::Hash;
 use std::str::FromStr;

--- a/chain-crypto/src/testing.rs
+++ b/chain-crypto/src/testing.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use quickcheck::{Arbitrary, Gen};
-use rand::SeedableRng;
+use rand_core::SeedableRng;
 use rand_chacha::ChaChaRng;
 
 #[allow(dead_code)]

--- a/chain-crypto/src/vrf.rs
+++ b/chain-crypto/src/vrf.rs
@@ -1,5 +1,5 @@
 use crate::key;
-use rand::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VRFVerification {

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -19,7 +19,8 @@ chain-addr = { path = "../chain-addr" }
 chain-crypto = { path = "../chain-crypto" }
 chain-storage = { path = "../chain-storage" }
 chain-time = { path = "../chain-time" }
-rand = "0.6"
+rand_core = "0.3"
+rand_os = "0.1"
 imhamt = { path = "../imhamt" }
 lazy_static = "1.3.0"
 strum = "0.15.0"
@@ -36,4 +37,4 @@ chain-crypto = { path = "../chain-crypto", features=["property-test-api"]}
 chain-addr = { path = "../chain-addr", features=["property-test-api"]}
 ed25519-bip32 = "0.1"
 rand_chacha = "0.1"
-rand_core = "0.4"
+rand = "0.6"

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -37,4 +37,3 @@ chain-crypto = { path = "../chain-crypto", features=["property-test-api"]}
 chain-addr = { path = "../chain-addr", features=["property-test-api"]}
 ed25519-bip32 = "0.1"
 rand_chacha = "0.1"
-rand = "0.6"

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -7,7 +7,7 @@ use chain_crypto as crypto;
 use chain_crypto::{
     AsymmetricKey, AsymmetricPublicKey, SecretKey, SigningAlgorithm, VerificationAlgorithm,
 };
-use rand::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
 
 use std::str::FromStr;
 

--- a/chain-impl-mockchain/src/leadership/genesis/vrfeval.rs
+++ b/chain-impl-mockchain/src/leadership/genesis/vrfeval.rs
@@ -8,7 +8,7 @@ use chain_crypto::{
     vrf_evaluate_and_prove, vrf_verified_get_output, vrf_verify, Curve25519_2HashDH, PublicKey,
     SecretKey, VRFVerification, VerifiableRandomFunction,
 };
-use rand::rngs::OsRng;
+use rand_os::OsRng;
 use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};

--- a/chain-impl-mockchain/src/multisig/mod.rs
+++ b/chain-impl-mockchain/src/multisig/mod.rs
@@ -18,7 +18,7 @@ mod test {
     use crate::transaction::TransactionId;
     use crate::{account, key};
     use chain_crypto::{PublicKey, SecretKey};
-    use rand::{CryptoRng, RngCore};
+    use rand_core::{CryptoRng, RngCore};
 
     fn make_keypair<R: RngCore + CryptoRng>(
         rng: &mut R,

--- a/chain-impl-mockchain/src/multisig/mod.rs
+++ b/chain-impl-mockchain/src/multisig/mod.rs
@@ -48,7 +48,7 @@ mod test {
 
     #[test]
     fn multisig_works_depth1() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand_os::OsRng::new().unwrap();
         let (sk1, pk1, o1, i1) = make_participant(&mut rng, 0);
         let (sk2, pk2, o2, i2) = make_participant(&mut rng, 1);
         let (sk3, pk3, o3, i3) = make_participant(&mut rng, 2);

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -270,7 +270,6 @@ mod test {
     use chain_crypto::{Ed25519, SecretKey};
     use chain_storage::store::BlockStore;
     use chain_time::{Epoch, SlotDuration, TimeEra, TimeFrame, Timeline};
-    use quickcheck::{Arbitrary, StdGen};
     use std::time::SystemTime;
 
     fn apply_block(state: &Ledger, block: &Block) -> Ledger {
@@ -298,18 +297,16 @@ mod test {
         let slot0 = tf.slot0();
         let era = TimeEra::new(slot0, Epoch(0), NUM_BLOCK_PER_EPOCH);
 
-        let mut g = StdGen::new(rand::thread_rng(), 10);
-        let leader_key = Arbitrary::arbitrary(&mut g);
+        let leader_key : SecretKey<Ed25519> = SecretKey::generate(rand_os::OsRng::new().unwrap());
+        let leader_pub_key = leader_key.to_public();
 
         let mut store = chain_storage::memory::MemoryBlockStore::new();
 
-        let random_sk: SecretKey<Ed25519> = SecretKey::generate(rand::thread_rng());
 
         let mut genesis_block = BlockBuilder::new();
         let mut ents = ConfigParams::new();
         ents.push(ConfigParam::Discrimination(Discrimination::Test));
         ents.push(ConfigParam::ConsensusVersion(ConsensusVersion::Bft));
-        let leader_pub_key = random_sk.to_public();
         ents.push(ConfigParam::AddBftLeader(LeaderId::from(leader_pub_key)));
         ents.push(ConfigParam::Block0Date(Block0Date(0)));
         ents.push(ConfigParam::SlotDuration(10));

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -297,11 +297,10 @@ mod test {
         let slot0 = tf.slot0();
         let era = TimeEra::new(slot0, Epoch(0), NUM_BLOCK_PER_EPOCH);
 
-        let leader_key : SecretKey<Ed25519> = SecretKey::generate(rand_os::OsRng::new().unwrap());
+        let leader_key: SecretKey<Ed25519> = SecretKey::generate(rand_os::OsRng::new().unwrap());
         let leader_pub_key = leader_key.to_public();
 
         let mut store = chain_storage::memory::MemoryBlockStore::new();
-
 
         let mut genesis_block = BlockBuilder::new();
         let mut ents = ConfigParams::new();

--- a/chain-impl-mockchain/src/txbuilder.rs
+++ b/chain-impl-mockchain/src/txbuilder.rs
@@ -432,7 +432,7 @@ mod tests {
     }
 
     fn arbitrary_range(gen: &mut impl Gen, range: u64) -> u64 {
-        u64::arbitrary(gen) % (range+1)
+        u64::arbitrary(gen) % (range + 1)
     }
 
     #[quickcheck]

--- a/chain-impl-mockchain/src/txbuilder.rs
+++ b/chain-impl-mockchain/src/txbuilder.rs
@@ -292,8 +292,6 @@ mod tests {
     use chain_addr::Address;
     use quickcheck::{Arbitrary, Gen, TestResult};
     use quickcheck_macros::quickcheck;
-    use rand::distributions::uniform::{SampleUniform, Uniform};
-    use rand::Rng;
     use std::iter;
 
     #[quickcheck]
@@ -389,8 +387,8 @@ mod tests {
     impl Arbitrary for ArbitraryInputs {
         fn arbitrary<G: Gen>(gen: &mut G) -> Self {
             let value = u64::arbitrary(gen);
-            let count = arbitrary_range(gen, 0..=255);
-            let inputs = split_value(gen, value, count)
+            let count = u8::arbitrary(gen);
+            let inputs = split_value(gen, value, count as u16)
                 .into_iter()
                 .map(|value| arbitrary_input(gen, value))
                 .collect();
@@ -404,8 +402,8 @@ mod tests {
     impl Arbitrary for ArbitraryOutputs {
         fn arbitrary<G: Gen>(gen: &mut G) -> Self {
             let value = u64::arbitrary(gen);
-            let count = arbitrary_range(gen, 0..=255);
-            let outputs = split_value(gen, value, count)
+            let count = u8::arbitrary(gen);
+            let outputs = split_value(gen, value, count as u16)
                 .into_iter()
                 .map(|value| (Address::arbitrary(gen), Value(value)))
                 .collect();
@@ -425,7 +423,7 @@ mod tests {
 
     fn split_value(gen: &mut impl Gen, value: u64, parts: u16) -> Vec<u64> {
         let mut in_values: Vec<_> = iter::once(0)
-            .chain(iter::repeat_with(|| arbitrary_range(gen, 0..=value)))
+            .chain(iter::repeat_with(|| arbitrary_range(gen, value)))
             .take(parts as usize)
             .chain(iter::once(value))
             .collect();
@@ -433,8 +431,8 @@ mod tests {
         in_values.windows(2).map(|pair| pair[1] - pair[0]).collect()
     }
 
-    fn arbitrary_range<T: SampleUniform>(gen: &mut impl Gen, range: impl Into<Uniform<T>>) -> T {
-        gen.sample(range.into())
+    fn arbitrary_range(gen: &mut impl Gen, range: u64) -> u64 {
+        u64::arbitrary(gen) % (range+1)
     }
 
     #[quickcheck]

--- a/chain-impl-mockchain/tests/common/address.rs
+++ b/chain-impl-mockchain/tests/common/address.rs
@@ -53,6 +53,6 @@ impl AddressData {
     }
 
     fn generate_random_secret_key() -> EitherEd25519SecretKey {
-        EitherEd25519SecretKey::generate(rand::thread_rng())
+        EitherEd25519SecretKey::generate(rand_os::OsRng::new().unwrap())
     }
 }

--- a/chain-impl-mockchain/tests/common/ledger.rs
+++ b/chain-impl-mockchain/tests/common/ledger.rs
@@ -50,7 +50,8 @@ impl ConfigBuilder {
         ie.push(ConfigParam::ConsensusVersion(ConsensusVersion::Bft));
 
         // TODO remove rng: make this creation deterministic
-        let leader_prv_key: SecretKey<Ed25519Extended> = SecretKey::generate(rand_os::OsRng::new().unwrap());
+        let leader_prv_key: SecretKey<Ed25519Extended> =
+            SecretKey::generate(rand_os::OsRng::new().unwrap());
         let leader_pub_key = leader_prv_key.to_public();
         ie.push(ConfigParam::AddBftLeader(leader_pub_key.into()));
         ie.push(ConfigParam::Block0Date(

--- a/chain-impl-mockchain/tests/common/ledger.rs
+++ b/chain-impl-mockchain/tests/common/ledger.rs
@@ -50,7 +50,7 @@ impl ConfigBuilder {
         ie.push(ConfigParam::ConsensusVersion(ConsensusVersion::Bft));
 
         // TODO remove rng: make this creation deterministic
-        let leader_prv_key: SecretKey<Ed25519Extended> = SecretKey::generate(rand::thread_rng());
+        let leader_prv_key: SecretKey<Ed25519Extended> = SecretKey::generate(rand_os::OsRng::new().unwrap());
         let leader_pub_key = leader_prv_key.to_public();
         ie.push(ConfigParam::AddBftLeader(leader_pub_key.into()));
         ie.push(ConfigParam::Block0Date(

--- a/chain-impl-mockchain/tests/genesis/genesis_tests.rs
+++ b/chain-impl-mockchain/tests/genesis/genesis_tests.rs
@@ -12,7 +12,7 @@ use chain_impl_mockchain::value::*;
 use std::collections::HashMap;
 
 fn make_pool(ledger: &mut Ledger) -> (StakePoolId, SecretKey<Curve25519_2HashDH>) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand_os::OsRng::new().unwrap();
 
     let pool_vrf_private_key = SecretKey::generate(&mut rng);
     let pool_kes: KeyPair<SumEd25519_12> = KeyPair::generate(&mut rng);

--- a/chain-storage-sqlite/Cargo.toml
+++ b/chain-storage-sqlite/Cargo.toml
@@ -21,3 +21,4 @@ features = ["bundled"]
 
 [dev-dependencies]
 chain-storage = { path = "../chain-storage", features=["test-api"] }
+rand_os = "0.1"

--- a/chain-storage-sqlite/src/lib.rs
+++ b/chain-storage-sqlite/src/lib.rs
@@ -223,6 +223,7 @@ where
 mod tests {
     use super::*;
     use chain_storage::store::testing::Block;
+    use rand_os::OsRng;
 
     #[test]
     pub fn put_get() {
@@ -232,13 +233,15 @@ mod tests {
 
     #[test]
     pub fn nth_ancestor() {
+        let mut rng = OsRng::new().unwrap();
         let mut store = SQLiteBlockStore::<Block>::new(":memory:");
-        chain_storage::store::testing::test_nth_ancestor(&mut store);
+        chain_storage::store::testing::test_nth_ancestor(&mut rng, &mut store);
     }
 
     #[test]
     pub fn iterate_range() {
+        let mut rng = OsRng::new().unwrap();
         let mut store = SQLiteBlockStore::<Block>::new(":memory:");
-        chain_storage::store::testing::test_iterate_range(&mut store);
+        chain_storage::store::testing::test_iterate_range(&mut rng, &mut store);
     }
 }

--- a/chain-storage/Cargo.toml
+++ b/chain-storage/Cargo.toml
@@ -11,10 +11,11 @@ edition = "2018"
 
 [dependencies]
 chain-core = { path = "../chain-core" }
-rand = { version = "0.6", optional = true }
+rand_core = { version = "0.3", optional = true }
 
 [dev-dependencies]
-rand = { version = "0.6" }
+rand_core = { version = "0.3" }
+rand_os = { version = "0.1" }
 
 [features]
-test-api = ["rand"]
+test-api = ["rand_core"]

--- a/chain-storage/src/memory.rs
+++ b/chain-storage/src/memory.rs
@@ -75,8 +75,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand_os::OsRng;
     use crate::store::testing::Block;
+    use rand_os::OsRng;
 
     #[test]
     pub fn put_get() {

--- a/chain-storage/src/memory.rs
+++ b/chain-storage/src/memory.rs
@@ -75,6 +75,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand_os::OsRng;
     use crate::store::testing::Block;
 
     #[test]
@@ -85,13 +86,15 @@ mod tests {
 
     #[test]
     pub fn nth_ancestor() {
+        let mut rng = OsRng::new().unwrap();
         let mut store = MemoryBlockStore::<Block>::new();
-        crate::store::testing::test_nth_ancestor(&mut store);
+        crate::store::testing::test_nth_ancestor(&mut rng, &mut store);
     }
 
     #[test]
     pub fn iterate_range() {
+        let mut rng = OsRng::new().unwrap();
         let mut store = MemoryBlockStore::<Block>::new();
-        crate::store::testing::test_iterate_range(&mut store);
+        crate::store::testing::test_iterate_range(&mut rng, &mut store);
     }
 }

--- a/chain-storage/src/store.rs
+++ b/chain-storage/src/store.rs
@@ -507,7 +507,10 @@ pub mod testing {
         &v[s % v.len()]
     }
 
-    pub fn generate_chain<R: RngCore, Store: BlockStore<Block = Block>>(rng: &mut R, store: &mut Store) -> Vec<Block> {
+    pub fn generate_chain<R: RngCore, Store: BlockStore<Block = Block>>(
+        rng: &mut R,
+        store: &mut Store,
+    ) -> Vec<Block> {
         let mut blocks = vec![];
 
         let genesis_block = Block::genesis();
@@ -549,7 +552,10 @@ pub mod testing {
         assert_eq!(store.get_tag("tip").unwrap().unwrap(), genesis_block.id());
     }
 
-    pub fn test_nth_ancestor<R: RngCore, Store: BlockStore<Block = Block>>(rng: &mut R, store: &mut Store) {
+    pub fn test_nth_ancestor<R: RngCore, Store: BlockStore<Block = Block>>(
+        rng: &mut R,
+        store: &mut Store,
+    ) {
         let blocks = generate_chain(rng, store);
 
         let mut blocks_fetched = 0;
@@ -585,7 +591,10 @@ pub mod testing {
         assert!(blocks_per_test < 35.0);
     }
 
-    pub fn test_iterate_range<R: RngCore, Store: BlockStore<Block = Block>>(rng: &mut R, store: &mut Store) {
+    pub fn test_iterate_range<R: RngCore, Store: BlockStore<Block = Block>>(
+        rng: &mut R,
+        store: &mut Store,
+    ) {
         let blocks = generate_chain(rng, store);
 
         let blocks_by_id: HashMap<BlockId, &Block> = blocks.iter().map(|b| (b.id(), b)).collect();


### PR DESCRIPTION
remove rand in favor of using directly rand_core and rand_os directly. rand has kitchen-sink dependencies compared which are not typically necessary for what we build