### PR TITLE
Add spending counter in witness

### DIFF
--- a/chain-impl-mockchain/doc/format.md
+++ b/chain-impl-mockchain/doc/format.md
@@ -149,8 +149,8 @@ With the following serialization:
   * Type=2 utxo witness scheme (64 bytes):
     * ED25519 Signature (64 bytes)
   * Type=3 Account witness (68 bytes):
-    * Account Counter (4 bytes : TODO-ENDIANNESS)
     * ED25519 Signature (64 bytes)
+    * Account Counter (4 bytes in big endian)
 
 The message, w.r.t the cryptographic signature, is generally of the form:
 

--- a/chain-impl-mockchain/src/txbuilder.rs
+++ b/chain-impl-mockchain/src/txbuilder.rs
@@ -248,7 +248,7 @@ impl TransactionFinalizer {
         match (self.tx.inputs[index].get_type(), &witness) {
             (tx::InputType::Utxo, tx::Witness::OldUtxo(_, _)) => (),
             (tx::InputType::Utxo, tx::Witness::Utxo(_)) => (),
-            (tx::InputType::Account, tx::Witness::Account(_)) => (),
+            (tx::InputType::Account, tx::Witness::Account(_, _)) => (),
             (tx::InputType::Account, tx::Witness::Multisig(_)) => (),
             (_, _) => return Err(BuildError::WitnessMismatch { index }),
         };


### PR DESCRIPTION
The Jormungandr docs say that the spending counter should be part ofthe account witness. However, it turns out it is not present and so this PR adds it.

Before: 
```
0277b757da13eed8c5c934541782d389b1e955577a071f0a2c400bdecc538b34cd9632f38416e7b1022b57f6ac72dabebd89f6d946354d2ea0a349c7e0e5e8b705

02df368fa3a6d699d67e16f3d1da986574ea3eda06262cc0b5477ab16608cf3d0df2b09cad1030b674761c34325418c188972ea51c71c603c99f67568a93e8e604
```
After: 
```
0277b757da13eed8c5c934541782d389b1e955577a071f0a2c400bdecc538b34cd9632f38416e7b1022b57f6ac72dabebd89f6d946354d2ea0a349c7e0e5e8b70500000000

02df368fa3a6d699d67e16f3d1da986574ea3eda06262cc0b5477ab16608cf3d0df2b09cad1030b674761c34325418c188972ea51c71c603c99f67568a93e8e60400000001
```