### PR TITLE
Rename content to fragment, flatten chain-core public namespace

### DIFF
--- a/network-core/src/client.rs
+++ b/network-core/src/client.rs
@@ -1,7 +1,7 @@
 //! Abstractions for the client-side network interface of a blockchain node.
 
 pub mod block;
-pub mod content;
+pub mod fragment;
 pub mod gossip;
 pub mod p2p;
 

--- a/network-core/src/client.rs
+++ b/network-core/src/client.rs
@@ -1,9 +1,14 @@
 //! Abstractions for the client-side network interface of a blockchain node.
 
-pub mod block;
-pub mod fragment;
-pub mod gossip;
-pub mod p2p;
+mod block;
+mod fragment;
+mod gossip;
+mod p2p;
+
+pub use block::{BlockService, HandshakeError};
+pub use fragment::FragmentService;
+pub use gossip::GossipService;
+pub use p2p::P2pService;
 
 use crate::error::Error;
 

--- a/network-core/src/client/fragment.rs
+++ b/network-core/src/client/fragment.rs
@@ -6,7 +6,7 @@ use futures::prelude::*;
 
 /// Interface for the blockchain node service responsible for
 /// providing access to block content known as fragments.
-pub trait ContentService: P2pService {
+pub trait FragmentService: P2pService {
     /// The data type to represent fragments constituting a block.
     type Fragment: Fragment;
 
@@ -30,21 +30,21 @@ pub trait ContentService: P2pService {
     ///
     /// The future resolves to a stream of fragments sent by the remote node
     /// and the identifier of the node in the network.
-    type ContentSubscriptionFuture: Future<
-        Item = (Self::ContentSubscription, Self::NodeId),
+    type FragmentSubscriptionFuture: Future<
+        Item = (Self::FragmentSubscription, Self::NodeId),
         Error = Error,
     >;
 
     /// The type of an asynchronous stream that provides notifications
     /// of fragments created or accepted by the remote node.
-    type ContentSubscription: Stream<Item = Self::Fragment, Error = Error>;
+    type FragmentSubscription: Stream<Item = Self::Fragment, Error = Error>;
 
     /// Establishes a bidirectional stream of notifications for fragments
     /// created or accepted by either of the peers.
     ///
     /// The client can use the stream that the returned future resolves to
     /// as a long-lived subscription handle.
-    fn content_subscription<S>(&mut self, outbound: S) -> Self::ContentSubscriptionFuture
+    fn fragment_subscription<S>(&mut self, outbound: S) -> Self::FragmentSubscriptionFuture
     where
         S: Stream<Item = Self::Fragment> + Send + 'static;
 }

--- a/network-core/src/server.rs
+++ b/network-core/src/server.rs
@@ -1,8 +1,12 @@
 //! Abstractions for the server-side network interface of a blockchain node.
 
-pub mod block;
-pub mod fragment;
-pub mod gossip;
+mod block;
+mod fragment;
+mod gossip;
+
+pub use block::BlockService;
+pub use fragment::FragmentService;
+pub use gossip::GossipService;
 
 use crate::gossip::NodeId;
 
@@ -18,13 +22,13 @@ use crate::gossip::NodeId;
 /// created to serve different requests from a single client.
 pub trait Node {
     /// The implementation of the block service.
-    type BlockService: block::BlockService;
+    type BlockService: BlockService;
 
     /// The implementation of the content service.
-    type FragmentService: fragment::FragmentService;
+    type FragmentService: FragmentService;
 
     /// The implementation of the gossip service.
-    type GossipService: gossip::GossipService;
+    type GossipService: GossipService;
 
     /// Instantiates the block service,
     /// if supported by this node.

--- a/network-core/src/server.rs
+++ b/network-core/src/server.rs
@@ -1,7 +1,7 @@
 //! Abstractions for the server-side network interface of a blockchain node.
 
 pub mod block;
-pub mod content;
+pub mod fragment;
 pub mod gossip;
 
 use crate::gossip::NodeId;
@@ -21,7 +21,7 @@ pub trait Node {
     type BlockService: block::BlockService;
 
     /// The implementation of the content service.
-    type ContentService: content::ContentService;
+    type FragmentService: fragment::FragmentService;
 
     /// The implementation of the gossip service.
     type GossipService: gossip::GossipService;
@@ -30,9 +30,9 @@ pub trait Node {
     /// if supported by this node.
     fn block_service(&mut self) -> Option<&mut Self::BlockService>;
 
-    /// Instantiates the content service,
+    /// Instantiates the fragment service,
     /// if supported by this node.
-    fn content_service(&mut self) -> Option<&mut Self::ContentService>;
+    fn fragment_service(&mut self) -> Option<&mut Self::FragmentService>;
 
     /// Instantiates the gossip service,
     /// if supported by this node.

--- a/network-core/src/server/fragment.rs
+++ b/network-core/src/server/fragment.rs
@@ -10,7 +10,7 @@ use futures::prelude::*;
 /// Interface for the blockchain node service implementation responsible for
 /// validating and accepting transactions and other block contents, known
 /// together as fragments.
-pub trait ContentService: P2pService {
+pub trait FragmentService: P2pService {
     /// The data type to represent fragments constituting a block.
     type Fragment: Fragment;
 
@@ -29,13 +29,13 @@ pub trait ContentService: P2pService {
 
     /// The type of an asynchronous stream that provides fragments announced
     /// by the peer via the bidirectional subscription.
-    type ContentSubscription: Stream<Item = Self::Fragment, Error = Error> + Send + 'static;
+    type FragmentSubscription: Stream<Item = Self::Fragment, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by method `content_subscription`.
     ///
     /// The future resolves to a stream that will be used by the protocol
     /// implementation to produce a server-streamed response.
-    type ContentSubscriptionFuture: Future<Item = Self::ContentSubscription, Error = Error>
+    type FragmentSubscriptionFuture: Future<Item = Self::FragmentSubscription, Error = Error>
         + Send
         + 'static;
 
@@ -50,11 +50,11 @@ pub trait ContentService: P2pService {
     ///
     /// Returns a future resolving to an asynchronous stream
     /// that will be used by this node to send fragment announcements.
-    fn content_subscription<In>(
+    fn fragment_subscription<In>(
         &mut self,
         subscriber: Self::NodeId,
         inbound: In,
-    ) -> Self::ContentSubscriptionFuture
+    ) -> Self::FragmentSubscriptionFuture
     where
         In: Stream<Item = Self::Fragment, Error = Error> + Send + 'static;
 }

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -136,7 +136,7 @@ service Node {
 
   // Establishes a bidirectional stream to exchange information on new
   // block fragments created or accepted by the peers.
-  rpc ContentSubscription(stream Fragment) returns (stream Fragment);
+  rpc FragmentSubscription(stream Fragment) returns (stream Fragment);
 
   // Establishes a bidirectional stream to exchange information on new
   // network peers.

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use chain_core::property;
 use network_core::client::block::BlockService;
-use network_core::client::content::ContentService;
+use network_core::client::fragment::FragmentService;
 use network_core::client::gossip::GossipService;
 use network_core::client::p2p::P2pService;
 use network_core::client::Client;
@@ -438,7 +438,7 @@ where
     }
 }
 
-impl<P> ContentService for Connection<P>
+impl<P> FragmentService for Connection<P>
 where
     P: ProtocolConfig,
 {
@@ -447,8 +447,8 @@ where
     type GetFragmentsStream = ResponseStream<P::Fragment, gen::node::Fragment>;
     type GetFragmentsFuture = ResponseStreamFuture<P::Fragment, gen::node::Fragment>;
 
-    type ContentSubscription = ResponseStream<P::Fragment, gen::node::Fragment>;
-    type ContentSubscriptionFuture =
+    type FragmentSubscription = ResponseStream<P::Fragment, gen::node::Fragment>;
+    type FragmentSubscriptionFuture =
         SubscriptionFuture<P::Fragment, Self::NodeId, gen::node::Fragment>;
 
     fn get_fragments(&mut self, ids: &[P::FragmentId]) -> Self::GetFragmentsFuture {
@@ -458,12 +458,12 @@ where
         ResponseStreamFuture::new(future)
     }
 
-    fn content_subscription<Out>(&mut self, outbound: Out) -> Self::ContentSubscriptionFuture
+    fn fragment_subscription<Out>(&mut self, outbound: Out) -> Self::FragmentSubscriptionFuture
     where
         Out: Stream<Item = P::Fragment> + Send + 'static,
     {
         let req = self.new_subscription_request(outbound);
-        let future = self.service.content_subscription(req);
+        let future = self.service.fragment_subscription(req);
         SubscriptionFuture::new(future)
     }
 }

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -10,11 +10,7 @@ use crate::{
 };
 
 use chain_core::property;
-use network_core::client::block::BlockService;
-use network_core::client::fragment::FragmentService;
-use network_core::client::gossip::GossipService;
-use network_core::client::p2p::P2pService;
-use network_core::client::Client;
+use network_core::client::{BlockService, Client, FragmentService, GossipService, P2pService};
 use network_core::error as core_error;
 use network_core::gossip::{self, Gossip, NodeId};
 use network_core::subscription::BlockEvent;

--- a/network-grpc/src/client/handshake.rs
+++ b/network-grpc/src/client/handshake.rs
@@ -1,6 +1,6 @@
 use crate::{convert, gen, PROTOCOL_VERSION};
 use chain_core::property;
-use network_core::client::block::HandshakeError;
+use network_core::client::HandshakeError;
 
 use futures::prelude::*;
 

--- a/network-grpc/src/server.rs
+++ b/network-grpc/src/server.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use network_core::server::{
-    block::BlockService, content::ContentService, gossip::GossipService, Node,
+    block::BlockService, fragment::FragmentService, gossip::GossipService, Node,
 };
 
 use futures::prelude::*;
@@ -33,7 +33,7 @@ where
     T: Node + Clone,
     <T::BlockService as BlockService>::Block: protocol_bounds::Block,
     <T::BlockService as BlockService>::Header: protocol_bounds::Header,
-    <T::ContentService as ContentService>::Fragment: protocol_bounds::Fragment,
+    <T::FragmentService as FragmentService>::Fragment: protocol_bounds::Fragment,
     <T::GossipService as GossipService>::Node: protocol_bounds::Node,
 {
     inner: tower_hyper::Server<
@@ -66,7 +66,7 @@ where
     T: Node + Clone + Send + 'static,
     <T::BlockService as BlockService>::Block: protocol_bounds::Block,
     <T::BlockService as BlockService>::Header: protocol_bounds::Header,
-    <T::ContentService as ContentService>::Fragment: protocol_bounds::Fragment,
+    <T::FragmentService as FragmentService>::Fragment: protocol_bounds::Fragment,
     <T::GossipService as GossipService>::Node: protocol_bounds::Node,
 {
     /// Creates a server instance around the node service implementation.

--- a/network-grpc/src/server.rs
+++ b/network-grpc/src/server.rs
@@ -3,9 +3,7 @@ use crate::{
     service::{protocol_bounds, NodeService},
 };
 
-use network_core::server::{
-    block::BlockService, fragment::FragmentService, gossip::GossipService, Node,
-};
+use network_core::server::{BlockService, FragmentService, GossipService, Node};
 
 use futures::prelude::*;
 use tokio_io::{AsyncRead, AsyncWrite};

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -11,9 +11,7 @@ use chain_core::property;
 use network_core::{
     error as core_error,
     gossip::NodeId,
-    server::{
-        block::BlockService, fragment::FragmentService, gossip::GossipService, Node, P2pService,
-    },
+    server::{BlockService, FragmentService, GossipService, Node, P2pService},
 };
 
 use futures::future::{self, FutureResult};


### PR DESCRIPTION
Consistently use "fragment" in API related to fragments.
Flatten the public namespace of network-core, removing per-service submodules that only get in the way.