### PR TITLE
Add error for block0 in the future

### DIFF
--- a/chain-storage/src/error.rs
+++ b/chain-storage/src/error.rs
@@ -5,6 +5,7 @@ pub enum Error {
     BlockNotFound, // FIXME: add BlockId
     CannotIterate,
     BackendError(Box<dyn std::error::Error + Send + Sync>),
+    Block0InFuture,
 }
 
 impl fmt::Display for Error {
@@ -13,6 +14,7 @@ impl fmt::Display for Error {
             Error::BlockNotFound => write!(f, "block not found"),
             Error::CannotIterate => write!(f, "cannot iterate between the 2 given blocks"),
             Error::BackendError(_) => write!(f, "miscellaneous storage error"),
+            Error::Block0InFuture => write!(f, "block0 is in the future"),
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/input-output-hk/jormungandr/issues/563 to return error instead of panicking when loaded chain has block0 in the future, blocks https://github.com/input-output-hk/jormungandr/pull/661