### PR TITLE
Correct binary size of praos/genesis proof in format.md

### DIFF
--- a/chain-impl-mockchain/doc/format.md
+++ b/chain-impl-mockchain/doc/format.md
@@ -42,7 +42,7 @@ In BFT the header also contains (768 bits = 96 bytes):
 * BFT Public Key of the leader (32 bytes)
 * BFT Signature (64 bytes)
 
-In Praos/Genesis the header also contains (616 bytes):
+In Praos/Genesis the header also contains (612 bytes):
 
 * VRF PubKey: 32 bytes (ristretto25519)
 * VRF Proof: 96 bytes (ristretto25519 DLEQs)


### PR DESCRIPTION
In `cardano-wallet` we don't do anything with the block proofs, but we do verify that they have one of the possible correct sizes: `0`, `96`, `616` according to the `format.md` document.

When decoding the following block, it seems like it should be 612.
```
02b60002000000000000000100000d32000000010e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8ce7395113e2c04a9c91890f0c7f7eb4a265a55b4ed50bc444fc071983ee4d37d7d749ef424507fb80fed0d2289d535a94f6870add0cf8b374cfe6cae078320ec30afb387a4b5c8e37a3237abbeafd638f15cbb4236eca72dd6550b33cc45d974df03aa0d262631e449cb0cb5e94a9ed6af3caf2725a2b292377bca97c1f3be0d2464513c4649e29ddaa19364614e7675a3cba8cb29d0cd307fef0765ce9b020800000000208077299cc76267fb31726bc13c87b3ed31ee6c4da96dfa6715284bcbd19519163fd30822b1e97cff50459c2e2c45dfb49c33368637c5a6a52e81abc51b470382aedaae137684545e07547249daa62768f4db7cdbaeb00c2091bcc91418d73e8c4f174ab04dc277ff20a024f7d00a660dcf530c4bc3181f9ab906ac998cab7eb6830499f01aa05d9b8bae664a6d9646a726cf0ab64726a6177ca20f6c02acd9278eade5aaa36c17f557e33fd7c53505df6b6db442653ee928b3e7468fff2fba4cf894c42532d4d4a52dac73aec22de0c33d6a1857093946235b396a332d6e1165abf868f2cfe6abbe6cb362c4b25d34ebfc49ce779a8ca55211ea20c6e8c07980fa82c01508c033d58db5f86b40e431fdc021737c1ac122b25cac26a883edbb70f60474bfeb869b3ffe4f2745b5b499965bdf8306791dd47d6ebef949b258714bdbb32c5ecb915e8675c371151e24ad109b6e05d3ffade40b68bf851fa7802f2c2721e2c5d85e707a816cc13e805ffd1119a6ad4b38e9b9265abb4c3070a66e1bcd8e63fc822080a75913fcd027e67ad0a8ccf4e045464b474dddb805c76f26dc82d47cd46aa7f04d3fd7d1efd6344e1997cb175b43811ed98a3e54ecb8ca09c3e0e5df00a88d6a53c776c3cf415834cdb8a100027742b51222428786c0e98e
```

The sum of the components in the document is also in fact 612:`484+96+32= 612`.

```
VRF PubKey: 32 bytes (ristretto25519)
VRF Proof: 96 bytes (ristretto25519 DLEQs)
KES Signature: 484 bytes (sumed25519-12)
```