### PR TITLE
CircleCI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v3-{{ checksum "Cargo.toml" }}
+            - cargo-v3-{{ checksum "Cargo.toml" }}-
             - cargo-v3-
       - run: git submodule sync
       - run: git submodule update --init
@@ -18,7 +18,7 @@ jobs:
           paths:
             - Cargo.lock
       - save_cache:
-          key: cargo-v3-{{ checksum "Cargo.toml" }}
+          key: cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
           paths:
             - /usr/local/cargo/registry
             - /usr/local/cargo/git
@@ -52,14 +52,12 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
           name: Build
-          command: cargo build
+          command: cargo build --frozen
   test_debug:
     docker:
       - image: rust:latest
@@ -73,14 +71,12 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
           name: Test
-          command: cargo test --verbose
+          command: cargo test --verbose --frozen
 
   build_release:
     docker:
@@ -95,14 +91,12 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
           name: Build in release profile
-          command: cargo build --release
+          command: cargo build --frozen --release
 
   test_release:
     docker:
@@ -117,14 +111,12 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
           name: Test
-          command: cargo test --release --verbose
+          command: cargo test --verbose --frozen --release
 
   test_nightly:
     docker:
@@ -137,14 +129,12 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-            - cargo-v3-{{ checksum "Cargo.toml" }}
-            - cargo-v3-
       - run:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
           name: Build and test with nightly Rust
-          command: cargo test --verbose
+          command: cargo test --verbose --frozen
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,10 @@ jobs:
       - run:
           name: Build
           command: cargo build --frozen
+      - persist_to_workspace:
+          root: /mnt/crate
+          paths:
+            - target/debug
   test_debug:
     docker:
       - image: rust:latest
@@ -97,6 +101,10 @@ jobs:
       - run:
           name: Build in release profile
           command: cargo build --frozen --release
+      - persist_to_workspace:
+          root: /mnt/crate
+          paths:
+            - target/release
 
   test_release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,10 @@ jobs:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
-          name: Build and test
+          name: Build
+          command: cargo build --tests --verbose --frozen
+      - run:
+          name: Test
           command: cargo test --verbose --frozen
 
   test_release:
@@ -70,7 +73,10 @@ jobs:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
-          name: Build and test with release profile
+          name: Build
+          command: cargo build --tests --verbose --frozen --release
+      - run:
+          name: Test
           command: cargo test --verbose --frozen --release
 
   test_nightly:
@@ -88,9 +94,11 @@ jobs:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
-          name: Build and test with nightly Rust
+          name: Build
+          command: cargo build --tests --verbose --frozen
+      - run:
+          name: Test
           command: cargo test --verbose --frozen
-
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ jobs:
           command: cargo build --tests --verbose --frozen
       - run:
           name: Test
+          environment:
+            RUST_BACKTRACE: 1
           command: cargo test --verbose --frozen
 
   test_release:
@@ -98,6 +100,8 @@ jobs:
           command: cargo build --tests --verbose --frozen
       - run:
           name: Test
+          environment:
+            RUST_BACKTRACE: 1
           command: cargo test --verbose --frozen
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,27 +37,6 @@ jobs:
           name: Check rustfmt
           command: cargo fmt -- --check
 
-  build_debug:
-    docker:
-      - image: rust:latest
-    working_directory: /mnt/crate
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /mnt/crate
-      - restore_cache:
-          keys:
-            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-      - run:
-          name: Print version information
-          command: rustc --version; cargo --version
-      - run:
-          name: Build
-          command: cargo build --frozen
-      - persist_to_workspace:
-          root: /mnt/crate
-          paths:
-            - target/debug
   test_debug:
     docker:
       - image: rust:latest
@@ -73,30 +52,8 @@ jobs:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
-          name: Test
+          name: Build and test
           command: cargo test --verbose --frozen
-
-  build_release:
-    docker:
-      - image: rust:latest
-    working_directory: /mnt/crate
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /mnt/crate
-      - restore_cache:
-          keys:
-            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
-      - run:
-          name: Print version information
-          command: rustc --version; cargo --version
-      - run:
-          name: Build in release profile
-          command: cargo build --frozen --release
-      - persist_to_workspace:
-          root: /mnt/crate
-          paths:
-            - target/release
 
   test_release:
     docker:
@@ -113,7 +70,7 @@ jobs:
           name: Print version information
           command: rustc --version; cargo --version
       - run:
-          name: Test
+          name: Build and test with release profile
           command: cargo test --verbose --frozen --release
 
   test_nightly:
@@ -141,20 +98,14 @@ workflows:
     jobs:
       - cargo_fetch
       - rustfmt
-      - build_debug:
-          requires:
-            - rustfmt
-            - cargo_fetch
-      - build_release:
-          requires:
-            - rustfmt
-            - cargo_fetch
       - test_debug:
           requires:
-            - build_debug
+            - rustfmt
+            - cargo_fetch
       - test_release:
           requires:
-            - build_release
+            - rustfmt
+            - cargo_fetch
       - test_nightly:
           requires:
             - rustfmt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,6 @@ jobs:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-
             - cargo-v3-
-      - run: git submodule sync
-      - run: git submodule update --init
       - run: cargo fetch
       - persist_to_workspace:
           root: /mnt/crate
@@ -47,8 +45,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: /mnt/crate
-      - run: git submodule sync
-      - run: git submodule update --init
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
@@ -70,8 +66,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: /mnt/crate
-      - run: git submodule sync
-      - run: git submodule update --init
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
@@ -90,8 +84,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: /mnt/crate
-      - run: git submodule sync
-      - run: git submodule update --init
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
@@ -114,8 +106,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: /mnt/crate
-      - run: git submodule sync
-      - run: git submodule update --init
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}


### PR DESCRIPTION
Ensure the cache is freshened once by `cargo_fetch` and correctly reused by all other commands.

Eliminated the unnecessary build jobs, separating most of the build output in a separate step of each of the test jobs instead.

Set `RUST_BACKTRACE` when running tests, except those build with release profile.