### PR TITLE
network-grpc: Update tower dependencies

### DIFF
--- a/network-grpc/Cargo.toml
+++ b/network-grpc/Cargo.toml
@@ -24,13 +24,10 @@ tokio-io = "0.1"
 tokio-tcp = "0.1"
 tokio-uds = "0.2"
 tower-hyper = "0.1.1"
-tower-grpc = "0.1"
+tower-grpc = "0.1.1"
+tower-request-modifier = "0.1"
 tower-service = "0.2"
 tower-util = "0.1"
-
-[dependencies.tower-request-modifier]
-git = "https://github.com/tower-rs/tower-http"
-rev = "707a91db820b736da2f3e950c94383cda0088f43"
 
 [build-dependencies]
 tower-grpc-build = { version = "0.1", features = ["tower-hyper"] }


### PR DESCRIPTION
- tower-grpc to 0.1.1;
- tower-request-modifier to 0.1.x, now available on crates.io

The tower-grpc update may remove some spurious stream error diagnostics observed while troubleshooting Jormungandr bugs.