### PR TITLE
Work around a bug in futures::stream::Forward

### DIFF
--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -293,7 +293,7 @@ where
     type Item = ();
     type Error = core_error::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, core_error::Error> {
+    fn poll(&mut self) -> Poll<(), core_error::Error> {
         let _ = try_ready!(self.inner.poll());
         Ok(Async::Ready(()))
     }


### PR DESCRIPTION
Needed until rust-lang-nursery/futures-rs#1864 is fixed, or until we port to futures 0.3.