### PR TITLE
Transaction-ID removal

### DIFF
--- a/chain-impl-mockchain/doc/format.md
+++ b/chain-impl-mockchain/doc/format.md
@@ -57,25 +57,28 @@ header is just applying the hash function to the binary data except the first
 
 ## Block Body
 
-We need to be able to have different type of content on the blockchain, we
-also need a flexible system for future extension. The block content is
-effectively a sequence of serialized content, one after another.
+We need to be able to have different type of content on the blockchain, we also
+need a flexible system for future expansion of this content.  The block content
+is effectively a sequence of serialized content, one after another.
 
-Each individual piece of block content is prefixed with a header which
-contains the following information:
+Each individual piece of block content is called a fragment and is prefixed
+with a header which contains the following information:
 
 * Size of content piece in bytes (2 bytes)
 * Type of piece (1 byte): up to 256 different type of block content.
 
 The block body is formed of the following stream of data:
 
-    HEADER(CONTENT1) | CONTENT1 | HEADER(CONTENT2) | CONTENT2 ...
+    HEADER(FRAGMENT1) | FRAGMENT1 | HEADER(FRAGMENT2) | FRAGMENT2 ...
 
 Where HEADER is:
 
 	SIZE (2 bytes) | TYPE (1 byte)
 
-Additionally, we introduce the capability to address each content object individually by using a cryptographic hash function : `H(TYPE | CONTENT)`. The hash doesn't include the size prefix in the header to simplify calculation of hash with on-the-fly (non serialized) structure.
+Additionally, we introduce the capability to refer to each fragment
+individually by fragment-id, using a cryptographic hash function : `H(TYPE |
+CONTENT)`. The hash doesn't include the size prefix in the header to simplify
+calculation of hash with on-the-fly (non serialized) structure.
 
 Types of content:
 
@@ -91,7 +94,7 @@ Types of content:
 
 Token Transfer is found in different type of messages, and allow to transfer tokens between an input to an output.
 
-There's 4 differents type of spending:
+There's 4 differents type of supported spending:
 
 * Utxo -> Utxo
 * Utxo -> Account

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -6,7 +6,7 @@ use crate::block::{
 };
 use crate::config::{self, ConfigParam};
 use crate::fee::{FeeAlgorithm, LinearFee};
-use crate::fragment::Fragment;
+use crate::fragment::{Fragment, FragmentId};
 use crate::leadership::genesis::ActiveSlotsCoeffError;
 use crate::stake::{DelegationError, DelegationState, StakeDistribution};
 use crate::transaction::*;
@@ -239,6 +239,7 @@ impl Ledger {
         let ledger_params = ledger.get_ledger_parameters();
 
         for content in content_iter {
+            let fragment_id = content.id();
             match content {
                 Fragment::Initial(_) => {
                     return Err(Error::Block0 {
@@ -246,7 +247,7 @@ impl Ledger {
                     });
                 }
                 Fragment::OldUtxoDeclaration(old) => {
-                    ledger.oldutxos = apply_old_declaration(ledger.oldutxos, old)?;
+                    ledger.oldutxos = apply_old_declaration(&fragment_id, ledger.oldutxos, old)?;
                 }
                 Fragment::Transaction(authenticated_tx) => {
                     if authenticated_tx.transaction.inputs.len() != 0 {
@@ -259,7 +260,6 @@ impl Ledger {
                             source: Block0Error::TransactionHasWitnesses,
                         });
                     }
-                    let transaction_id = authenticated_tx.transaction.hash();
                     let (new_utxos, new_accounts, new_multisig) =
                         internal_apply_transaction_output(
                             ledger.utxos,
@@ -267,7 +267,7 @@ impl Ledger {
                             ledger.multisig,
                             &ledger.static_params,
                             &ledger_params,
-                            &transaction_id,
+                            &fragment_id,
                             &authenticated_tx.transaction.outputs,
                         )?;
                     ledger.utxos = new_utxos;
@@ -371,6 +371,7 @@ impl Ledger {
     ) -> Result<Self, Error> {
         let mut new_ledger = self.clone();
 
+        let fragment_id = content.id();
         match content {
             Fragment::Initial(_) => {
                 return Err(Error::Block0 {
@@ -383,8 +384,11 @@ impl Ledger {
                 });
             }
             Fragment::Transaction(authenticated_tx) => {
-                let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&authenticated_tx, &ledger_params)?;
+                let (new_ledger_, _fee) = new_ledger.apply_transaction(
+                    &fragment_id,
+                    &authenticated_tx,
+                    &ledger_params,
+                )?;
                 new_ledger = new_ledger_;
             }
             Fragment::UpdateProposal(update_proposal) => {
@@ -398,8 +402,11 @@ impl Ledger {
                 new_ledger = new_ledger.apply_update_vote(&vote)?;
             }
             Fragment::Certificate(authenticated_cert_tx) => {
-                let (new_ledger_, _fee) =
-                    new_ledger.apply_certificate(authenticated_cert_tx, &ledger_params)?;
+                let (new_ledger_, _fee) = new_ledger.apply_certificate(
+                    &fragment_id,
+                    authenticated_cert_tx,
+                    &ledger_params,
+                )?;
                 new_ledger = new_ledger_;
             }
         }
@@ -409,6 +416,7 @@ impl Ledger {
 
     pub fn apply_transaction<Extra>(
         mut self,
+        fragment_id: &FragmentId,
         signed_tx: &AuthenticatedTransaction<Address, Extra>,
         dyn_params: &LedgerParameters,
     ) -> Result<(Self, Value), Error>
@@ -416,7 +424,7 @@ impl Ledger {
         Extra: property::Serialize,
         LinearFee: FeeAlgorithm<Transaction<Address, Extra>>,
     {
-        let transaction_id = signed_tx.transaction.hash();
+        let sign_data_hash = signed_tx.transaction.hash();
         let fee = dyn_params
             .fees
             .calculate(&signed_tx.transaction)
@@ -427,7 +435,8 @@ impl Ledger {
         self = internal_apply_transaction(
             self,
             dyn_params,
-            &transaction_id,
+            &fragment_id,
+            &sign_data_hash,
             &signed_tx.transaction.inputs[..],
             &signed_tx.transaction.outputs[..],
             &signed_tx.witnesses[..],
@@ -494,6 +503,7 @@ impl Ledger {
 
     pub fn apply_certificate(
         mut self,
+        fragment_id: &FragmentId,
         auth_cert: &AuthenticatedTransaction<Address, certificate::Certificate>,
         dyn_params: &LedgerParameters,
     ) -> Result<(Self, Value), Error> {
@@ -501,7 +511,7 @@ impl Ledger {
         if verified == chain_crypto::Verification::Failed {
             return Err(Error::CertificateInvalidSignature);
         };
-        let (new_ledger, fee) = self.apply_transaction(auth_cert, dyn_params)?;
+        let (new_ledger, fee) = self.apply_transaction(fragment_id, auth_cert, dyn_params)?;
 
         self = new_ledger.apply_certificate_content(&auth_cert.transaction.extra)?;
 
@@ -577,11 +587,11 @@ impl Ledger {
 }
 
 fn apply_old_declaration(
+    fragment_id: &FragmentId,
     mut utxos: utxo::Ledger<legacy::OldAddress>,
     decl: &legacy::UtxoDeclaration,
 ) -> Result<utxo::Ledger<legacy::OldAddress>, Error> {
     assert!(decl.addrs.len() < 255);
-    let txid = decl.hash();
     let mut outputs = Vec::with_capacity(decl.addrs.len());
     for (i, d) in decl.addrs.iter().enumerate() {
         let output = Output {
@@ -590,7 +600,7 @@ fn apply_old_declaration(
         };
         outputs.push((i as u8, output))
     }
-    utxos = utxos.add(&txid, &outputs)?;
+    utxos = utxos.add(&fragment_id, &outputs)?;
     Ok(utxos)
 }
 
@@ -598,7 +608,8 @@ fn apply_old_declaration(
 fn internal_apply_transaction(
     mut ledger: Ledger,
     dyn_params: &LedgerParameters,
-    transaction_id: &TransactionSignDataHash,
+    fragment_id: &FragmentId,
+    sign_data_hash: &TransactionSignDataHash,
     inputs: &[Input],
     outputs: &[Output<Address>],
     witnesses: &[Witness],
@@ -639,14 +650,14 @@ fn internal_apply_transaction(
     for (input, witness) in inputs.iter().zip(witnesses.iter()) {
         match input.to_enum() {
             InputEnum::UtxoInput(utxo) => {
-                ledger = input_utxo_verify(ledger, transaction_id, &utxo, witness)?
+                ledger = input_utxo_verify(ledger, sign_data_hash, &utxo, witness)?
             }
             InputEnum::AccountInput(account_id, value) => {
                 let (single, multi) = input_account_verify(
                     ledger.accounts,
                     ledger.multisig,
                     &ledger.static_params.block0_initial_hash,
-                    transaction_id,
+                    sign_data_hash,
                     &account_id,
                     value,
                     witness,
@@ -676,7 +687,7 @@ fn internal_apply_transaction(
         ledger.multisig,
         &ledger.static_params,
         dyn_params,
-        transaction_id,
+        fragment_id,
         outputs,
     )?;
     ledger.utxos = new_utxos;
@@ -695,7 +706,7 @@ fn internal_apply_transaction_output(
     mut multisig: multisig::Ledger,
     static_params: &LedgerStaticParameters,
     _dyn_params: &LedgerParameters,
-    transaction_id: &TransactionSignDataHash,
+    transaction_id: &FragmentId,
     outputs: &[Output<Address>],
 ) -> Result<(utxo::Ledger<Address>, account::Ledger, multisig::Ledger), Error> {
     let mut new_utxos = Vec::new();
@@ -746,7 +757,7 @@ fn internal_apply_transaction_output(
 
 fn input_utxo_verify(
     mut ledger: Ledger,
-    transaction_id: &TransactionSignDataHash,
+    sign_data_hash: &TransactionSignDataHash,
     utxo: &UtxoPointer,
     witness: &Witness,
 ) -> Result<Ledger, Error> {
@@ -775,7 +786,7 @@ fn input_utxo_verify(
             };
 
             let data_to_verify =
-                WitnessUtxoData::new(&ledger.static_params.block0_initial_hash, &transaction_id);
+                WitnessUtxoData::new(&ledger.static_params.block0_initial_hash, sign_data_hash);
             let verified = signature.verify(&xpub, &data_to_verify);
             if verified == chain_crypto::Verification::Failed {
                 return Err(Error::OldUtxoInvalidSignature {
@@ -800,7 +811,7 @@ fn input_utxo_verify(
             }
 
             let data_to_verify =
-                WitnessUtxoData::new(&ledger.static_params.block0_initial_hash, &transaction_id);
+                WitnessUtxoData::new(&ledger.static_params.block0_initial_hash, sign_data_hash);
             let verified = signature.verify(
                 &associated_output.address.public_key().unwrap(),
                 &data_to_verify,
@@ -821,7 +832,7 @@ fn input_account_verify(
     mut ledger: account::Ledger,
     mut mledger: multisig::Ledger,
     block0_hash: &HeaderHash,
-    transaction_id: &TransactionSignDataHash,
+    sign_data_hash: &TransactionSignDataHash,
     account: &AccountIdentifier,
     value: Value,
     witness: &Witness,
@@ -840,7 +851,7 @@ fn input_account_verify(
             let (new_ledger, spending_counter) = ledger.remove_value(&account, value)?;
             ledger = new_ledger;
 
-            let tidsc = WitnessAccountData::new(block0_hash, transaction_id, &spending_counter);
+            let tidsc = WitnessAccountData::new(block0_hash, sign_data_hash, &spending_counter);
             let verified = sig.verify(&account.clone().into(), &tidsc);
             if verified == chain_crypto::Verification::Failed {
                 return Err(Error::AccountInvalidSignature {
@@ -858,7 +869,7 @@ fn input_account_verify(
                 mledger.remove_value(&account, value)?;
 
             let data_to_verify =
-                WitnessMultisigData::new(&block0_hash, &transaction_id, &spending_counter);
+                WitnessMultisigData::new(&block0_hash, sign_data_hash, &spending_counter);
             if msignature.verify(declaration, &data_to_verify) != true {
                 return Err(Error::MultisigInvalidSignature {
                     multisig: account,
@@ -1048,13 +1059,13 @@ impl<'a> std::iter::FromIterator<Entry<'a>> for Result<Ledger, Error> {
                 }
                 Entry::Utxo(entry) => {
                     utxos
-                        .entry(entry.transaction_id)
+                        .entry(entry.fragment_id)
                         .or_insert(vec![])
                         .push((entry.output_index, entry.output.clone()));
                 }
                 Entry::OldUtxo(entry) => {
                     oldutxos
-                        .entry(entry.transaction_id)
+                        .entry(entry.fragment_id)
                         .or_insert(vec![])
                         .push((entry.output_index, entry.output.clone()));
                 }

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -598,7 +598,7 @@ fn apply_old_declaration(
 fn internal_apply_transaction(
     mut ledger: Ledger,
     dyn_params: &LedgerParameters,
-    transaction_id: &TransactionId,
+    transaction_id: &TransactionSignDataHash,
     inputs: &[Input],
     outputs: &[Output<Address>],
     witnesses: &[Witness],
@@ -695,7 +695,7 @@ fn internal_apply_transaction_output(
     mut multisig: multisig::Ledger,
     static_params: &LedgerStaticParameters,
     _dyn_params: &LedgerParameters,
-    transaction_id: &TransactionId,
+    transaction_id: &TransactionSignDataHash,
     outputs: &[Output<Address>],
 ) -> Result<(utxo::Ledger<Address>, account::Ledger, multisig::Ledger), Error> {
     let mut new_utxos = Vec::new();
@@ -746,7 +746,7 @@ fn internal_apply_transaction_output(
 
 fn input_utxo_verify(
     mut ledger: Ledger,
-    transaction_id: &TransactionId,
+    transaction_id: &TransactionSignDataHash,
     utxo: &UtxoPointer,
     witness: &Witness,
 ) -> Result<Ledger, Error> {
@@ -821,7 +821,7 @@ fn input_account_verify(
     mut ledger: account::Ledger,
     mut mledger: multisig::Ledger,
     block0_hash: &HeaderHash,
-    transaction_id: &TransactionId,
+    transaction_id: &TransactionSignDataHash,
     account: &AccountIdentifier,
     value: Value,
     witness: &Witness,

--- a/chain-impl-mockchain/src/ledger/tests/discrimination_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/discrimination_tests.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+use crate::fragment::Fragment;
 use crate::testing::{
     address::AddressData,
     arbitrary::KindTypeWithoutMultisig,
@@ -9,6 +10,7 @@ use crate::testing::{
 use crate::transaction::*;
 use crate::value::*;
 use chain_addr::Discrimination;
+use chain_core::property::Message as _;
 use quickcheck::TestResult;
 use quickcheck_macros::quickcheck;
 
@@ -78,11 +80,12 @@ pub fn ledger_verifies_transaction_discrimination(
         .authenticate()
         .with_witness(&block0_hash, &faucet)
         .seal();
+    let fragment_id = Fragment::Transaction(signed_tx.clone()).id();
 
     let are_discriminations_unified = arbitrary_input_disc == arbitrary_output_disc;
 
     let fees = ledger.get_ledger_parameters();
-    let actual_result = ledger.apply_transaction(&signed_tx, &fees);
+    let actual_result = ledger.apply_transaction(&fragment_id, &signed_tx, &fees);
 
     match (are_discriminations_unified, actual_result) {
         (true, Ok(_)) => TestResult::passed(),

--- a/chain-impl-mockchain/src/legacy.rs
+++ b/chain-impl-mockchain/src/legacy.rs
@@ -1,4 +1,4 @@
-use crate::transaction::TransactionId;
+use crate::transaction::TransactionSignDataHash;
 use crate::value::Value;
 
 pub use cardano_legacy_address::Addr as OldAddress;
@@ -18,9 +18,9 @@ pub fn oldaddress_from_xpub(address: &OldAddress, xpub: &PublicKey<Ed25519Bip32>
 }
 
 impl UtxoDeclaration {
-    pub fn hash(&self) -> TransactionId {
+    pub fn hash(&self) -> TransactionSignDataHash {
         let v = self.serialize_as_vec().unwrap();
-        TransactionId::hash_bytes(&v[..])
+        TransactionSignDataHash::hash_bytes(&v[..])
     }
 }
 

--- a/chain-impl-mockchain/src/legacy.rs
+++ b/chain-impl-mockchain/src/legacy.rs
@@ -1,11 +1,9 @@
-use crate::transaction::TransactionSignDataHash;
 use crate::value::Value;
 
 pub use cardano_legacy_address::Addr as OldAddress;
 
 use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_core::property;
-use chain_core::property::Serialize;
 use chain_crypto::{Ed25519Bip32, PublicKey};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,13 +13,6 @@ pub struct UtxoDeclaration {
 
 pub fn oldaddress_from_xpub(address: &OldAddress, xpub: &PublicKey<Ed25519Bip32>) -> bool {
     address.identical_with_pubkey_raw(xpub.as_ref())
-}
-
-impl UtxoDeclaration {
-    pub fn hash(&self) -> TransactionSignDataHash {
-        let v = self.serialize_as_vec().unwrap();
-        TransactionSignDataHash::hash_bytes(&v[..])
-    }
 }
 
 impl Readable for UtxoDeclaration {

--- a/chain-impl-mockchain/src/multisig/mod.rs
+++ b/chain-impl-mockchain/src/multisig/mod.rs
@@ -15,7 +15,7 @@ pub use index::{Index, TreeIndex};
 mod test {
     use super::*;
     use crate::accounting::account::SpendingCounter;
-    use crate::transaction::TransactionSignDataHash;
+    use crate::transaction::{TransactionSignData, TransactionSignDataHash};
     use crate::{account, key};
     use chain_crypto::{PublicKey, SecretKey};
     use rand_core::{CryptoRng, RngCore};
@@ -63,9 +63,14 @@ mod test {
         };
 
         let fake_spending_counter = SpendingCounter::zero();
-        let fake_tid = TransactionSignDataHash::hash_bytes(&[1, 2, 3]);
+        let fake_sign_data: TransactionSignData = vec![1, 2, 3].into();
+        let fake_sign_data_hash = TransactionSignDataHash::digest(&fake_sign_data);
         let fake_block0_hash = key::Hash::hash_bytes(&[1, 2, 3, 4, 5, 6, 7]);
-        let msg = WitnessMultisigData::new(&fake_block0_hash, &fake_tid, &fake_spending_counter);
+        let msg = WitnessMultisigData::new(
+            &fake_block0_hash,
+            &fake_sign_data_hash,
+            &fake_spending_counter,
+        );
 
         // test participant 1 and 3
         {

--- a/chain-impl-mockchain/src/multisig/mod.rs
+++ b/chain-impl-mockchain/src/multisig/mod.rs
@@ -15,7 +15,7 @@ pub use index::{Index, TreeIndex};
 mod test {
     use super::*;
     use crate::accounting::account::SpendingCounter;
-    use crate::transaction::TransactionId;
+    use crate::transaction::TransactionSignDataHash;
     use crate::{account, key};
     use chain_crypto::{PublicKey, SecretKey};
     use rand_core::{CryptoRng, RngCore};
@@ -63,7 +63,7 @@ mod test {
         };
 
         let fake_spending_counter = SpendingCounter::zero();
-        let fake_tid = TransactionId::hash_bytes(&[1, 2, 3]);
+        let fake_tid = TransactionSignDataHash::hash_bytes(&[1, 2, 3]);
         let fake_block0_hash = key::Hash::hash_bytes(&[1, 2, 3, 4, 5, 6, 7]);
         let msg = WitnessMultisigData::new(&fake_block0_hash, &fake_tid, &fake_spending_counter);
 

--- a/chain-impl-mockchain/src/transaction/transaction.rs
+++ b/chain-impl-mockchain/src/transaction/transaction.rs
@@ -6,7 +6,7 @@ use chain_core::mempack::{read_vec, ReadBuf, ReadError, Readable};
 use chain_core::property;
 
 // FIXME: should this be a wrapper type?
-pub type TransactionId = Hash;
+pub type TransactionSignDataHash = Hash;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NoExtra;
@@ -112,10 +112,10 @@ impl<Extra: property::Serialize> Transaction<Address, Extra> {
         self.serialize_body(&mut codec.into_inner())
     }
 
-    pub fn hash(&self) -> TransactionId {
+    pub fn hash(&self) -> TransactionSignDataHash {
         let mut bytes = Vec::new();
         self.serialize_body(&mut bytes).unwrap();
-        TransactionId::hash_bytes(&bytes)
+        TransactionSignDataHash::hash_bytes(&bytes)
     }
 }
 
@@ -219,5 +219,3 @@ impl<A, Extra> Transaction<A, Extra> {
         }
     }
 }
-
-impl property::TransactionId for TransactionId {}

--- a/chain-impl-mockchain/src/transaction/transfer.rs
+++ b/chain-impl-mockchain/src/transaction/transfer.rs
@@ -1,6 +1,6 @@
-use super::transaction::TransactionSignDataHash;
 use super::utxo::UtxoPointer;
 use crate::account::Identifier;
+use crate::fragment::FragmentId;
 use crate::key::SpendingPublicKey;
 use crate::legacy::OldAddress;
 use crate::utxo::Entry;
@@ -99,7 +99,7 @@ impl Input {
 
     pub fn from_utxo_entry(utxo_entry: Entry<Address>) -> Self {
         let mut input_ptr = [0u8; INPUT_PTR_SIZE];
-        input_ptr.clone_from_slice(utxo_entry.transaction_id.as_ref());
+        input_ptr.clone_from_slice(utxo_entry.fragment_id.as_ref());
         Input {
             index_or_account: utxo_entry.output_index,
             value: utxo_entry.output.value,
@@ -142,7 +142,7 @@ impl Input {
                 InputEnum::AccountInput(id, self.value)
             }
             InputType::Utxo => InputEnum::UtxoInput(UtxoPointer::new(
-                TransactionSignDataHash::from_bytes(self.input_ptr.clone()),
+                FragmentId::from(self.input_ptr.clone()),
                 self.index_or_account,
                 self.value,
             )),

--- a/chain-impl-mockchain/src/transaction/transfer.rs
+++ b/chain-impl-mockchain/src/transaction/transfer.rs
@@ -1,4 +1,4 @@
-use super::transaction::TransactionId;
+use super::transaction::TransactionSignDataHash;
 use super::utxo::UtxoPointer;
 use crate::account::Identifier;
 use crate::key::SpendingPublicKey;
@@ -14,7 +14,7 @@ use chain_crypto::PublicKey;
 pub const INPUT_PTR_SIZE: usize = 32;
 
 /// Generalized input which have a specific input value, and
-/// either contains an account reference or a TransactionId+index
+/// either contains an account reference or a TransactionSignDataHash+index
 ///
 /// This uniquely refer to a specific source of value.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -142,7 +142,7 @@ impl Input {
                 InputEnum::AccountInput(id, self.value)
             }
             InputType::Utxo => InputEnum::UtxoInput(UtxoPointer::new(
-                TransactionId::from_bytes(self.input_ptr.clone()),
+                TransactionSignDataHash::from_bytes(self.input_ptr.clone()),
                 self.index_or_account,
                 self.value,
             )),

--- a/chain-impl-mockchain/src/transaction/utxo.rs
+++ b/chain-impl-mockchain/src/transaction/utxo.rs
@@ -1,4 +1,4 @@
-use super::transaction::TransactionSignDataHash;
+use crate::fragment::FragmentId;
 use crate::value::*;
 
 pub type TransactionIndex = u8;
@@ -7,7 +7,7 @@ pub type TransactionIndex = u8;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UtxoPointer {
     /// the transaction identifier where the unspent output is
-    pub transaction_id: TransactionSignDataHash,
+    pub transaction_id: FragmentId,
     /// the output index within the pointed transaction's outputs
     pub output_index: TransactionIndex,
     /// the value we expect to read from this output
@@ -19,7 +19,7 @@ pub struct UtxoPointer {
 
 impl UtxoPointer {
     pub fn new(
-        transaction_id: TransactionSignDataHash,
+        transaction_id: FragmentId,
         output_index: TransactionIndex,
         value: Value,
     ) -> Self {

--- a/chain-impl-mockchain/src/transaction/utxo.rs
+++ b/chain-impl-mockchain/src/transaction/utxo.rs
@@ -1,4 +1,4 @@
-use super::transaction::TransactionId;
+use super::transaction::TransactionSignDataHash;
 use crate::value::*;
 
 pub type TransactionIndex = u8;
@@ -7,7 +7,7 @@ pub type TransactionIndex = u8;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UtxoPointer {
     /// the transaction identifier where the unspent output is
-    pub transaction_id: TransactionId,
+    pub transaction_id: TransactionSignDataHash,
     /// the output index within the pointed transaction's outputs
     pub output_index: TransactionIndex,
     /// the value we expect to read from this output
@@ -19,7 +19,7 @@ pub struct UtxoPointer {
 
 impl UtxoPointer {
     pub fn new(
-        transaction_id: TransactionId,
+        transaction_id: TransactionSignDataHash,
         output_index: TransactionIndex,
         value: Value,
     ) -> Self {

--- a/chain-impl-mockchain/src/transaction/utxo.rs
+++ b/chain-impl-mockchain/src/transaction/utxo.rs
@@ -18,11 +18,7 @@ pub struct UtxoPointer {
 }
 
 impl UtxoPointer {
-    pub fn new(
-        transaction_id: FragmentId,
-        output_index: TransactionIndex,
-        value: Value,
-    ) -> Self {
+    pub fn new(transaction_id: FragmentId, output_index: TransactionIndex, value: Value) -> Self {
         UtxoPointer {
             transaction_id,
             output_index,

--- a/chain-impl-mockchain/src/transaction/witness.rs
+++ b/chain-impl-mockchain/src/transaction/witness.rs
@@ -55,7 +55,7 @@ impl std::fmt::Display for Witness {
 pub struct WitnessUtxoData(Vec<u8>);
 
 impl WitnessUtxoData {
-    pub fn new(block0: &HeaderHash, transaction_id: &TransactionId) -> Self {
+    pub fn new(block0: &HeaderHash, transaction_id: &TransactionSignDataHash) -> Self {
         let mut v = Vec::with_capacity(65);
         v.extend_from_slice(block0.as_ref());
         v.extend_from_slice(transaction_id.as_ref());
@@ -74,7 +74,7 @@ pub struct WitnessAccountData(Vec<u8>);
 impl WitnessAccountData {
     pub fn new(
         block0: &HeaderHash,
-        transaction_id: &TransactionId,
+        transaction_id: &TransactionSignDataHash,
         spending_counter: &account::SpendingCounter,
     ) -> Self {
         let mut v = Vec::with_capacity(65);
@@ -97,7 +97,7 @@ pub struct WitnessMultisigData(Vec<u8>);
 impl WitnessMultisigData {
     pub fn new(
         block0: &HeaderHash,
-        transaction_id: &TransactionId,
+        transaction_id: &TransactionSignDataHash,
         spending_counter: &account::SpendingCounter,
     ) -> Self {
         let mut v = Vec::with_capacity(65);
@@ -119,7 +119,7 @@ impl Witness {
     /// Creates new `Witness` value.
     pub fn new_utxo(
         block0: &HeaderHash,
-        transaction_id: &TransactionId,
+        transaction_id: &TransactionSignDataHash,
         secret_key: &EitherEd25519SecretKey,
     ) -> Self {
         let wud = WitnessUtxoData::new(block0, transaction_id);
@@ -129,7 +129,7 @@ impl Witness {
 
     pub fn new_account(
         block0: &HeaderHash,
-        transaction_id: &TransactionId,
+        transaction_id: &TransactionSignDataHash,
         spending_counter: &account::SpendingCounter,
         secret_key: &EitherEd25519SecretKey,
     ) -> Self {
@@ -138,12 +138,12 @@ impl Witness {
         Witness::Account(sig)
     }
 
-    // Verify the given `TransactionId` using the witness.
+    // Verify the given `TransactionSignDataHash` using the witness.
     pub fn verify_utxo(
         &self,
         public_key: &SpendingPublicKey,
         block0: &HeaderHash,
-        transaction_id: &TransactionId,
+        transaction_id: &TransactionSignDataHash,
     ) -> Verification {
         match self {
             Witness::OldUtxo(_xpub, _signature) => unimplemented!(),
@@ -250,7 +250,7 @@ pub mod test {
         /// ```
         /// \forall w=Witness(tx) => w.verifies(tx)
         /// ```
-        fn prop_witness_verifies_own_tx(sk: TransactionSigningKey, tx:TransactionId, block0: HeaderHash) -> bool {
+        fn prop_witness_verifies_own_tx(sk: TransactionSigningKey, tx:TransactionSignDataHash, block0: HeaderHash) -> bool {
             let pk = sk.0.to_public();
             let witness = Witness::new_utxo(&block0, &tx, &sk.0);
             witness.verify_utxo(&pk, &block0, &tx) == Verification::Success

--- a/chain-impl-mockchain/src/transaction/witness.rs
+++ b/chain-impl-mockchain/src/transaction/witness.rs
@@ -119,21 +119,21 @@ impl Witness {
     /// Creates new `Witness` value.
     pub fn new_utxo(
         block0: &HeaderHash,
-        transaction_id: &TransactionSignDataHash,
+        sign_data_hash: &TransactionSignDataHash,
         secret_key: &EitherEd25519SecretKey,
     ) -> Self {
-        let wud = WitnessUtxoData::new(block0, transaction_id);
+        let wud = WitnessUtxoData::new(block0, sign_data_hash);
         let sig = secret_key.sign(&wud);
         Witness::Utxo(sig)
     }
 
     pub fn new_account(
         block0: &HeaderHash,
-        transaction_id: &TransactionSignDataHash,
+        sign_data_hash: &TransactionSignDataHash,
         spending_counter: &account::SpendingCounter,
         secret_key: &EitherEd25519SecretKey,
     ) -> Self {
-        let wud = WitnessAccountData::new(block0, transaction_id, spending_counter);
+        let wud = WitnessAccountData::new(block0, sign_data_hash, spending_counter);
         let sig = secret_key.sign(&wud);
         Witness::Account(sig)
     }
@@ -143,12 +143,12 @@ impl Witness {
         &self,
         public_key: &SpendingPublicKey,
         block0: &HeaderHash,
-        transaction_id: &TransactionSignDataHash,
+        sign_data_hash: &TransactionSignDataHash,
     ) -> Verification {
         match self {
             Witness::OldUtxo(_xpub, _signature) => unimplemented!(),
             Witness::Utxo(signature) => {
-                signature.verify(public_key, &WitnessUtxoData::new(block0, transaction_id))
+                signature.verify(public_key, &WitnessUtxoData::new(block0, sign_data_hash))
             }
             Witness::Account(_) => Verification::Failed,
             Witness::Multisig(_) => Verification::Failed,

--- a/chain-impl-mockchain/src/txbuilder.rs
+++ b/chain-impl-mockchain/src/txbuilder.rs
@@ -259,7 +259,7 @@ impl TransactionFinalizer {
         }
     }
 
-    pub fn get_txid(&self) -> tx::TransactionId {
+    pub fn get_txid(&self) -> tx::TransactionSignDataHash {
         match self {
             TransactionFinalizer::Type1(t, _) => t.hash(),
             TransactionFinalizer::Type2(t, _) => t.hash(),


### PR DESCRIPTION
remove transaction-id for transaction, and replace by:

* `TransactionSignDataHash` for the data that need to be signed for authenticating the transaction
* `FragmentId` which is used to store the transaction and identify it uniquely in the ledger

fix #25 