### PR TITLE
Hermetize ActiveSlotsCoeff

### DIFF
--- a/chain-impl-mockchain/src/leadership/genesis/vrfeval.rs
+++ b/chain-impl-mockchain/src/leadership/genesis/vrfeval.rs
@@ -51,7 +51,7 @@ impl Error for ActiveSlotsCoeffError {}
 /// Described in Ouroboros Praos paper, also referred to as parameter F of phi function
 /// Always in range (0, 1]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ActiveSlotsCoeff(pub(crate) Milli);
+pub struct ActiveSlotsCoeff(Milli);
 
 impl TryFrom<Milli> for ActiveSlotsCoeff {
     type Error = ActiveSlotsCoeffError;
@@ -65,9 +65,15 @@ impl TryFrom<Milli> for ActiveSlotsCoeff {
     }
 }
 
-impl Into<f64> for ActiveSlotsCoeff {
-    fn into(self) -> f64 {
-        self.0.to_float()
+impl From<ActiveSlotsCoeff> for Milli {
+    fn from(coeff: ActiveSlotsCoeff) -> Milli {
+        coeff.0
+    }
+}
+
+impl From<ActiveSlotsCoeff> for f64 {
+    fn from(coeff: ActiveSlotsCoeff) -> f64 {
+        coeff.0.to_float()
     }
 }
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -79,7 +79,7 @@ impl Settings {
                     new_state.epoch_stability_depth = *d;
                 }
                 ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(d) => {
-                    new_state.active_slots_coeff = ActiveSlotsCoeff(*d);
+                    new_state.active_slots_coeff = ActiveSlotsCoeff::try_from(*d)?;
                 }
                 ConfigParam::MaxNumberOfTransactionsPerBlock(d) => {
                     new_state.max_number_of_transactions_per_block = *d;
@@ -126,7 +126,7 @@ impl Settings {
         params.push(ConfigParam::SlotDuration(self.slot_duration));
         params.push(ConfigParam::EpochStabilityDepth(self.epoch_stability_depth));
         params.push(ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(
-            self.active_slots_coeff.0,
+            self.active_slots_coeff.into(),
         ));
         params.push(ConfigParam::MaxNumberOfTransactionsPerBlock(
             self.max_number_of_transactions_per_block,

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -1,6 +1,8 @@
 use crate::certificate::{verify_certificate, HasPublicKeys, SignatureRaw};
 use crate::date::BlockDate;
-use crate::{leadership::bft, message::config::ConfigParams, setting::Settings};
+use crate::leadership::{bft, genesis::ActiveSlotsCoeffError};
+use crate::message::config::ConfigParams;
+use crate::setting::Settings;
 use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_core::property;
 use chain_crypto::{Ed25519, Ed25519Extended, PublicKey, SecretKey, Verification};
@@ -154,6 +156,7 @@ pub enum Error {
     DuplicateVote(UpdateProposalId, UpdateVoterId),
     ReadOnlySetting,
     BadBftSlotsRatio(crate::milli::Milli),
+    BadConsensusGenesisPraosActiveSlotsCoeff(ActiveSlotsCoeffError),
 }
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -207,10 +210,22 @@ impl std::fmt::Display for Error {
             Error::BadBftSlotsRatio(m) => {
                 write!(f, "Cannot set BFT slots ratio to invalid value {}", m)
             }
+            Error::BadConsensusGenesisPraosActiveSlotsCoeff(err) => write!(
+                f,
+                "Cannot set consensus genesis praos active slots coefficient: {}",
+                err
+            ),
         }
     }
 }
+
 impl std::error::Error for Error {}
+
+impl From<ActiveSlotsCoeffError> for Error {
+    fn from(err: ActiveSlotsCoeffError) -> Self {
+        Error::BadConsensusGenesisPraosActiveSlotsCoeff(err)
+    }
+}
 
 pub type UpdateProposalId = crate::message::MessageId;
 pub type UpdateVoterId = bft::LeaderId;


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/chain-libs/issues/21

It turned out that the structure API was safe, but because it wasn't hermetic, it was bypassed causing security threat