### PR TITLE
network: PushHeaders and UploadBlocks forward to Sink

### DIFF
--- a/network-core/src/server/block.rs
+++ b/network-core/src/server/block.rs
@@ -76,11 +76,11 @@ pub trait BlockService: P2pService {
     /// implementation to produce a server-streamed response.
     type GetHeadersFuture: Future<Item = Self::GetHeadersStream, Error = Error> + Send + 'static;
 
-    /// The type of asynchronous futures returned by method `on_pushed_headers`.
-    type OnPushedHeadersFuture: Future<Item = (), Error = Error> + Send + 'static;
+    /// A sink object returned by the `get_push_headers_sink` method.
+    type PushHeadersSink: Sink<SinkItem = Self::Header, SinkError = Error> + Send + 'static;
 
-    /// The type of asynchronous futures returned by method `on_uploaded_block`.
-    type OnUploadedBlockFuture: Future<Item = (), Error = Error> + Send + 'static;
+    /// A sink object returned by the `get_upload_blocks_sink` method.
+    type UploadBlocksSink: Sink<SinkItem = Self::Block, SinkError = Error> + Send + 'static;
 
     /// The type of asynchronous stream that lets the client receive
     /// new block announcements and solicitation requests from the service.
@@ -132,32 +132,15 @@ pub trait BlockService: P2pService {
     /// to the server's tip.
     fn pull_headers_to_tip(&mut self, from: &[Self::BlockId]) -> Self::PullHeadersFuture;
 
-    /// Preferred maximum size of processing chunks to split the incoming
-    /// stream of block headers, to be passed to the `on_pushed_headers` method.
-    const PUSH_HEADERS_CHUNK_SIZE: usize;
-
-    /// Called by the protocol implementation with an `Ok` variant when a
-    /// series of block headers constituting the chain is sent by the client
+    /// Called by the protocol implementation to get a sink
+    /// that receives and handles a stream of block headers sent by the peer
     /// in response to a `BlockEvent::Missing` solicitation.
-    /// An `Err` is used to report errors with streaming of inbound headers.
-    /// A client may report that the solicitation does not refer to blocks
-    /// found in its local blockchain by sending a `NotFound` error which
-    /// is passed to this method.
-    fn on_pushed_headers(
-        &mut self,
-        item: Result<Vec<Self::Header>, Error>,
-    ) -> Self::OnPushedHeadersFuture;
+    fn get_push_headers_sink(&mut self) -> Self::PushHeadersSink;
 
-    /// Called with an `Ok` value when the client connection uploads a block
-    /// in response to a `BlockEvent::Solicit` solicitation.
-    /// An `Err` is used to report errors with streaming of inbound blocks.
-    /// A client may report that the solicitation refers to a block not
-    /// found in its local blockchain by sending a `NotFound` error which
-    /// is passed to this method.
-    fn on_uploaded_block(
-        &mut self,
-        item: Result<Self::Block, Error>,
-    ) -> Self::OnUploadedBlockFuture;
+    /// Called by the protocol implementation to get a sink
+    /// that receives blocks uploaded in response to a `BlockEvent::Solicit`
+    /// solicitation.
+    fn get_upload_blocks_sink(&mut self) -> Self::UploadBlocksSink;
 
     /// Establishes a bidirectional subscription for announcing blocks.
     ///


### PR DESCRIPTION
Rework the server-side API for implementing `PushHeaders` and `UploadBlocks` around associated types of `BlockService` implementing `Sink`.
Forwarding a push stream to a sink implemented by the application is more flexible than piecemeal method calls.