### PR TITLE
Add to_bytes for signature

### DIFF
--- a/chain-crypto/src/sign.rs
+++ b/chain-crypto/src/sign.rs
@@ -116,6 +116,9 @@ impl<A: VerificationAlgorithm, T> Signature<T, A> {
             phantom: PhantomData,
         })
     }
+    pub fn to_bytes<'a>(&'a self) -> Vec<u8> {
+        self.signdata.as_ref().to_vec()
+    }
     pub fn coerce<U>(self) -> Signature<U, A> {
         Signature {
             signdata: self.signdata,

--- a/chain-crypto/src/sign.rs
+++ b/chain-crypto/src/sign.rs
@@ -116,7 +116,7 @@ impl<A: VerificationAlgorithm, T> Signature<T, A> {
             phantom: PhantomData,
         })
     }
-    pub fn to_bytes<'a>(&'a self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Vec<u8> {
         self.signdata.as_ref().to_vec()
     }
     pub fn coerce<U>(self) -> Signature<U, A> {


### PR DESCRIPTION
Adds `to_bytes` to `VerificationAlgorithm`

See WASM PR (https://github.com/input-output-hk/js-chain-libs/pull/57) for more details