### PR TITLE
Expose key derivation for WASM

### DIFF
--- a/chain-crypto/src/algorithms/ed25519.rs
+++ b/chain-crypto/src/algorithms/ed25519.rs
@@ -21,7 +21,7 @@ pub struct Sig(pub(crate) [u8; ed25519::SIGNATURE_LENGTH]);
 
 impl Pub {
     pub fn from_xpub(xpub: &XPub) -> Self {
-        let mut buf = [0; 32];
+        let mut buf = [0; ed25519::PUBLIC_KEY_LENGTH];
         xpub.get_without_chaincode(&mut buf);
         Pub(buf)
     }

--- a/chain-crypto/src/algorithms/mod.rs
+++ b/chain-crypto/src/algorithms/mod.rs
@@ -4,8 +4,10 @@ mod ed25519_extended;
 mod sumed25519;
 pub mod vrf;
 
-pub use ed25519::{Ed25519, Pub};
+pub use ed25519::{Ed25519};
+pub(crate) use ed25519::{Pub};
 pub use ed25519_derive::Ed25519Bip32;
-pub use ed25519_extended::{Ed25519Extended, ExtendedPriv};
+pub use ed25519_extended::{Ed25519Extended};
+pub(crate) use ed25519_extended::{ExtendedPriv};
 pub use sumed25519::SumEd25519_12;
 pub use vrf::Curve25519_2HashDH;

--- a/chain-crypto/src/algorithms/mod.rs
+++ b/chain-crypto/src/algorithms/mod.rs
@@ -4,8 +4,8 @@ mod ed25519_extended;
 mod sumed25519;
 pub mod vrf;
 
-pub use ed25519::Ed25519;
+pub use ed25519::{Ed25519, Pub};
 pub use ed25519_derive::Ed25519Bip32;
-pub use ed25519_extended::Ed25519Extended;
+pub use ed25519_extended::{Ed25519Extended, ExtendedPriv};
 pub use sumed25519::SumEd25519_12;
 pub use vrf::Curve25519_2HashDH;

--- a/chain-crypto/src/derive.rs
+++ b/chain-crypto/src/derive.rs
@@ -1,3 +1,4 @@
+use ed25519_bip32::{PrivateKeyError, XPrv, XPRV_SIZE};
 use ed25519_bip32::{DerivationScheme, DerivationError};
 use crate::key::{SecretKey, PublicKey};
 use crate::{Ed25519Bip32, Ed25519, Ed25519Extended, ExtendedPriv, Pub};
@@ -19,14 +20,20 @@ pub fn derive_pk_ed25519(
       .map(PublicKey)
 }
 
-pub fn to_raw_sk(
-    key: &SecretKey<Ed25519Bip32>,
-) -> SecretKey<Ed25519Extended> {
+pub fn to_raw_sk(key: &SecretKey<Ed25519Bip32>) -> SecretKey<Ed25519Extended> {
     SecretKey(ExtendedPriv::from_xprv(&key.0))
 }
 
-pub fn to_raw_pk(
-    key: &PublicKey<Ed25519Bip32>,
-) -> PublicKey<Ed25519> {
+pub fn to_raw_pk(key: &PublicKey<Ed25519Bip32>) -> PublicKey<Ed25519> {
     PublicKey(Pub::from_xpub(&key.0))
+}
+
+pub fn from_bip39_seed(seed: &[u8]) -> Result<SecretKey<Ed25519Bip32>, PrivateKeyError> {
+    if seed.len() != XPRV_SIZE {
+      return Err(PrivateKeyError::LengthInvalid(seed.len()));
+    }
+
+    let mut buf = [0u8; XPRV_SIZE];
+    buf[..].clone_from_slice(seed);
+    Ok(SecretKey(XPrv::normalize_bytes(buf)))
 }

--- a/chain-crypto/src/derive.rs
+++ b/chain-crypto/src/derive.rs
@@ -1,4 +1,3 @@
-use ed25519_bip32::{XPrv, XPub, XPRV_SIZE, XPUB_SIZE};
 use ed25519_bip32::{DerivationScheme, DerivationError};
 use crate::key::{SecretKey, PublicKey};
 use crate::{Ed25519Bip32, Ed25519, Ed25519Extended, ExtendedPriv, Pub};

--- a/chain-crypto/src/derive.rs
+++ b/chain-crypto/src/derive.rs
@@ -1,0 +1,33 @@
+use ed25519_bip32::{XPrv, XPub, XPRV_SIZE, XPUB_SIZE};
+use ed25519_bip32::{DerivationScheme, DerivationError};
+use crate::key::{SecretKey, PublicKey};
+use crate::{Ed25519Bip32, Ed25519, Ed25519Extended, ExtendedPriv, Pub};
+
+pub fn derive_sk_ed25519(
+    key: &SecretKey<Ed25519Bip32>,
+    index: u32,
+) -> SecretKey<Ed25519Bip32> {
+    let new_key = key.0.derive(DerivationScheme::V2, index);
+    SecretKey(new_key)
+}
+
+pub fn derive_pk_ed25519(
+    key: &PublicKey<Ed25519Bip32>,
+    index: u32,
+) -> Result<PublicKey<Ed25519Bip32>, DerivationError> {
+    key.0
+      .derive(DerivationScheme::V2, index)
+      .map(PublicKey)
+}
+
+pub fn to_raw_sk(
+    key: &SecretKey<Ed25519Bip32>,
+) -> SecretKey<Ed25519Extended> {
+    SecretKey(ExtendedPriv::from_xprv(&key.0))
+}
+
+pub fn to_raw_pk(
+    key: &PublicKey<Ed25519Bip32>,
+) -> PublicKey<Ed25519> {
+    PublicKey(Pub::from_xpub(&key.0))
+}

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -150,6 +150,12 @@ impl<A: AsymmetricPublicKey> AsRef<[u8]> for PublicKey<A> {
     }
 }
 
+impl<A: AsymmetricKey> AsRef<[u8]> for SecretKey<A> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl<A: AsymmetricKey> From<SecretKey<A>> for KeyPair<A> {
     fn from(secret_key: SecretKey<A>) -> Self {
         let public_key = secret_key.to_public();

--- a/chain-crypto/src/lib.rs
+++ b/chain-crypto/src/lib.rs
@@ -26,6 +26,7 @@ cfg_if! {
 pub mod algorithms;
 pub mod asymlock;
 pub mod bech32;
+pub mod derive;
 pub mod digest;
 mod evolving;
 pub mod hash;


### PR DESCRIPTION
See https://github.com/input-output-hk/js-chain-libs/pull/58 for usage

Currently the Shelley WASM bindings don't allow for child key derivations because the capability isn't exposed by chain-libs. This PR fixes this. At the same time I also add the ability to create a key from a bip39 seed

### Design decisions

##### 1) Why create a `derive.rs` file

Currently `XPrv` and `XPub` are private so you can't access them from the WASM bindings. Instead of changing this, I add a new file called `derive.rs` that forwards the derivation to the `XPrv`. I put it in a new file because

1) It doesn't belong in `Ed25519_derive.rs` since it needs to access `SecretKey<A>`
2) It doesn't belong in `key.rs` because it needs to access an algorithm-specific function

It seems the current pattern for when (1) and (2) hold is to put them in separate files (such as `sign.rs` and `asymlock.rs`

##### 2) Not exposing DerivationScheme

Since we don't support support the v1 derivation scheme, I manually hardcode using v2 in `derive.rs`. We could decide to still take `DerivationScheme` as an argument to the function in case we want to define a v3 later. I'm open to either for this.