### PR TITLE
Fix Legacy address boolean blindness

### DIFF
--- a/cardano-legacy-address/src/lib.rs
+++ b/cardano-legacy-address/src/lib.rs
@@ -19,4 +19,4 @@ mod base58;
 mod cbor;
 mod crc32;
 
-pub use address::{Addr, ExtendedAddr, ParseExtendedAddrError};
+pub use address::{Addr, AddressMatchXPub, ExtendedAddr, ParseExtendedAddrError};

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -847,7 +847,9 @@ impl Ledger {
                     });
                 };
 
-                if legacy::oldaddress_from_xpub(&associated_output.address, xpub) == legacy::OldAddressMatchXPub::No {
+                if legacy::oldaddress_from_xpub(&associated_output.address, xpub)
+                    == legacy::OldAddressMatchXPub::No
+                {
                     return Err(Error::OldUtxoInvalidPublicKey {
                         utxo: utxo.clone(),
                         output: associated_output.clone(),

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -847,7 +847,7 @@ impl Ledger {
                     });
                 };
 
-                if !legacy::oldaddress_from_xpub(&associated_output.address, xpub) {
+                if legacy::oldaddress_from_xpub(&associated_output.address, xpub) == legacy::OldAddressMatchXPub::No {
                     return Err(Error::OldUtxoInvalidPublicKey {
                         utxo: utxo.clone(),
                         output: associated_output.clone(),

--- a/chain-impl-mockchain/src/legacy.rs
+++ b/chain-impl-mockchain/src/legacy.rs
@@ -12,7 +12,10 @@ pub struct UtxoDeclaration {
     pub addrs: Vec<(OldAddress, Value)>,
 }
 
-pub fn oldaddress_from_xpub(address: &OldAddress, xpub: &PublicKey<Ed25519Bip32>) -> OldAddressMatchXPub {
+pub fn oldaddress_from_xpub(
+    address: &OldAddress,
+    xpub: &PublicKey<Ed25519Bip32>,
+) -> OldAddressMatchXPub {
     address.identical_with_pubkey_raw(xpub.as_ref())
 }
 

--- a/chain-impl-mockchain/src/legacy.rs
+++ b/chain-impl-mockchain/src/legacy.rs
@@ -1,6 +1,7 @@
 use crate::value::Value;
 
 pub use cardano_legacy_address::Addr as OldAddress;
+pub use cardano_legacy_address::AddressMatchXPub as OldAddressMatchXPub;
 
 use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_core::property;
@@ -11,7 +12,7 @@ pub struct UtxoDeclaration {
     pub addrs: Vec<(OldAddress, Value)>,
 }
 
-pub fn oldaddress_from_xpub(address: &OldAddress, xpub: &PublicKey<Ed25519Bip32>) -> bool {
+pub fn oldaddress_from_xpub(address: &OldAddress, xpub: &PublicKey<Ed25519Bip32>) -> OldAddressMatchXPub {
     address.identical_with_pubkey_raw(xpub.as_ref())
 }
 


### PR DESCRIPTION
replace bool by a proper enum that need explicit `==` or pattern match to get a boolean value

@KtorZ