### PR TITLE
[Tests] Fix for #79. Added property & negative tests for update module

### DIFF
--- a/chain-impl-mockchain/src/ledger/tests/mod.rs
+++ b/chain-impl-mockchain/src/ledger/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod discrimination_tests;
 pub mod initial_funds_tests;
 pub mod ledger_tests;
+pub mod update_tests;

--- a/chain-impl-mockchain/src/ledger/tests/update_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/update_tests.rs
@@ -1,0 +1,89 @@
+use crate::{
+    block::{Block, BlockBuilder, HeaderHash},
+    date::BlockDate,
+    ledger::ledger::Ledger,
+    testing::arbitrary::update_proposal::UpdateProposalData,
+    testing::ledger as mock_ledger,
+};
+use chain_core::property::ChainLength as ChainLengthProperty;
+use chain_crypto::{Ed25519, SecretKey};
+use quickcheck::{TestResult};
+use quickcheck_macros::quickcheck;
+
+#[quickcheck]
+pub fn ledger_adopt_settings_from_update_proposal(
+    update_proposal_data: UpdateProposalData,
+) -> TestResult {
+    let config = mock_ledger::ConfigBuilder::new()
+        .with_leaders(&update_proposal_data.leaders_ids())
+        .build();
+
+    let (block0_hash, mut ledger) = mock_ledger::create_initial_fake_ledger(&[], config).unwrap();
+
+    // apply proposal
+    let date = ledger.date();
+    ledger = ledger
+        .apply_update_proposal(
+            update_proposal_data.proposal_id,
+            &update_proposal_data.proposal,
+            date,
+        )
+        .unwrap();
+
+    // apply votes
+    for vote in update_proposal_data.votes.iter() {
+        ledger = ledger.apply_update_vote(&vote).unwrap();
+    }
+
+    // trigger proposal process (build block)
+    let block = build_block(
+        &ledger,
+        block0_hash,
+        date.next_epoch(),
+        &update_proposal_data.block_signing_key,
+    );
+    let header_meta = block.header.to_content_eval_context();
+    ledger = ledger
+        .apply_block(
+            &ledger.get_ledger_parameters(),
+            block.contents.iter(),
+            &header_meta,
+        )
+        .unwrap();
+
+    // assert
+    let actual_params = ledger.settings.to_config_params();
+    let expected_params = update_proposal_data.proposal_settings();
+
+    let mut all_settings_equal = true;
+    for expected_param in expected_params.iter() {
+        if !actual_params.iter().any(|x| x == expected_param) {
+            all_settings_equal = false;
+            break;
+        }
+    }
+
+    if !ledger.updates.proposals.is_empty() {
+        return TestResult::error(format!("Error: proposal collection should be empty but contains:{:?}",
+                                ledger.updates.proposals));
+    }
+
+    match all_settings_equal {
+            false => TestResult::error(format!("Error: proposed update reached required votes, but proposal was NOT updated, Expected: {:?} vs Actual: {:?}",
+                                expected_params,actual_params)),
+            true => TestResult::passed(),
+        }
+}
+
+fn build_block(
+    ledger: &Ledger,
+    block0_hash: HeaderHash,
+    date: BlockDate,
+    block_signing_key: &SecretKey<Ed25519>,
+) -> Block {
+    let mut block_builder = BlockBuilder::new();
+    block_builder.chain_length(ledger.chain_length.next());
+    block_builder.parent(block0_hash);
+    block_builder.date(date.next_epoch());
+    block_builder.make_bft_block(block_signing_key)
+}

--- a/chain-impl-mockchain/src/ledger/tests/update_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/update_tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    block::{Block, BlockBuilder, HeaderHash},
+    block::{Block, BlockBuilder, HeaderHash, Contents},
     date::BlockDate,
     ledger::ledger::Ledger,
     testing::arbitrary::update_proposal::UpdateProposalData,
@@ -81,7 +81,7 @@ fn build_block(
     date: BlockDate,
     block_signing_key: &SecretKey<Ed25519>,
 ) -> Block {
-    let mut block_builder = BlockBuilder::new();
+    let mut block_builder = BlockBuilder::new(Contents::empty());
     block_builder.chain_length(ledger.chain_length.next());
     block_builder.parent(block0_hash);
     block_builder.date(date.next_epoch());

--- a/chain-impl-mockchain/src/testing/arbitrary/update_proposal.rs
+++ b/chain-impl-mockchain/src/testing/arbitrary/update_proposal.rs
@@ -5,6 +5,7 @@ use crate::{
     fee::LinearFee,
     fragment::config::ConfigParams,
     leadership::bft::LeaderId,
+    testing::builders::SignedProposalBuilder,
     testing::{arbitrary::utils as arbitrary_utils, builders::update_builder::ProposalBuilder},
     update::{SignedUpdateProposal, SignedUpdateVote, UpdateVote},
 };
@@ -72,25 +73,17 @@ impl Arbitrary for UpdateProposalData {
             ConfigParam::ProposalExpiration(u32::arbitrary(gen)),
         ];
 
-        let signed_update_proposal = ProposalBuilder::new()
+        let update_proposal = ProposalBuilder::new()
             .with_proposal_changes(arbitrary_utils::choose_random_vec_subset(
                 &unique_arbitrary_settings,
                 gen,
             ))
-            .with_proposer_id(proposer_id)
-            .with_signature_key(proposer_key.clone())
             .build();
 
-        //add proposer
-        let update_proposal_with_proposer = UpdateProposalWithProposer {
-            proposal: update_proposal,
-            proposer_id: proposer_id.clone(),
-        };
-
-        //sign proposal
-        let signed_update_proposal = SignedUpdateProposal {
-            proposal: update_proposal_with_proposer,
-        };
+        let signed_update_proposal = SignedProposalBuilder::new()
+            .with_proposal_update(update_proposal)
+            .with_proposer_id(proposer_id.clone())
+            .build();
 
         //generate proposal header
         let proposal_id = Hash::arbitrary(gen);

--- a/chain-impl-mockchain/src/testing/builders/mod.rs
+++ b/chain-impl-mockchain/src/testing/builders/mod.rs
@@ -6,6 +6,7 @@ pub mod proposal_builder;
 pub mod tx_builder;
 pub mod tx_cert_builder;
 pub mod witness_builder;
+pub mod update_builder;
 
 pub use block_builder::*;
 pub use cert_builder::*;
@@ -14,3 +15,4 @@ pub use old_address_builder::*;
 pub use proposal_builder::*;pub use tx_builder::*;
 pub use tx_cert_builder::*;
 pub use witness_builder::*;
+pub use update_builder::*;

--- a/chain-impl-mockchain/src/testing/builders/update_builder.rs
+++ b/chain-impl-mockchain/src/testing/builders/update_builder.rs
@@ -1,0 +1,112 @@
+use crate::{
+    config::ConfigParam,
+    fragment::config::ConfigParams,
+    leadership::bft::LeaderId,
+    update::{
+        SignedUpdateProposal, SignedUpdateVote, UpdateProposal, UpdateProposalId,
+        UpdateProposalWithProposer, UpdateVote,
+    },
+};
+use chain_crypto::{Ed25519Extended, SecretKey};
+
+pub struct ProposalBuilder {
+    proposer_id: Option<LeaderId>,
+    config_params: ConfigParams,
+    signature_key: Option<SecretKey<Ed25519Extended>>,
+}
+
+impl ProposalBuilder {
+    pub fn new() -> Self {
+        ProposalBuilder {
+            proposer_id: None,
+            config_params: ConfigParams::new(),
+            signature_key: None,
+        }
+    }
+
+    pub fn with_proposer_id(&mut self, proposer_id: LeaderId) -> &mut Self {
+        self.proposer_id = Some(proposer_id);
+        self
+    }
+
+    pub fn with_proposal_changes(&mut self, changes: Vec<ConfigParam>) -> &mut Self {
+        for change in changes {
+            self.with_proposal_change(change);
+        }
+        self
+    }
+
+    pub fn with_proposal_change(&mut self, change: ConfigParam) -> &mut Self {
+        self.config_params.push(change);
+        self
+    }
+
+    pub fn with_signature_key(&mut self, signature_key: SecretKey<Ed25519Extended>) -> &mut Self {
+        self.signature_key = Some(signature_key);
+        self
+    }
+
+    pub fn build(&self) -> SignedUpdateProposal {
+        let mut update_proposal = UpdateProposal::new();
+        for config_param in self.config_params.iter().cloned() {
+            update_proposal.changes.push(config_param);
+        }
+
+        //add proposer
+        let proposal_signature =
+            update_proposal.make_certificate(&self.signature_key.clone().unwrap());
+        let update_proposal_with_proposer = UpdateProposalWithProposer {
+            proposal: update_proposal,
+            proposer_id: self.proposer_id.clone().unwrap(),
+        };
+
+        //sign proposal
+        SignedUpdateProposal {
+            proposal: update_proposal_with_proposer,
+            signature: proposal_signature,
+        }
+    }
+}
+
+pub struct UpdateVoteBuilder {
+    proposal_id: Option<UpdateProposalId>,
+    voter_id: Option<LeaderId>,
+    signature_key: Option<SecretKey<Ed25519Extended>>,
+}
+
+impl UpdateVoteBuilder {
+    pub fn new() -> Self {
+        UpdateVoteBuilder {
+            proposal_id: None,
+            voter_id: None,
+            signature_key: None,
+        }
+    }
+
+    pub fn with_proposal_id(&mut self, proposal_id: UpdateProposalId) -> &mut Self {
+        self.proposal_id = Some(proposal_id);
+        self
+    }
+
+    pub fn with_voter_id(&mut self, voter_id: LeaderId) -> &mut Self {
+        self.voter_id = Some(voter_id);
+        self
+    }
+
+    pub fn with_signature_key(&mut self, signature_key: SecretKey<Ed25519Extended>) -> &mut Self {
+        self.signature_key = Some(signature_key);
+        self
+    }
+
+    pub fn build(&self) -> SignedUpdateVote {
+        let update_vote = UpdateVote {
+            proposal_id: self.proposal_id.unwrap().clone(),
+            voter_id: self.voter_id.clone().unwrap(),
+        };
+        let vote_signature = update_vote.make_certificate(&self.signature_key.clone().unwrap());
+        SignedUpdateVote {
+            vote: update_vote,
+            signature: vote_signature,
+        }
+    }
+}

--- a/chain-impl-mockchain/src/testing/data/leader.rs
+++ b/chain-impl-mockchain/src/testing/data/leader.rs
@@ -5,8 +5,8 @@ use std::fmt::{self, Debug};
 
 #[derive(Clone)]
 pub struct LeaderPair {
-    leader_id: LeaderId,
-    leader_key: SecretKey<Ed25519Extended>,
+    pub leader_id: LeaderId,
+    pub leader_key: SecretKey<Ed25519Extended>,
 }
 
 impl Debug for LeaderPair {

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -118,7 +118,7 @@ impl UpdateState {
                     settings = settings.apply(&proposal_state.proposal.changes)?;
                     expired_ids.push(proposal_id.clone());
                 } else if proposal_state.proposal_date.epoch + settings.proposal_expiration
-                    > new_date.epoch
+                    < new_date.epoch
                 {
                     expired_ids.push(proposal_id.clone());
                 }

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -374,8 +374,30 @@ impl Readable for SignedUpdateVote {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::{
+        config::ConfigParam,
+        fragment::config::ConfigParams,
+        testing::{
+            builders::update_builder::{ProposalBuilder, UpdateVoteBuilder},
+            data::LeaderPair,
+            TestGen,
+            arbitrary::update_proposal::UpdateProposalData,
+            ledger as mock_ledger,
+        },
+        block::{Block, BlockBuilder, Contents, HeaderHash},
+        ledger::ledger::Ledger,
+        update::{
+            SignedUpdateProposal, SignedUpdateVote, UpdateProposal, UpdateProposalWithProposer,
+            UpdateVote,
+        },
+    };
+    use chain_core::property::ChainLength;
+    use chain_addr::Discrimination;
+    use chain_crypto::{Ed25519, SecretKey};
+
     use quickcheck::{Arbitrary, Gen, TestResult};
     use quickcheck_macros::quickcheck;
+
 
     impl Arbitrary for UpdateProposal {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
@@ -421,77 +443,336 @@ mod test {
         }
     }
 
-    use crate::{
-        block::{Block, BlockBuilder, Contents, HeaderHash},
-        ledger::ledger::Ledger,
-        testing::arbitrary::update_proposal::UpdateProposalData,
-        testing::ledger as mock_ledger,
-        update::{
-            SignedUpdateProposal, SignedUpdateVote, UpdateProposal, UpdateProposalWithProposer,
-            UpdateVote,
-        },
-    };
-    use chain_core::property::ChainLength;
-    use chain_crypto::{Ed25519, SecretKey};
+    fn apply_update_proposal(
+        update_state: UpdateState,
+        proposal_id: UpdateProposalId,
+        config_param: &ConfigParam,
+        proposer: &LeaderPair,
+        settings: &Settings,
+        block_date: BlockDate,
+    ) -> Result<UpdateState, Error> {
+        let signed_update_proposal = ProposalBuilder::new()
+            .with_proposal_change(config_param.clone())
+            .with_proposer_id(proposer.id())
+            .with_signature_key(proposer.key())
+            .build();
+    
+        update_state.apply_proposal(proposal_id, &signed_update_proposal, &settings, block_date)
+    }
 
-    #[quickcheck]
-    pub fn ledger_adopt_settings_from_update_proposal(
-        update_proposal_data: UpdateProposalData,
-    ) -> TestResult {
-        let config = mock_ledger::ConfigBuilder::new()
-            .with_leaders(&update_proposal_data.leaders_ids())
+    fn apply_update_vote(
+        update_state: UpdateState,
+        proposal_id: UpdateProposalId,
+        proposer: &LeaderPair,
+        settings: &Settings,
+    ) -> Result<UpdateState, Error> {
+        let signed_update_vote = UpdateVoteBuilder::new()
+            .with_proposal_id(proposal_id)
+            .with_voter_id(proposer.id())
+            .with_signature_key(proposer.key())
             .build();
 
-        let (block0_hash, mut ledger) =
-            mock_ledger::create_initial_fake_ledger(&[], config).unwrap();
+        update_state.apply_vote(&signed_update_vote, &settings)
+    }
 
-        // apply proposal
-        let date = ledger.date();
-        ledger = ledger
-            .apply_update_proposal(
-                update_proposal_data.proposal_id,
-                &update_proposal_data.proposal,
-                date,
+    #[test]
+    pub fn apply_proposal_with_unknown_proposer_should_return_error() {
+        // data
+        let unknown_leader = TestGen::leader_pair();
+        let block_date = BlockDate::first();
+        let proposal_id = TestGen::hash();
+        let config_param = ConfigParam::SlotsPerEpoch(100);
+        //setup
+        let update_state = UpdateState::new();
+        let settings = Settings::new();
+
+        assert_eq!(
+            apply_update_proposal(
+                update_state,
+                proposal_id,
+                &config_param,
+                &unknown_leader,
+                &settings,
+                block_date
             )
-            .unwrap();
-
-        // apply votes
-        for vote in update_proposal_data.votes.iter() {
-            ledger = ledger.apply_update_vote(&vote).unwrap();
-        }
-
-        // trigger proposal process (build block)
-        let block = build_block(
-            &ledger,
-            block0_hash,
-            date.next_epoch(),
-            &update_proposal_data.block_signing_key,
+            .is_err(),
+            true
         );
-        let header_meta = block.header.to_content_eval_context();
-        ledger = ledger
-            .apply_block(
-                &ledger.get_ledger_parameters(),
-                block.contents.iter(),
-                &header_meta,
+    }
+
+    #[test]
+    pub fn apply_duplicated_proposal_should_return_error() {
+        // data
+        let proposal_id = TestGen::hash();
+        let block_date = BlockDate::first();
+        let config_param = ConfigParam::SlotsPerEpoch(100);
+        //setup
+        let mut update_state = UpdateState::new();
+
+        let leaders = TestGen::leaders_pairs()
+            .take(5)
+            .collect::<Vec<LeaderPair>>();
+        let proposer = leaders.iter().next().clone().unwrap();
+        let settings = TestGen::settings(leaders.clone());
+
+        update_state = apply_update_proposal(
+            update_state,
+            proposal_id,
+            &config_param,
+            proposer,
+            &settings,
+            block_date,
+        )
+        .expect("failed while applying first proposal");
+
+        assert_eq!(
+            apply_update_proposal(
+                update_state,
+                proposal_id,
+                &config_param,
+                proposer,
+                &settings,
+                block_date
             )
-            .unwrap();
+            .is_err(),
+            true
+        );
+    }
 
-        // assert
-        let actual_params = ledger.settings.to_config_params();
-        let expected_params = update_proposal_data.proposal_settings();
+    #[test]
+    pub fn test_add_vote_for_non_existing_proposal_should_return_error() {
+        let mut update_state = UpdateState::new();
+        let proposal_id = TestGen::hash();
+        let unknown_proposal_id = TestGen::hash();
+        let block_date = BlockDate::first();
+        let config_param = ConfigParam::SlotsPerEpoch(100);
+        let leaders = TestGen::leaders_pairs()
+            .take(5)
+            .collect::<Vec<LeaderPair>>();
+        let proposer = leaders.iter().next().clone().unwrap();
+        let settings = TestGen::settings(leaders.clone());
 
-        let mut all_settings_equal = true;
-        for expected_param in expected_params.iter() {
-            if !actual_params.iter().any(|x| x == expected_param) {
-                all_settings_equal = false;
-                break;
+        // Apply proposal
+        update_state = apply_update_proposal(
+            update_state,
+            proposal_id,
+            &config_param,
+            proposer,
+            &settings,
+            block_date,
+        )
+        .expect("failed while applying first proposal");
+
+        // Apply vote for unknown proposal
+        assert_eq!(
+            apply_update_vote(update_state, unknown_proposal_id, proposer, &settings).is_err(),
+            true
+        );
+    }
+
+    #[test]
+    pub fn test_add_duplicated_vote_should_return_error() {
+        let mut update_state = UpdateState::new();
+        let proposal_id = TestGen::hash();
+        let block_date = BlockDate::first();
+        let config_param = ConfigParam::SlotsPerEpoch(100);
+
+        let leaders = TestGen::leaders_pairs()
+            .take(5)
+            .collect::<Vec<LeaderPair>>();
+        let proposer = leaders.iter().next().clone().unwrap();
+        let settings = TestGen::settings(leaders.clone());
+
+        update_state = apply_update_proposal(
+            update_state,
+            proposal_id,
+            &config_param,
+            proposer,
+            &settings,
+            block_date,
+        )
+        .expect("failed while applying proposal");
+
+        // Apply vote
+        update_state = apply_update_vote(update_state, proposal_id, proposer, &settings)
+            .expect("failed while applying first vote");
+
+        // Apply duplicated vote
+        assert_eq!(
+            apply_update_vote(update_state, proposal_id, proposer, &settings).is_err(),
+            true
+        );
+    }
+
+    #[test]
+    pub fn test_add_vote_from_unknown_voter_should_return_error() {
+        let mut update_state = UpdateState::new();
+        let proposal_id = TestGen::hash();
+        let unknown_leader = TestGen::leader_pair();
+        let block_date = BlockDate::first();
+        let config_param = ConfigParam::SlotsPerEpoch(100);
+
+        let leaders = TestGen::leaders_pairs()
+            .take(5)
+            .collect::<Vec<LeaderPair>>();
+        let proposer = leaders.iter().next().clone().unwrap();
+        let settings = TestGen::settings(leaders.clone());
+
+        update_state = apply_update_proposal(
+            update_state,
+            proposal_id,
+            &config_param,
+            proposer,
+            &settings,
+            block_date,
+        )
+        .expect("failed while applying proposal");
+
+        // Apply vote for unknown leader
+        assert_eq!(
+            apply_update_vote(update_state, proposal_id, &unknown_leader, &settings).is_err(),
+            true
+        );
+    }
+
+    #[test]
+    pub fn process_proposals_for_readonly_setting_should_return_error() {
+        let mut update_state = UpdateState::new();
+        let proposal_id = TestGen::hash();
+        let proposer = TestGen::leader_pair();
+        let block_date = BlockDate::first();
+        let readonly_setting = ConfigParam::Discrimination(Discrimination::Test);
+
+        let settings = TestGen::settings(vec![proposer.clone()]);
+
+        update_state = apply_update_proposal(
+            update_state,
+            proposal_id,
+            &readonly_setting,
+            &proposer,
+            &settings,
+            block_date,
+        )
+        .expect("failed while applying proposal");
+
+        // Apply vote
+        update_state = apply_update_vote(update_state, proposal_id, &proposer, &settings)
+            .expect("failed while applying vote");
+
+        assert_eq!(
+            update_state
+                .process_proposals(settings, block_date, block_date.next_epoch())
+                .is_err(),
+            true
+        );
+    }
+
+    #[test]
+    pub fn process_proposal_is_ordered() {
+        let mut update_state = UpdateState::new();
+        let first_proposal_id = TestGen::hash();
+        let second_proposal_id = TestGen::hash();
+        let first_proposer = TestGen::leader_pair();
+        let second_proposer = TestGen::leader_pair();
+        let block_date = BlockDate::first();
+        let first_update = ConfigParam::SlotsPerEpoch(100);
+        let second_update = ConfigParam::SlotsPerEpoch(200);
+
+        let settings = TestGen::settings(vec![first_proposer.clone(), second_proposer.clone()]);
+
+        // Apply proposal
+        update_state = apply_update_proposal(
+            update_state,
+            first_proposal_id,
+            &first_update,
+            &first_proposer,
+            &settings,
+            block_date,
+        )
+        .expect("failed while applying proposal");
+
+        // Apply vote
+        update_state =
+            apply_update_vote(update_state, first_proposal_id, &first_proposer, &settings)
+                .expect("failed while applying vote");
+
+        // Apply vote
+        update_state =
+            apply_update_vote(update_state, first_proposal_id, &second_proposer, &settings)
+                .expect("failed while applying vote");
+
+        // Apply proposal
+        update_state = apply_update_proposal(
+            update_state,
+            second_proposal_id,
+            &second_update,
+            &second_proposer,
+            &settings,
+            block_date,
+        )
+        .expect("failed while applying proposal");
+
+        // Apply vote
+        update_state =
+            apply_update_vote(update_state, second_proposal_id, &first_proposer, &settings)
+                .expect("failed while applying vote");
+
+        // Apply vote
+        update_state = apply_update_vote(
+            update_state,
+            second_proposal_id,
+            &second_proposer,
+            &settings,
+        )
+        .expect("failed while applying vote");
+
+        let last_proposal_id = update_state.proposals.keys().cloned().last().unwrap();
+
+        let (update_state, settings) = update_state
+            .process_proposals(settings, block_date, block_date.next_epoch())
+            .expect("error while processing proposal");
+
+        match first_proposal_id == last_proposal_id {
+            true => {
+                assert_eq!(settings.slots_per_epoch, 100);
+            }
+            false => {
+                assert_eq!(settings.slots_per_epoch, 200);
             }
         }
 
-        match all_settings_equal {
-            false => TestResult::error(format!("Error: proposed update reached required votes, but proposal was NOT updated, Expected: {:?} vs Actual: {:?}",
-                                expected_params,actual_params)),
-            true => TestResult::passed(),
+        assert_eq!(update_state.proposals.len(), 0);
+    }
+
+    #[derive(Debug, Copy, Clone)]
+    pub struct ExpiryBlockDate {
+        pub block_date: BlockDate,
+        pub proposal_expiration: u32,
+    }
+
+    impl ExpiryBlockDate {
+        pub fn block_date(&self) -> BlockDate {
+            self.block_date.clone()
+        }
+
+        pub fn proposal_expiration(&self) -> u32 {
+            self.proposal_expiration
+        }
+
+        pub fn get_last_epoch(&self) -> u32 {
+            self.block_date().epoch + self.proposal_expiration() + 1
+        }
+    }
+
+    impl Arbitrary for ExpiryBlockDate {
+        fn arbitrary<G: Gen>(gen: &mut G) -> Self {
+            let mut block_date = BlockDate::arbitrary(gen);
+            block_date.epoch = block_date.epoch % 10;
+            let proposal_expiration = u32::arbitrary(gen) % 10;
+            ExpiryBlockDate {
+                block_date,
+                proposal_expiration,
+            }
         }
     }
 
@@ -506,5 +787,60 @@ mod test {
         block_builder.parent(block0_hash);
         block_builder.date(date.next_epoch());
         block_builder.make_bft_block(block_signing_key)
+    }
+
+    #[quickcheck]
+    pub fn rejected_proposals_are_removed_after_expiration_period(
+        expiry_block_data: ExpiryBlockDate,
+    ) -> TestResult {
+        let proposal_date = expiry_block_data.block_date();
+        let proposal_expiration = expiry_block_data.proposal_expiration();
+
+        let mut update_state = UpdateState::new();
+        let proposal_id = TestGen::hash();
+        let proposer = TestGen::leader_pair();
+        let update = ConfigParam::SlotsPerEpoch(100);
+
+        let mut settings = TestGen::settings(vec![proposer.clone()]);
+        settings.proposal_expiration = proposal_expiration;
+
+        // Apply proposal
+        update_state = apply_update_proposal(
+            update_state,
+            proposal_id,
+            &update,
+            &proposer,
+            &settings,
+            proposal_date,
+        )
+        .expect("failed while applying proposal");
+
+        let mut current_block_date = BlockDate::first();
+
+        // Traverse through epoch and check if proposal is still in queue
+        // if proposal expiration period is not exceeded after that
+        // proposal should be removed from proposal collection
+        for _i in 0..expiry_block_data.get_last_epoch() {
+            let (update_state, _settings) = update_state
+                .clone()
+                .process_proposals(
+                    settings.clone(),
+                    current_block_date,
+                    current_block_date.next_epoch(),
+                )
+                .expect("error while processing proposal");
+
+            match proposal_date.epoch + proposal_expiration <= current_block_date.epoch {
+                true => {
+                    assert_eq!(update_state.proposals.len(), 0);
+                }
+                false => {
+                    assert_eq!(update_state.proposals.len(), 1);
+                }
+            }
+            current_block_date = current_block_date.next_epoch()
+        }
+
+        TestResult::passed()
     }
 }

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -378,7 +378,7 @@ mod test {
         config::ConfigParam,
         fragment::config::ConfigParams,
         testing::{
-            builders::update_builder::{ProposalBuilder, UpdateVoteBuilder},
+            builders::update_builder::{ProposalBuilder, SignedProposalBuilder, UpdateVoteBuilder},
             data::LeaderPair,
             TestGen,
             arbitrary::update_proposal::UpdateProposalData,
@@ -451,12 +451,15 @@ mod test {
         settings: &Settings,
         block_date: BlockDate,
     ) -> Result<UpdateState, Error> {
-        let signed_update_proposal = ProposalBuilder::new()
+        let update_proposal = ProposalBuilder::new()
             .with_proposal_change(config_param.clone())
-            .with_proposer_id(proposer.id())
-            .with_signature_key(proposer.key())
             .build();
-    
+
+        let signed_update_proposal = SignedProposalBuilder::new()
+            .with_proposal_update(update_proposal)
+            .with_proposer_id(proposer.leader_id.clone())
+            .build();
+
         update_state.apply_proposal(proposal_id, &signed_update_proposal, &settings, block_date)
     }
 
@@ -469,7 +472,6 @@ mod test {
         let signed_update_vote = UpdateVoteBuilder::new()
             .with_proposal_id(proposal_id)
             .with_voter_id(proposer.id())
-            .with_signature_key(proposer.key())
             .build();
 
         update_state.apply_vote(&signed_update_vote, &settings)

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -375,29 +375,27 @@ impl Readable for SignedUpdateVote {
 mod test {
     use super::*;
     use crate::{
+        block::{Block, BlockBuilder, Contents, HeaderHash},
         config::ConfigParam,
         fragment::config::ConfigParams,
+        ledger::ledger::Ledger,
         testing::{
+            arbitrary::update_proposal::UpdateProposalData,
             builders::update_builder::{ProposalBuilder, SignedProposalBuilder, UpdateVoteBuilder},
             data::LeaderPair,
-            TestGen,
-            arbitrary::update_proposal::UpdateProposalData,
-            ledger as mock_ledger,
+            ledger as mock_ledger, TestGen,
         },
-        block::{Block, BlockBuilder, Contents, HeaderHash},
-        ledger::ledger::Ledger,
         update::{
             SignedUpdateProposal, SignedUpdateVote, UpdateProposal, UpdateProposalWithProposer,
             UpdateVote,
         },
     };
-    use chain_core::property::ChainLength;
     use chain_addr::Discrimination;
+    use chain_core::property::ChainLength;
     use chain_crypto::{Ed25519, SecretKey};
 
     use quickcheck::{Arbitrary, Gen, TestResult};
     use quickcheck_macros::quickcheck;
-
 
     impl Arbitrary for UpdateProposal {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {


### PR DESCRIPTION
Fix for #79 

Since e2e property test was already developed. i focused on negative tests and some corner cases:
- apply_proposal_with_unknown_proposer_should_return_error - negative test
- apply_duplicated_proposal_should_return_error   - negative test
- test_add_vote_for_non_existing_proposal_should_return_error - negative test
- test_add_duplicated_vote_should_return_error - negative test
- test_add_vote_from_unknown_voter_should_return_error  - negative test
- process_proposals_for_readonly_setting_should_return_error - negative test
- process_proposal_is_ordered - functional test
- rejected_proposals_are_removed_after_expiration_period - property test

