### PR TITLE
Expose full delegation possibility in certificates

### DIFF
--- a/chain-impl-mockchain/doc/format.md
+++ b/chain-impl-mockchain/doc/format.md
@@ -255,7 +255,7 @@ TODO:
 
     TokenTransfer<PAYLOAD = OwnerStakeDelegation> | Witnesses
 
-    OwnerStakeDelegation = StakePoolId
+    OwnerStakeDelegation = DelegationType
 
 ## Type 3: Certificate
 
@@ -303,3 +303,48 @@ where `ProposalId` is the message ID of an earlier update proposal
 message, `VoterId` is an ed25519 extended public key, and `Signature`
 is a signature by the corresponding secret key over `ProposalId |
 VoterId`.
+
+## Shared formats
+
+Delegation Type has 3 different encodings:
+
+```
+No Delegation:
+
+    00
+
+Full delegation to 1 node:
+
+    01 POOL-ID
+
+Ratio delegation:
+
+    Byte(PARTS) Byte(#POOLS) ( Byte(POOL-PARTS) POOL-ID )[#POOLS times]
+
+    with PARTS >= 2 and #POOLS >= 2
+```
+
+Thus the encodings in hexadecimal:
+
+```
+
+No Delegation:
+
+    00
+
+Full Delegation to POOL-ID f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0
+
+    01 f0 f0 f0 f0 f0 f0 f0  f0 f0 f0 f0 f0 f0 f0 f0
+    f0 f0 f0 f0 f0 f0 f0 f0  f0 f0 f0 f0 f0 f0 f0 f0
+    f0
+
+Ratio Delegation of:
+* 1/4 to POOL-ID f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0
+* 3/4 to POOL-ID abababababababababababababababababababababababababababababababab
+
+    04 02 01 f0 f0 f0 f0 f0  f0 f0 f0 f0 f0 f0 f0 f0
+    f0 f0 f0 f0 f0 f0 f0 f0  f0 f0 f0 f0 f0 f0 f0 f0
+    f0 f0 f0 03 ab ab ab ab  ab ab ab ab ab ab ab ab
+    ab ab ab ab ab ab ab ab  ab ab ab ab ab ab ab ab
+    ab ab ab ab 
+```

--- a/chain-impl-mockchain/src/account.rs
+++ b/chain-impl-mockchain/src/account.rs
@@ -7,7 +7,7 @@ use chain_core::{
 };
 use chain_crypto::{Ed25519, PublicKey, Signature};
 
-pub use account::{LedgerError, SpendingCounter};
+pub use account::{DelegationRatio, DelegationType, LedgerError, SpendingCounter};
 
 pub type AccountAlg = Ed25519;
 

--- a/chain-impl-mockchain/src/accounting/account/account_state.rs
+++ b/chain-impl-mockchain/src/accounting/account/account_state.rs
@@ -32,18 +32,30 @@ pub struct DelegationRatio {
     pools: Box<[(PoolId, u8)]>,
 }
 
+/// The maximum number of pools
+pub const DELEGATION_RATIO_MAX_DECLS: usize = 8;
+
 impl DelegationRatio {
     pub fn is_valid(&self) -> bool {
         // map to u32 before summing to make sure we don't overflow
         let total: u32 = self.pools.iter().map(|x| x.1 as u32).sum();
         let has_no_zero = self.pools.iter().find(|x| x.1 == 0).is_none();
-        has_no_zero && self.parts > 1 && self.pools.len() > 1 && total == (self.parts as u32)
+        has_no_zero
+            && self.parts > 1
+            && self.pools.len() > 1
+            && self.pools.len() <= DELEGATION_RATIO_MAX_DECLS
+            && total == (self.parts as u32)
     }
 
     pub fn new(parts: u8, pools: Vec<(PoolId, u8)>) -> Option<DelegationRatio> {
         let total: u32 = pools.iter().map(|x| x.1 as u32).sum();
         let has_no_zero = pools.iter().find(|x| x.1 == 0).is_none();
-        if has_no_zero && parts > 1 && pools.len() > 1 && total == (parts as u32) {
+        if has_no_zero
+            && parts > 1
+            && pools.len() > 1
+            && pools.len() <= DELEGATION_RATIO_MAX_DECLS
+            && total == (parts as u32)
+        {
             Some(Self {
                 parts,
                 pools: pools.into(),

--- a/chain-impl-mockchain/src/accounting/account/account_state.rs
+++ b/chain-impl-mockchain/src/accounting/account/account_state.rs
@@ -16,17 +16,49 @@ pub enum DelegationType {
     Ratio(DelegationRatio),
 }
 
+/// Delegation Ratio type express a number of parts
+/// and a list of pools and their
+///
+/// E.g. parts: 7, pools: [(A, 3), (B,1), (C,4)] means that
+/// A is associated with 3/7 of the stake, B has 1/7 of stake and C
+/// has 4/7 of the stake.
+///
+/// It's invalid to have less than 2 elements in the array,
+/// and by extension parts need to be equal to the sum of individual
+/// pools parts.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DelegationRatio {
-    pub parts: u8,
-    pub pools: Vec<(PoolId, u8)>,
+    parts: u8,
+    pools: Box<[(PoolId, u8)]>,
 }
 
 impl DelegationRatio {
     pub fn is_valid(&self) -> bool {
         // map to u32 before summing to make sure we don't overflow
         let total: u32 = self.pools.iter().map(|x| x.1 as u32).sum();
-        self.parts > 0 && self.pools.len() > 0 && total == (self.parts as u32)
+        let has_no_zero = self.pools.iter().find(|x| x.1 == 0).is_none();
+        has_no_zero && self.parts > 1 && self.pools.len() > 1 && total == (self.parts as u32)
+    }
+
+    pub fn new(parts: u8, pools: Vec<(PoolId, u8)>) -> Option<DelegationRatio> {
+        let total: u32 = pools.iter().map(|x| x.1 as u32).sum();
+        let has_no_zero = pools.iter().find(|x| x.1 == 0).is_none();
+        if has_no_zero && parts > 1 && pools.len() > 1 && total == (parts as u32) {
+            Some(Self {
+                parts,
+                pools: pools.into(),
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn parts(&self) -> u8 {
+        self.parts
+    }
+
+    pub fn pools(&self) -> &[(PoolId, u8)] {
+        &self.pools
     }
 }
 

--- a/chain-impl-mockchain/src/accounting/account/account_state.rs
+++ b/chain-impl-mockchain/src/accounting/account/account_state.rs
@@ -17,10 +17,10 @@ pub enum DelegationType {
 }
 
 /// Delegation Ratio type express a number of parts
-/// and a list of pools and their
+/// and a list of pools and their individual parts
 ///
-/// E.g. parts: 7, pools: [(A, 3), (B,1), (C,4)] means that
-/// A is associated with 3/7 of the stake, B has 1/7 of stake and C
+/// E.g. parts: 7, pools: [(A,2), (B,1), (C,4)] means that
+/// A is associated with 2/7 of the stake, B has 1/7 of stake and C
 /// has 4/7 of the stake.
 ///
 /// It's invalid to have less than 2 elements in the array,

--- a/chain-impl-mockchain/src/certificate/delegation.rs
+++ b/chain-impl-mockchain/src/certificate/delegation.rs
@@ -1,4 +1,4 @@
-use crate::accounting::account::{DelegationRatio, DelegationType};
+use crate::accounting::account::{DelegationRatio, DelegationType, DELEGATION_RATIO_MAX_DECLS};
 use crate::certificate::CertificateSlice;
 use crate::transaction::{
     AccountBindingSignature, AccountIdentifier, Payload, PayloadAuthData, PayloadData, PayloadSlice,
@@ -10,8 +10,6 @@ use chain_core::{
 };
 use std::marker::PhantomData;
 use typed_bytes::ByteBuilder;
-
-pub const NB_MAX_RATIO_DECLS: u8 = 8;
 
 /// A self delegation to a specific StakePoolId.
 ///
@@ -164,10 +162,10 @@ fn deserialize_delegation_type<'a>(buf: &mut ReadBuf<'a>) -> Result<DelegationTy
         }
         _ => {
             let sz = buf.get_u8()?;
-            if sz > NB_MAX_RATIO_DECLS {
+            if sz as usize > DELEGATION_RATIO_MAX_DECLS {
                 Err(ReadError::SizeTooBig(
                     sz as usize,
-                    NB_MAX_RATIO_DECLS as usize,
+                    DELEGATION_RATIO_MAX_DECLS,
                 ))?
             }
             let mut pools = Vec::with_capacity(sz as usize);

--- a/chain-impl-mockchain/src/certificate/test.rs
+++ b/chain-impl-mockchain/src/certificate/test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::accounting::account::DelegationType;
 use crate::leadership::genesis::GenesisPraosLeader;
 use crate::rewards::TaxType;
 use chain_crypto::{testing, Ed25519};
@@ -44,11 +45,25 @@ impl Arbitrary for PoolOwnersSigned {
     }
 }
 
+impl Arbitrary for DelegationType {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        DelegationType::Full(Arbitrary::arbitrary(g))
+    }
+}
+
 impl Arbitrary for StakeDelegation {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         StakeDelegation {
             account_id: Arbitrary::arbitrary(g),
-            pool_id: Arbitrary::arbitrary(g),
+            delegation: Arbitrary::arbitrary(g),
+        }
+    }
+}
+
+impl Arbitrary for OwnerStakeDelegation {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        Self {
+            delegation: Arbitrary::arbitrary(g),
         }
     }
 }

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -3,7 +3,6 @@
 
 use super::check::{self, TxVerifyError};
 use super::pots::Pots;
-use crate::accounting::account::DelegationType;
 use crate::block::{BlockDate, ChainLength, ConsensusVersion, HeaderContentEvalContext};
 use crate::config::{self, ConfigParam, RewardParams};
 use crate::fee::{FeeAlgorithm, LinearFee};
@@ -564,15 +563,13 @@ impl Ledger {
         mut self,
         auth_cert: &certificate::StakeDelegation,
     ) -> Result<Self, Error> {
-        let pool_id = &auth_cert.pool_id;
+        let delegation = &auth_cert.delegation;
 
         let account_key = auth_cert
             .account_id
             .to_single_account()
             .ok_or(Error::AccountIdentifierInvalid)?;
-        self.accounts = self
-            .accounts
-            .set_delegation(&account_key, DelegationType::Full(pool_id.clone()))?;
+        self.accounts = self.accounts.set_delegation(&account_key, delegation)?;
         Ok(self)
     }
 

--- a/chain-impl-mockchain/src/multisig/ledger.rs
+++ b/chain-impl-mockchain/src/multisig/ledger.rs
@@ -125,7 +125,7 @@ impl Ledger {
     pub fn set_delegation(
         &self,
         identifier: &Identifier,
-        delegation: DelegationType,
+        delegation: &DelegationType,
     ) -> Result<Self, LedgerError> {
         let new_accounts = self.accounts.set_delegation(identifier, delegation)?;
         Ok(Self {

--- a/chain-impl-mockchain/src/stake/distribution.rs
+++ b/chain-impl-mockchain/src/stake/distribution.rs
@@ -114,10 +114,9 @@ fn assign_account_value(
             // separate the total in as many parts as pools, and try to assign from the first to the last,
             // the stake associated plus if there's any remaining from the division.
             if dr.is_valid() {
-                assert!(dr.pools.len() > 0); // verified by is_valid
-                let sin = value.split_in(dr.pools.len() as u32);
+                let sin = value.split_in(dr.parts() as u32);
                 let mut r = sin.remaining;
-                for (pool_id, ratio) in dr.pools.iter() {
+                for (pool_id, ratio) in dr.pools().iter() {
                     match sd.to_pools.get_mut(pool_id) {
                         None => sd.dangling = (sd.dangling + value).unwrap(),
                         Some(pool_info) => {
@@ -416,7 +415,7 @@ mod tests {
             accounts = accounts
                 .set_delegation(
                     &Identifier::from(account_public_key.clone()),
-                    DelegationType::Full(id_active_pool.clone()),
+                    &DelegationType::Full(id_active_pool.clone()),
                 )
                 .unwrap();
         }
@@ -439,7 +438,7 @@ mod tests {
         for (id, value) in stake_distribution_data.assigned_accounts.iter().cloned() {
             accounts = accounts.add_account(&id, value, ()).unwrap();
             accounts = accounts
-                .set_delegation(&id, DelegationType::Full(id_active_pool.clone()))
+                .set_delegation(&id, &DelegationType::Full(id_active_pool.clone()))
                 .unwrap();
         }
 
@@ -451,7 +450,7 @@ mod tests {
         accounts = accounts
             .set_delegation(
                 &single_account.0.clone(),
-                DelegationType::Full(id_active_pool.clone()),
+                &DelegationType::Full(id_active_pool.clone()),
             )
             .unwrap();
 
@@ -459,7 +458,7 @@ mod tests {
         for (id, value) in stake_distribution_data.dangling_accounts.iter().cloned() {
             accounts = accounts.add_account(&id, value, ()).unwrap();
             accounts = accounts
-                .set_delegation(&id, DelegationType::Full(id_retired_pool.clone()))
+                .set_delegation(&id, &DelegationType::Full(id_retired_pool.clone()))
                 .unwrap();
         }
 

--- a/chain-impl-mockchain/src/testing/builders/cert_builder.rs
+++ b/chain-impl-mockchain/src/testing/builders/cert_builder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    account::Identifier,
+    account::{DelegationType, Identifier},
     certificate::{
         Certificate, OwnerStakeDelegation, PoolId,
         PoolRegistration, PoolRetirement, StakeDelegation,
@@ -17,7 +17,7 @@ pub fn build_stake_delegation_cert(
         AccountIdentifier::from_single_account(Identifier::from(delegate_from.delegation_key()));
     Certificate::StakeDelegation(StakeDelegation {
         account_id: account_id,
-        pool_id: stake_pool.to_id(),
+        delegation: DelegationType::Full(stake_pool.to_id()),
     })
 }
 
@@ -27,7 +27,7 @@ pub fn build_stake_pool_registration_cert(stake_pool: &PoolRegistration) -> Cert
 
 pub fn build_owner_stake_delegation(stake_pool: PoolId) -> Certificate {
     Certificate::OwnerStakeDelegation(OwnerStakeDelegation {
-        pool_id: stake_pool,
+        delegation: DelegationType::Full(stake_pool),
     })
 }
 


### PR DESCRIPTION
Allow full DelegationType support in delegation certificates, fix an issue with stake distribution not using the ratio parts properly.

format breaking changes in OwnerStakeDelegation and StakeDelegation