### PR TITLE
Address removal of environment prefix

### DIFF
--- a/chain-addr/build.rs
+++ b/chain-addr/build.rs
@@ -1,10 +1,8 @@
 fn main() {
     let production_prefix = option_env!("PRODUCTION_ADDRESS_PREFIX").unwrap_or("ca");
-    let test_prefix = option_env!("TEST_ADDRESS_PREFIX").unwrap_or("ta");
 
     println!(
         "cargo:rustc-env=PRODUCTION_ADDRESS_PREFIX={}",
         production_prefix
     );
-    println!("cargo:rustc-env=TEST_ADDRESS_PREFIX={}", test_prefix);
 }

--- a/chain-addr/build.rs
+++ b/chain-addr/build.rs
@@ -1,8 +1,0 @@
-fn main() {
-    let production_prefix = option_env!("PRODUCTION_ADDRESS_PREFIX").unwrap_or("ca");
-
-    println!(
-        "cargo:rustc-env=PRODUCTION_ADDRESS_PREFIX={}",
-        production_prefix
-    );
-}

--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -304,6 +304,11 @@ impl AddressReadable {
         &self.0
     }
 
+    pub fn get_prefix(&self) -> String {
+        use std::str::FromStr;
+        Bech32::from_str(&self.0).expect("only valid bech32 string are accepted").hrp().to_string()
+    }
+
     /// Validate from a String to create a valid AddressReadable
     pub fn from_string(expected_prefix: &str, s: &str) -> Result<Self, Error> {
         use std::str::FromStr;
@@ -317,13 +322,17 @@ impl AddressReadable {
         Ok(AddressReadable(s.to_string()))
     }
 
-    pub fn from_string_anyprefix(s: &str) -> Result<Self, Error> {
+    pub fn from_str_anyprefix(s: &str) -> Result<Self, Error> {
         use std::str::FromStr;
         let r = Bech32::from_str(s)?;
         let dat = Vec::from_base32(r.data())?;
         let _ = is_valid_data(&dat[..])?;
 
         Ok(AddressReadable(s.to_string()))
+    }
+
+    pub fn from_string_anyprefix(s: &str) -> Result<Self, Error> {
+        Self::from_str_anyprefix(s)
     }
 
     /// Create a new AddressReadable from an encoded address

--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -301,7 +301,6 @@ pub struct AddressReadable(String);
 
 impl AddressReadable {
     const PRODUCTION_ADDRESS_PREFIX: &'static str = env!("PRODUCTION_ADDRESS_PREFIX");
-    const TEST_ADDRESS_PREFIX: &'static str = env!("TEST_ADDRESS_PREFIX");
 
     pub fn as_string(&self) -> &str {
         &self.0
@@ -311,28 +310,19 @@ impl AddressReadable {
     pub fn from_string(s: &str) -> Result<Self, Error> {
         use std::str::FromStr;
         let r = Bech32::from_str(s)?;
-        let expected_discrimination = if r.hrp() == Self::PRODUCTION_ADDRESS_PREFIX {
-            Discrimination::Production
-        } else if r.hrp() == Self::TEST_ADDRESS_PREFIX {
-            Discrimination::Test
-        } else {
+        if r.hrp() != Self::PRODUCTION_ADDRESS_PREFIX {
             return Err(Error::InvalidPrefix);
         };
         let dat = Vec::from_base32(r.data())?;
-        let (discrimination, _) = is_valid_data(&dat[..])?;
-        if discrimination != expected_discrimination {
-            return Err(Error::MismatchPrefix);
-        }
+        let _ = is_valid_data(&dat[..])?;
+
         Ok(AddressReadable(s.to_string()))
     }
 
     /// Create a new AddressReadable from an encoded address
     pub fn from_address(addr: &Address) -> Self {
         let v = ToBase32::to_base32(&addr.to_bytes());
-        let prefix = match addr.0 {
-            Discrimination::Production => Self::PRODUCTION_ADDRESS_PREFIX.to_string(),
-            Discrimination::Test => Self::TEST_ADDRESS_PREFIX.to_string(),
-        };
+        let prefix = Self::PRODUCTION_ADDRESS_PREFIX.to_string();
         let r = Bech32::new(prefix, v).unwrap();
         AddressReadable(r.to_string())
     }
@@ -621,7 +611,7 @@ mod test {
             );
             property_serialize_deserialize(&addr);
             property_readable(&addr);
-            expected_bech32(&addr, "ta1ssqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jq2f29vkz6t30xqcnyve5x5mrwwpe8ganc0f78aqyzsjrg3z5v36ge5qsky");
+            expected_bech32(&addr, "ca1ssqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jq2f29vkz6t30xqcnyve5x5mrwwpe8ganc0f78aqyzsjrg3z5v36gjdetkp");
             expected_base32(&addr, "qqaqeayeaudaocajbifqydiob4ibceqtcqkrmfyydenbwha5dypsakjkfmwc2lrpgaytemzugu3doobzhi5typj6h5aecqsdircumr2i");
         }
 
@@ -635,7 +625,7 @@ mod test {
             );
             expected_bech32(
                 &addr,
-                "ta1s55j52ev95hz7vp3xgengdfkxuurjw3m8s7nu06qg9pyx3z9ger5s28ezm6",
+                "ca1s55j52ev95hz7vp3xgengdfkxuurjw3m8s7nu06qg9pyx3z9ger5samu4rv",
             );
         }
     }

--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -306,7 +306,10 @@ impl AddressReadable {
 
     pub fn get_prefix(&self) -> String {
         use std::str::FromStr;
-        Bech32::from_str(&self.0).expect("only valid bech32 string are accepted").hrp().to_string()
+        Bech32::from_str(&self.0)
+            .expect("only valid bech32 string are accepted")
+            .hrp()
+            .to_string()
     }
 
     /// Validate from a String to create a valid AddressReadable

--- a/chain-addr/src/testing.rs
+++ b/chain-addr/src/testing.rs
@@ -24,9 +24,11 @@ impl Arbitrary for KindType {
     }
 }
 
+const ARBITRARY_PREFIX: &'static str = "qaddr";
+
 impl Arbitrary for AddressReadable {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        AddressReadable::from_address(&Arbitrary::arbitrary(g))
+        AddressReadable::from_address(ARBITRARY_PREFIX, &Arbitrary::arbitrary(g))
     }
 }
 

--- a/chain-impl-mockchain/src/transaction/transfer.rs
+++ b/chain-impl-mockchain/src/transaction/transfer.rs
@@ -215,14 +215,10 @@ impl<Address: Readable> Readable for Output<Address> {
 
 impl std::fmt::Display for Output<chain_addr::Address> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "{}.{}",
-            chain_addr::AddressReadable::from_address(&self.address).to_string(),
-            self.value
-        )
+        write!(f, "{}.{}", self.address.base32(), self.value)
     }
 }
+
 impl std::fmt::Display for Output<OldAddress> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}.{}", self.address, self.value)


### PR DESCRIPTION
Remove hardcoded address bech32 prefix

* no more testing/production difference
* display output addr in base32 form instead of bech32
* add arbitrary prefix 'qaddr'
* make 'ca' prefix in unit test to prevent rewriting
* remove environment gathering build.rs
