### PR TITLE
network: Change header push API to remove a generic

### DIFF
--- a/network-core/src/error.rs
+++ b/network-core/src/error.rs
@@ -14,6 +14,7 @@ pub enum Code {
     Aborted,
     Unimplemented,
     Internal,
+    Unavailable,
 }
 
 /// Represents errors that can be returned by the node protocol implementation.
@@ -56,6 +57,7 @@ impl fmt::Display for Error {
             Code::Aborted => "the operation was aborted",
             Code::Unimplemented => "not implemented",
             Code::Internal => "internal processing error",
+            Code::Unavailable => "the service is unavailable",
         };
         f.write_str(msg)
     }

--- a/network-core/src/error.rs
+++ b/network-core/src/error.rs
@@ -1,6 +1,9 @@
 use std::{error, fmt};
 
 /// Common error codes for network protocol requests.
+///
+/// These codes mimic the status codes used in gRPC and map one to one to
+/// those in the gRPC protocol implementation.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Code {
     Canceled,
@@ -8,6 +11,7 @@ pub enum Code {
     InvalidArgument,
     NotFound,
     FailedPrecondition,
+    Aborted,
     Unimplemented,
     Internal,
 }
@@ -49,6 +53,7 @@ impl fmt::Display for Error {
             Code::InvalidArgument => "invalid request data",
             Code::NotFound => "not found",
             Code::FailedPrecondition => "system state does not permit the operation",
+            Code::Aborted => "the operation was aborted",
             Code::Unimplemented => "not implemented",
             Code::Internal => "internal processing error",
         };

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -76,8 +76,8 @@ pub trait BlockService: P2pService {
     /// implementation to produce a server-streamed response.
     type GetHeadersFuture: Future<Item = Self::GetHeadersStream, Error = Error> + Send + 'static;
 
-    /// The type of asynchronous futures returned by method `push_headers`.
-    type PushHeadersFuture: Future<Item = (), Error = Error> + Send + 'static;
+    /// The type of asynchronous futures returned by method `on_pushed_headers`.
+    type OnPushedHeadersFuture: Future<Item = (), Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by method `on_uploaded_block`.
     type OnUploadedBlockFuture: Future<Item = (), Error = Error> + Send + 'static;
@@ -129,14 +129,21 @@ pub trait BlockService: P2pService {
     /// to the server's tip.
     fn pull_headers_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullHeadersFuture;
 
-    /// The outbound counterpart of `pull_headers`, called in response to a
-    /// `BlockEvent::Missing` solicitation. A client may report that
-    /// the solicitation does not refer to blocks found in the local blockchain
-    /// by making the `push_headers` call and failing the outbound stream with
-    /// a `NotFound` error.
-    fn push_headers<In>(&mut self, headers: In) -> Self::PushHeadersFuture
-    where
-        In: Stream<Item = Self::Header, Error = Error> + Send + 'static;
+    /// Preferred maximum size of processing chunks to split the incoming
+    /// stream of block headers, to be passed to the `on_pushed_headers` method.
+    const PUSH_HEADERS_CHUNK_SIZE: usize;
+
+    /// Called by the protocol implementation with an `Ok` variant when a
+    /// series of block headers constituting the chain is sent by the client
+    /// in response to a `BlockEvent::Missing` solicitation.
+    /// An `Err` is used to report errors with streaming of inbound headers.
+    /// A client may report that the solicitation does not refer to blocks
+    /// found in the local blockchain by sending a `NotFound` error which
+    /// is passed to this method.
+    fn on_pushed_headers(
+        &mut self,
+        headers: Result<Vec<Self::Header>, Error>,
+    ) -> Self::OnPushedHeadersFuture;
 
     /// Called when the client connection uploads a block.
     fn on_uploaded_block(&mut self, block: Self::Block) -> Self::OnUploadedBlockFuture;

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -138,15 +138,23 @@ pub trait BlockService: P2pService {
     /// in response to a `BlockEvent::Missing` solicitation.
     /// An `Err` is used to report errors with streaming of inbound headers.
     /// A client may report that the solicitation does not refer to blocks
-    /// found in the local blockchain by sending a `NotFound` error which
+    /// found in its local blockchain by sending a `NotFound` error which
     /// is passed to this method.
     fn on_pushed_headers(
         &mut self,
-        headers: Result<Vec<Self::Header>, Error>,
+        item: Result<Vec<Self::Header>, Error>,
     ) -> Self::OnPushedHeadersFuture;
 
-    /// Called when the client connection uploads a block.
-    fn on_uploaded_block(&mut self, block: Self::Block) -> Self::OnUploadedBlockFuture;
+    /// Called with an `Ok` value when the client connection uploads a block
+    /// in response to a `BlockEvent::Solicit` solicitation.
+    /// An `Err` is used to report errors with streaming of inbound blocks.
+    /// A client may report that the solicitation refers to a block not
+    /// found in its local blockchain by sending a `NotFound` error which
+    /// is passed to this method.
+    fn on_uploaded_block(
+        &mut self,
+        item: Result<Self::Block, Error>,
+    ) -> Self::OnUploadedBlockFuture;
 
     /// Establishes a bidirectional subscription for announcing blocks.
     ///

--- a/network-grpc/src/convert.rs
+++ b/network-grpc/src/convert.rs
@@ -25,6 +25,7 @@ pub fn error_into_grpc(err: core_error::Error) -> Status {
         InvalidArgument => Code::InvalidArgument,
         NotFound => Code::NotFound,
         FailedPrecondition => Code::FailedPrecondition,
+        Aborted => Code::Aborted,
         Unimplemented => Code::Unimplemented,
         Internal => Code::Internal,
         // When a new case has to be added here, remember to
@@ -43,6 +44,7 @@ pub fn error_from_grpc(e: Status) -> core_error::Error {
         InvalidArgument => core_error::Code::InvalidArgument,
         NotFound => core_error::Code::NotFound,
         FailedPrecondition => core_error::Code::FailedPrecondition,
+        Aborted => core_error::Code::Aborted,
         Unimplemented => core_error::Code::Unimplemented,
         Internal => core_error::Code::Internal,
         _ => core_error::Code::Unknown,

--- a/network-grpc/src/convert.rs
+++ b/network-grpc/src/convert.rs
@@ -28,6 +28,7 @@ pub fn error_into_grpc(err: core_error::Error) -> Status {
         Aborted => Code::Aborted,
         Unimplemented => Code::Unimplemented,
         Internal => Code::Internal,
+        Unavailable => Code::Unavailable,
         // When a new case has to be added here, remember to
         // add the corresponding case in error_from_grpc below.
     };
@@ -47,6 +48,7 @@ pub fn error_from_grpc(e: Status) -> core_error::Error {
         Aborted => core_error::Code::Aborted,
         Unimplemented => core_error::Code::Unimplemented,
         Internal => core_error::Code::Internal,
+        Unavailable => core_error::Code::Unavailable,
         _ => core_error::Code::Unknown,
     };
 

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -258,6 +258,131 @@ where
 }
 
 #[must_use = "futures do nothing unless polled"]
+pub struct PushHeadersFuture<T, S>
+where
+    T: Node,
+{
+    stream: Option<RequestStream<<T::BlockService as BlockService>::Header, S>>,
+    service: T,
+    state: push_headers::State<T::BlockService>,
+}
+
+impl<T, S> PushHeadersFuture<T, S>
+where
+    T: Node,
+{
+    fn new(service: T, stream: S) -> Self {
+        PushHeadersFuture {
+            stream: Some(RequestStream::new(stream)),
+            service,
+            state: Default::default(),
+        }
+    }
+}
+
+mod push_headers {
+    use network_core::error::Error;
+    use network_core::server::block::BlockService;
+
+    pub struct State<BS: BlockService> {
+        accum: Vec<BS::Header>,
+        processing: Option<BS::OnPushedHeadersFuture>,
+    }
+
+    impl<BS: BlockService> Default for State<BS> {
+        fn default() -> Self {
+            State {
+                accum: Vec::with_capacity(BS::PUSH_HEADERS_CHUNK_SIZE),
+                processing: None,
+            }
+        }
+    }
+
+    impl<BS: BlockService> State<BS> {
+        pub fn processing(&mut self) -> Option<&mut BS::OnPushedHeadersFuture> {
+            self.processing.as_mut()
+        }
+
+        pub fn finish_processing(&mut self) {
+            self.processing = None;
+        }
+
+        pub fn process_headers(&mut self, service: &mut BS) -> bool {
+            debug_assert!(self.processing.is_none());
+            if self.accum.is_empty() {
+                false
+            } else {
+                let headers = self.accum.split_off(0);
+                let future = service.on_pushed_headers(Ok(headers));
+                self.processing = Some(future);
+                true
+            }
+        }
+
+        pub fn push_header(&mut self, service: &mut BS, header: BS::Header) {
+            self.accum.push(header);
+            if self.accum.len() >= BS::PUSH_HEADERS_CHUNK_SIZE {
+                self.process_headers(service);
+            }
+        }
+
+        pub fn process_error(&mut self, service: &mut BS, err: Error) {
+            self.processing = Some(service.on_pushed_headers(Err(err)));
+        }
+    }
+}
+
+impl<T, S> Future for PushHeadersFuture<T, S>
+where
+    T: Node,
+    S: Stream<Error = tower_grpc::Status>,
+    <T::BlockService as BlockService>::Header: FromProtobuf<S::Item>,
+{
+    type Item = tower_grpc::Response<gen::node::PushHeadersResponse>;
+    type Error = tower_grpc::Status;
+
+    fn poll(&mut self) -> Poll<Self::Item, tower_grpc::Status> {
+        let service = self.service.block_service().ok_or_else(|| {
+            tower_grpc::Status::new(tower_grpc::Code::Unimplemented, "not implemented")
+        })?;
+        loop {
+            if let Some(ref mut future) = self.state.processing() {
+                try_ready!(future.poll().map_err(error_into_grpc));
+                self.state.finish_processing();
+            }
+            let stream = match self.stream {
+                None => break,
+                Some(ref mut stream) => stream,
+            };
+            match stream.poll() {
+                Ok(Async::NotReady) => {
+                    // Use the pause in the stream to process the headers,
+                    // if any have been buffered.
+                    if self.state.process_headers(service) {
+                        continue;
+                    } else {
+                        return Ok(Async::NotReady);
+                    }
+                }
+                Ok(Async::Ready(Some(header))) => {
+                    self.state.push_header(service, header);
+                }
+                Ok(Async::Ready(None)) => {
+                    self.state.process_headers(service);
+                    self.stream = None;
+                }
+                Err(e) => {
+                    self.state.process_error(service, e);
+                    self.stream = None;
+                }
+            }
+        }
+        let res = gen::node::PushHeadersResponse {};
+        Ok(Async::Ready(tower_grpc::Response::new(res)))
+    }
+}
+
+#[must_use = "futures do nothing unless polled"]
 pub struct UploadBlocksFuture<T, S>
 where
     T: Node,
@@ -425,10 +550,7 @@ where
         Self::GetMessagesStream,
         <<T as Node>::ContentService as ContentService>::GetMessagesFuture,
     >;
-    type PushHeadersFuture = ResponseFuture<
-        gen::node::PushHeadersResponse,
-        <T::BlockService as BlockService>::PushHeadersFuture,
-    >;
+    type PushHeadersFuture = PushHeadersFuture<T, Streaming<gen::node::Header>>;
     type UploadBlocksFuture = UploadBlocksFuture<T, Streaming<gen::node::Block>>;
     type BlockSubscriptionStream = ResponseStream<
         gen::node::BlockEvent,
@@ -534,9 +656,7 @@ where
         &mut self,
         req: Request<Streaming<gen::node::Header>>,
     ) -> Self::PushHeadersFuture {
-        let service = try_get_service!(self.inner.block_service());
-        let stream = RequestStream::new(req.into_inner());
-        ResponseFuture::new(service.push_headers(stream))
+        PushHeadersFuture::new(self.inner.clone(), req.into_inner())
     }
 
     fn upload_blocks(


### PR DESCRIPTION
The generic inbound stream in `BlockService::push_headers` does not play well with the implementation needing to return a future that is wholly defined by the implementing type (no generic associated types in Rust yet). This forces boxing in jormungandr.

Take a cue from `BlockService::on_uploaded_block` and rework the header push support in the network-core API to work with header chunks, accumulated by the protocol implementation accordingly to the inbound stream's readiness and the maximum chunk size, supplied by the application implementing the `BlockService` trait.

Support error reporting from the client via the inbound stream by passing a `Result`. Back-pollinate `BlockService::on_uploaded_block` with the same idea.