### PR TITLE
small update on the typed-bytes library to rely more on standard API and compiler

### DIFF
--- a/typed-bytes/src/builder.rs
+++ b/typed-bytes/src/builder.rs
@@ -60,34 +60,28 @@ impl<T> ByteBuilder<T> {
     ///
     /// note that the buffer contains a byte to represent the size
     /// of the list
-    pub fn iter8<F, I>(self, mut l: I, f: F) -> Self
+    pub fn iter8<F, I>(self, l: I, f: F) -> Self
     where
         I: Iterator + ExactSizeIterator,
-        F: Fn(Self, &I::Item) -> Self,
+        F: FnMut(Self, I::Item) -> Self,
     {
         assert!(l.len() < 256);
-        let mut bb = self.u8(l.len() as u8);
-        while let Some(ref i) = l.next() {
-            bb = f(bb, i)
-        }
-        bb
+        let bb = self.u8(l.len() as u8);
+        l.fold(bb, f)
     }
 
     /// write an iterator of maximum 2^16 items using the closure F
     ///
     /// note that the buffer contains 2 bytes to represent the size
     /// of the list
-    pub fn iter16<F, I>(self, mut l: I, f: F) -> Self
+    pub fn iter16<F, I>(self, l: I, f: F) -> Self
     where
         I: Iterator + ExactSizeIterator,
-        F: Fn(Self, &I::Item) -> Self,
+        F: FnMut(Self, I::Item) -> Self,
     {
         assert!(l.len() < 65536);
-        let mut bb = self.u16(l.len() as u16);
-        while let Some(ref i) = l.next() {
-            bb = f(bb, i)
-        }
-        bb
+        let bb = self.u16(l.len() as u16);
+        l.fold(bb, f)
     }
 
     pub fn sub<F, U>(self, f: F) -> Self

--- a/typed-bytes/src/lib.rs
+++ b/typed-bytes/src/lib.rs
@@ -30,7 +30,7 @@ impl<'a, T> AsRef<[u8]> for ByteSlice<'a, T> {
 }
 
 impl<T> ByteArray<T> {
-    pub fn as_byteslice<'a>(&'a self) -> ByteSlice<'a, T> {
+    pub fn as_byteslice(&self) -> ByteSlice<'_, T> {
         ByteSlice {
             slice: &self.array[..],
             phantom: self.phantom,
@@ -72,7 +72,7 @@ pub trait ByteAccessor<A> {
 }
 
 impl<T> ByteArray<T> {
-    pub fn sub<'a, U>(&'a self) -> ByteSlice<'a, U>
+    pub fn sub<U>(&self) -> ByteSlice<'_, U>
     where
         T: ByteAccessor<U>,
     {


### PR DESCRIPTION
a small change in the API (not breaking change though, not in our context).

1. instead of forcing the `f` function of the `iter8` or `iter16` to use a reference of the `I::Item` we let the API chose for us, it's a combination of both the `F` signature and the `Iterator`'s `Item` to decide to take a reference or not. This allows optimisation to pass values by value instead of a reference.
2. Remove useless lifetime parameters from some function signatures. Rust compiler is perfectly capable of picking that properly. The function signature is only simplified and will let the compiler make the right choice for us.