### PR TITLE
[Tests] Enabled Property-test-api annotation for arbitraries

### DIFF
--- a/chain-impl-mockchain/src/fee.rs
+++ b/chain-impl-mockchain/src/fee.rs
@@ -55,7 +55,7 @@ impl FeeAlgorithm<tx::Transaction<Address, Certificate>> for LinearFee {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "property-test-api"))]
 mod test {
     use super::*;
     use quickcheck::{Arbitrary, Gen};

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -289,7 +289,7 @@ impl FromStr for Hash {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "property-test-api"))]
 pub mod test {
     use super::*;
     use quickcheck::{Arbitrary, Gen};

--- a/chain-impl-mockchain/src/lib.rs
+++ b/chain-impl-mockchain/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(any(test, feature = "property-test-api"))]
 #[macro_use]
 extern crate quickcheck;
 #[macro_use(custom_error)]

--- a/chain-impl-mockchain/src/milli.rs
+++ b/chain-impl-mockchain/src/milli.rs
@@ -59,7 +59,7 @@ impl fmt::Display for Milli {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "property-test-api"))]
 mod tests {
     use super::*;
     use quickcheck::{Arbitrary, Gen, TestResult};

--- a/chain-impl-mockchain/src/testing/address.rs
+++ b/chain-impl-mockchain/src/testing/address.rs
@@ -134,16 +134,19 @@ impl AddressData {
         self.address.discrimination().clone()
     }
 
-    pub fn address_as_string(&self) -> String {
+    pub fn delegation_key(&self) -> PublicKey<Ed25519> {
+        match self.kind() {
+            Kind::Group(_, delegation_key) => delegation_key,
+            _ => panic!("cannot get delegation key from non group addres kind"),
+        }
+    }
+
+    pub fn to_bech32_str(&self) -> String {
         let prefix = match self.discrimination() {
             Discrimination::Production => "ta",
             Discrimination::Test => "ca",
         };
         AddressReadable::from_address(prefix, &self.address).to_string()
-    }
-
-    pub fn public_key_as_string(&self) -> String {
-        self.public_key().to_bech32_str()
     }
 
     pub fn generate_key_pair<A: AsymmetricKey>() -> KeyPair<A> {


### PR DESCRIPTION
Moved arbitrary to testing module (in order to use it in jormungand e2e tests). Small refactoring for AddressData
