### PR TITLE
network-grpc: limit reruns of the build script

### DIFF
--- a/network-grpc/build.rs
+++ b/network-grpc/build.rs
@@ -12,4 +12,5 @@ fn main() {
             writeln!(stderr(), "{}", e).unwrap();
             process::exit(1)
         });
+    println!("cargo:rerun-if-changed=proto/node.proto");
 }


### PR DESCRIPTION
Only rerun `build.rs` if the `.proto` file changes.