### PR TITLE
network: Add Handshake method

### DIFF
--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -20,7 +20,7 @@ pub trait BlockService: P2pService {
     type HandshakeFuture: Future<Item = <Self::Block as Block>::Id, Error = HandshakeError>;
 
     /// Requests the identifier of the genesis block from the service node.
-    /// 
+    ///
     /// The implementation can also perform version information checks to
     /// ascertain that the client use compatible protocol versions.
     ///

--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -94,6 +94,9 @@ pub trait BlockService: P2pService {
         + Send
         + 'static;
 
+    /// Returns the ID of the genesis block of the chain served by this node.
+    fn block0(&mut self) -> Self::BlockId;
+
     /// Request the current blockchain tip.
     /// The returned future resolves to the tip of the blockchain
     /// accepted by this node.

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -3,6 +3,18 @@ syntax = "proto3";
 // gRPC protocol for a blockchain node
 package iohk.chain.node;
 
+// Request message for method Handshake.
+message HandshakeRequest {}
+
+// Response message for method Handshake.
+message HandshakeResponse {
+  // Version of the protocol implemented by the server.
+  uint32 version = 1;
+  // The identifier of the genesis block. This can be used by the client
+  // to determine if the server node runs the expected blockchain.
+  bytes block0 = 2;
+}
+
 // Request message for method Tip.
 message TipRequest {}
 
@@ -87,6 +99,7 @@ message BlockEvent {
 }
 
 service Node {
+  rpc Handshake(HandshakeRequest) returns (HandshakeResponse);
   rpc Tip(TipRequest) returns (TipResponse);
   rpc GetBlocks(BlockIds) returns (stream Block) {
     option idempotency_level = NO_SIDE_EFFECTS;

--- a/network-grpc/src/client/handshake.rs
+++ b/network-grpc/src/client/handshake.rs
@@ -1,0 +1,48 @@
+use crate::{gen, convert, PROTOCOL_VERSION};
+use chain_core::property;
+use network_core::client::block::HandshakeError;
+
+use futures::prelude::*;
+
+use std::marker::PhantomData;
+
+type ResponseFuture = tower_grpc::client::unary::ResponseFuture<
+    gen::node::HandshakeResponse,
+    tower_hyper::client::ResponseFuture<hyper::client::conn::ResponseFuture>,
+    hyper::Body,
+>;
+
+pub struct HandshakeFuture<Id> {
+    inner: ResponseFuture,
+    _phantom: PhantomData<Id>,
+}
+
+impl<Id> HandshakeFuture<Id> {
+    pub fn new(inner: ResponseFuture) -> Self {
+        HandshakeFuture {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Id> Future for HandshakeFuture<Id>
+where
+    Id: property::BlockId + property::Deserialize,
+{
+    type Item = Id;
+    type Error = HandshakeError;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let res = match self.inner.poll() {
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Ok(Async::Ready(res)) => res.into_inner(),
+            Err(status) => return Err(HandshakeError::Rpc(convert::error_from_grpc(status))),
+        };
+        if res.version != PROTOCOL_VERSION {
+            return Err(HandshakeError::UnsupportedVersion(res.version.to_string().into()));
+        }
+        let block0_id = convert::deserialize_bytes(&res.block0)?;
+        Ok(Async::Ready(block0_id))
+    }
+}

--- a/network-grpc/src/client/handshake.rs
+++ b/network-grpc/src/client/handshake.rs
@@ -1,4 +1,4 @@
-use crate::{gen, convert, PROTOCOL_VERSION};
+use crate::{convert, gen, PROTOCOL_VERSION};
 use chain_core::property;
 use network_core::client::block::HandshakeError;
 
@@ -40,7 +40,9 @@ where
             Err(status) => return Err(HandshakeError::Rpc(convert::error_from_grpc(status))),
         };
         if res.version != PROTOCOL_VERSION {
-            return Err(HandshakeError::UnsupportedVersion(res.version.to_string().into()));
+            return Err(HandshakeError::UnsupportedVersion(
+                res.version.to_string().into(),
+            ));
         }
         let block0_id = convert::deserialize_bytes(&res.block0)?;
         Ok(Async::Ready(block0_id))

--- a/network-grpc/src/lib.rs
+++ b/network-grpc/src/lib.rs
@@ -16,3 +16,5 @@ pub mod client;
 mod convert;
 pub mod server;
 mod service;
+
+pub const PROTOCOL_VERSION: u32 = 0;

--- a/network-grpc/src/lib.rs
+++ b/network-grpc/src/lib.rs
@@ -17,4 +17,8 @@ mod convert;
 pub mod server;
 mod service;
 
-pub const PROTOCOL_VERSION: u32 = 0;
+/// Version of the protocol implemented by this crate.
+///
+/// Note that until the protocol is stabilized, breaking changes may still
+/// occur without changing this version number.
+pub const PROTOCOL_VERSION: u32 = 1;

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -1,9 +1,10 @@
 use crate::{
     convert::{
         decode_node_id, deserialize_bytes, deserialize_repeated_bytes, encode_node_id,
-        error_from_grpc, error_into_grpc, FromProtobuf, IntoProtobuf,
+        error_from_grpc, error_into_grpc, serialize_to_bytes, FromProtobuf, IntoProtobuf,
     },
     gen,
+    PROTOCOL_VERSION,
 };
 
 use chain_core::property;
@@ -16,9 +17,10 @@ use network_core::{
     },
 };
 
+use futures::future::{self, FutureResult};
 use futures::prelude::*;
 use futures::try_ready;
-use tower_grpc::{self, Code, Request, Status, Streaming};
+use tower_grpc::{self, Code, Request, Response, Status, Streaming};
 
 use std::{marker::PhantomData, mem};
 
@@ -508,6 +510,7 @@ where
     <T::ContentService as ContentService>::Fragment: protocol_bounds::Fragment,
     <T::GossipService as GossipService>::Node: protocol_bounds::Node,
 {
+    type HandshakeFuture = FutureResult<Response<gen::node::HandshakeResponse>, tower_grpc::Status>;
     type TipFuture = ResponseFuture<
         gen::node::TipResponse,
         <<T as Node>::BlockService as BlockService>::TipFuture,
@@ -581,6 +584,19 @@ where
         <T::GossipService as P2pService>::NodeId,
         <T::GossipService as GossipService>::GossipSubscriptionFuture,
     >;
+
+    fn handshake(&mut self, _req: Request<gen::node::HandshakeRequest>) -> Self::HandshakeFuture {
+        let service = match self.inner.block_service() {
+            Some(service) => service,
+            None => return future::err(Status::new(Code::Unimplemented, "not implemented")),
+        };
+        let block0 = serialize_to_bytes(&service.block0()).unwrap();
+        let res = gen::node::HandshakeResponse {
+            version: PROTOCOL_VERSION,
+            block0,
+        };
+        future::ok(Response::new(res))
+    }
 
     fn tip(&mut self, _request: Request<gen::node::TipRequest>) -> Self::TipFuture {
         let service = try_get_service!(self.inner.block_service());

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -3,8 +3,7 @@ use crate::{
         decode_node_id, deserialize_bytes, deserialize_repeated_bytes, encode_node_id,
         error_from_grpc, error_into_grpc, serialize_to_bytes, FromProtobuf, IntoProtobuf,
     },
-    gen,
-    PROTOCOL_VERSION,
+    gen, PROTOCOL_VERSION,
 };
 
 use chain_core::property;


### PR DESCRIPTION
The method to use on the client when connected initially, to get information on protocol version and genesis block. This will allow to bailing out of connections to wrong nodes.