### PR TITLE
Treat EINVAL as a per-connection error on MacOS

### DIFF
--- a/network-grpc/src/server.rs
+++ b/network-grpc/src/server.rs
@@ -121,6 +121,8 @@ fn connection_error(e: &io::Error) -> bool {
 
     match e.kind() {
         ConnectionAborted | ConnectionReset | ConnectionRefused => true,
+        #[cfg(target_os = "macos")]
+        InvalidInput => true,
         _ => false,
     }
 }


### PR DESCRIPTION
In network-grpc, when accepting server connections, MacOS may set the `EINVAL` error, [reportedly](https://github.com/input-output-hk/jormungandr/issues/953) when the node connects to itself . Make this condition non-fatal for the listener.