### PR TITLE
(#52) Optimize unspent utxo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ members = [
     "cardano-legacy-address",
     "network-core",
     "network-grpc",
+    "sparse-array",
     "typed-bytes",
 ]

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -22,6 +22,7 @@ typed-bytes = { path = "../typed-bytes" }
 rand_core = "0.3"
 rand_os = "0.1"
 imhamt = { path = "../imhamt" }
+sparse-array = { path = "../sparse-array" }
 strum = "0.15.0"
 strum_macros = "0.15.0"
 custom_error = "1.6"

--- a/chain-impl-mockchain/src/utxo.rs
+++ b/chain-impl-mockchain/src/utxo.rs
@@ -7,7 +7,7 @@
 use crate::fragment::FragmentId;
 use crate::transaction::{Output, TransactionIndex};
 use chain_addr::Address;
-use sparse_array::{FastSparseArray, FastSparseArrayIter};
+use sparse_array::{FastSparseArray, FastSparseArrayBuilder, FastSparseArrayIter};
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 
@@ -52,11 +52,11 @@ struct TransactionUnspents<OutAddress>(FastSparseArray<Output<OutAddress>>);
 impl<OutAddress: Clone> TransactionUnspents<OutAddress> {
     pub fn from_outputs(outs: &[(TransactionIndex, Output<OutAddress>)]) -> Self {
         assert!(outs.len() < 255);
-        let mut sa = FastSparseArray::with_capacity(outs.len() as u8);
+        let mut sa = FastSparseArrayBuilder::with_capacity(outs.len() as u8);
         for (index, output) in outs.iter() {
             sa.set(*index, output.clone());
         }
-        TransactionUnspents(sa)
+        TransactionUnspents(sa.build())
     }
 
     pub fn remove_input(

--- a/chain-impl-mockchain/src/utxo.rs
+++ b/chain-impl-mockchain/src/utxo.rs
@@ -7,9 +7,8 @@
 use crate::fragment::FragmentId;
 use crate::transaction::{Output, TransactionIndex};
 use chain_addr::Address;
-use std::collections::btree_map;
+use sparse_array::{SparseArray, SparseArrayIter};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::BTreeMap;
 use std::fmt;
 
 use imhamt::{Hamt, HamtIter, InsertError, RemoveError, ReplaceError, UpdateError};
@@ -48,18 +47,16 @@ impl From<RemoveError> for Error {
 
 /// Hold all the individual outputs that remain unspent
 #[derive(Clone, PartialEq, Eq, Debug)]
-struct TransactionUnspents<OutAddress>(BTreeMap<TransactionIndex, Output<OutAddress>>);
+struct TransactionUnspents<OutAddress>(SparseArray<Output<OutAddress>>);
 
 impl<OutAddress: Clone> TransactionUnspents<OutAddress> {
     pub fn from_outputs(outs: &[(TransactionIndex, Output<OutAddress>)]) -> Self {
         assert!(outs.len() < 255);
-        let mut b = BTreeMap::new();
+        let mut sa = SparseArray::with_capacity(outs.len() as u8);
         for (index, output) in outs.iter() {
-            let r = b.insert(*index, output.clone());
-            // duplicated index
-            if r.is_some() {}
+            sa.set(*index, output.clone());
         }
-        TransactionUnspents(b)
+        TransactionUnspents(sa)
     }
 
     pub fn remove_input(
@@ -68,7 +65,7 @@ impl<OutAddress: Clone> TransactionUnspents<OutAddress> {
     ) -> Result<(Self, Output<OutAddress>), Error> {
         assert!(index < 255);
         let mut t = self.0.clone();
-        match t.remove(&index) {
+        match t.remove(index) {
             None => Err(Error::IndexNotFound),
             Some(o) => Ok((TransactionUnspents(t), o)),
         }
@@ -81,15 +78,12 @@ pub struct Ledger<OutAddress>(Hamt<DefaultHasher, FragmentId, TransactionUnspent
 
 pub struct Iter<'a, V> {
     hamt_iter: HamtIter<'a, FragmentId, TransactionUnspents<V>>,
-    unspents_iter: Option<(
-        &'a FragmentId,
-        btree_map::Iter<'a, TransactionIndex, Output<V>>,
-    )>,
+    unspents_iter: Option<(&'a FragmentId, SparseArrayIter<'a, Output<V>>)>,
 }
 
 pub struct Values<'a, V> {
     hamt_iter: HamtIter<'a, FragmentId, TransactionUnspents<V>>,
-    unspents_iter: Option<btree_map::Iter<'a, TransactionIndex, Output<V>>>,
+    unspents_iter: Option<SparseArrayIter<'a, Output<V>>>,
 }
 
 impl fmt::Debug for Ledger<Address> {
@@ -129,7 +123,7 @@ impl<OutAddress> Ledger<OutAddress> {
     ) -> Option<Entry<'a, OutAddress>> {
         self.0
             .lookup(tid)
-            .and_then(|unspent| unspent.0.get(index))
+            .and_then(|unspent| unspent.0.get(*index))
             .map(|output| Entry {
                 fragment_id: tid.clone(),
                 output_index: *index,
@@ -176,9 +170,9 @@ impl<'a, V> Iterator for Iter<'a, V> {
                     Some(x) => {
                         return Some(Entry {
                             fragment_id: id.clone(),
-                            output_index: *x.0,
+                            output_index: x.0,
                             output: x.1,
-                        })
+                        });
                     }
                 },
             }
@@ -368,13 +362,13 @@ mod tests {
     #[quickcheck]
     pub fn transaction_unspent_remove(outputs: ArbitraryTransactionOutputs) -> TestResult {
         let transaction_unspent = TransactionUnspents::from_outputs(outputs.to_vec().as_slice());
-        let is_index_correct = transaction_unspent.0.contains_key(&outputs.idx_to_remove);
+        let is_index_correct = transaction_unspent.0.contains_key(outputs.idx_to_remove);
         match (
             transaction_unspent.remove_input(outputs.idx_to_remove),
             is_index_correct,
         ) {
             (Ok((transaction_unspent, output)), true) => {
-                if transaction_unspent.0.contains_key(&outputs.idx_to_remove) {
+                if transaction_unspent.0.contains_key(outputs.idx_to_remove) {
                     return TestResult::error("Element not removed");
                 }
 

--- a/chain-impl-mockchain/src/utxo.rs
+++ b/chain-impl-mockchain/src/utxo.rs
@@ -101,7 +101,7 @@ pub struct Entry<'a, OutputAddress> {
     pub output: &'a Output<OutputAddress>,
 }
 
-impl<OutAddress: Clone> Ledger<OutAddress> {
+impl<OutAddress> Ledger<OutAddress> {
     pub fn iter<'a>(&'a self) -> Iter<'a, OutAddress> {
         Iter {
             hamt_iter: self.0.iter(),
@@ -136,7 +136,7 @@ impl<OutAddress: Clone> Ledger<OutAddress> {
     }
 }
 
-impl<'a, V: Clone> Iterator for Values<'a, V> {
+impl<'a, V> Iterator for Values<'a, V> {
     type Item = &'a Output<V>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -155,7 +155,7 @@ impl<'a, V: Clone> Iterator for Values<'a, V> {
     }
 }
 
-impl<'a, V: Clone> Iterator for Iter<'a, V> {
+impl<'a, V> Iterator for Iter<'a, V> {
     type Item = Entry<'a, V>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -179,6 +179,7 @@ impl<'a, V: Clone> Iterator for Iter<'a, V> {
         }
     }
 }
+
 impl<OutAddress: Clone> Ledger<OutAddress> {
     /// Create a new empty UTXO Ledger
     pub fn new() -> Self {

--- a/sparse-array/Cargo.toml
+++ b/sparse-array/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sparse-array"
+version = "0.1.0"
+authors = ["Yevhenii Babichenko <eugene.babichenko@iohk.io>"]
+edition = "2018"
+
+[dev-dependencies]
+quickcheck = "0.8"
+quickcheck_macros = "0.8"

--- a/sparse-array/src/bitmap.rs
+++ b/sparse-array/src/bitmap.rs
@@ -1,0 +1,143 @@
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BitmapIndex(u128, u128);
+
+impl BitmapIndex {
+    pub fn new() -> Self {
+        Self(0u128, 0u128)
+    }
+
+    fn get_mask_and_part(&self, idx: u8) -> (u128, u8) {
+        let mask: u128 = 1 << (idx % 128);
+        let part: u8 = idx / 128;
+        (mask, part)
+    }
+
+    pub fn get_index(&self, idx: u8) -> bool {
+        let (mask, part) = self.get_mask_and_part(idx);
+
+        if part == 0 {
+            (self.0 & mask) != 0
+        } else {
+            (self.1 & mask) != 0
+        }
+    }
+
+    pub fn set_index(&mut self, idx: u8) {
+        let (mask, part) = self.get_mask_and_part(idx);
+
+        if part == 0 {
+            self.0 |= mask;
+        } else {
+            self.1 |= mask;
+        }
+    }
+
+    pub fn remove_index(&mut self, idx: u8) {
+        let (mask, part) = self.get_mask_and_part(idx);
+
+        if part == 0 {
+            self.0 &= !mask;
+        } else {
+            self.1 &= !mask;
+        }
+    }
+
+    pub fn get_real_index(&self, idx: u8) -> Option<u8> {
+        if !self.get_index(idx) {
+            return None;
+        }
+
+        let (mask, part) = self.get_mask_and_part(idx);
+        let mask = mask - 1;
+
+        if part == 0 {
+            Some((self.0 & mask).count_ones() as u8)
+        } else {
+            let count = self.0.count_ones() + (self.1 & mask).count_ones();
+            Some(count as u8)
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0 && self.1 == 0
+    }
+
+    pub fn get_first_index(&self) -> Option<u8> {
+        let trailing_zeros0 = self.0.trailing_zeros();
+        let trailing_zeros1 = self.1.trailing_zeros();
+        if trailing_zeros0 < 128 {
+            Some(trailing_zeros0 as u8)
+        } else if trailing_zeros1 < 128 {
+            Some(128u8 + trailing_zeros1 as u8)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_empty_when_created_test() {
+        let bitmap = BitmapIndex::new();
+        assert!(bitmap.is_empty());
+        assert!(bitmap.get_first_index().is_none());
+    }
+
+    #[quickcheck]
+    fn set_index_test(indices: Vec<u8>) -> bool {
+        let mut bitmap = BitmapIndex::new();
+        for idx in indices.iter() {
+            bitmap.set_index(*idx);
+        }
+        indices.iter().all(|idx| bitmap.get_index(*idx))
+            && !(bitmap.is_empty() && indices.len() > 0)
+    }
+
+    #[quickcheck]
+    fn remove_indextest(indices: Vec<u8>) -> bool {
+        // this test will not work correctly if there are two same numbers in
+        // both splits (see below)
+        let mut indices = indices;
+        indices.sort();
+        indices.dedup();
+
+        let mut bitmap = BitmapIndex::new();
+        for idx in indices.iter() {
+            bitmap.set_index(*idx);
+        }
+
+        // split indices vector in two and remove elements only from the first
+        // vector
+        let (to_remove, to_set) = indices.split_at(indices.len() / 2);
+        for idx in to_remove.iter() {
+            bitmap.remove_index(*idx);
+        }
+        to_remove.iter().all(|idx| !bitmap.get_index(*idx))
+            && to_set.iter().all(|idx| bitmap.get_index(*idx))
+    }
+
+    #[quickcheck]
+    fn get_real_index_test(indices: Vec<u8>) -> bool {
+        let mut indices = indices;
+        indices.sort();
+        indices.dedup();
+        let mut bitmap = BitmapIndex::new();
+        for idx in indices.iter() {
+            bitmap.set_index(*idx);
+        }
+        indices
+            .iter()
+            .enumerate()
+            .all(|(expected, idx)| bitmap.get_real_index(*idx) == Some(expected as u8))
+    }
+
+    #[quickcheck]
+    fn get_first_index_test(idx: u8) -> bool {
+        let mut bitmap = BitmapIndex::new();
+        bitmap.set_index(idx);
+        bitmap.get_first_index() == Some(idx)
+    }
+}

--- a/sparse-array/src/fast.rs
+++ b/sparse-array/src/fast.rs
@@ -1,0 +1,187 @@
+///! Wrapper for sparse arrays that doesn't delete anything from the memory
+/// unless `shrink` is called.
+
+use std::sync::Arc;
+use crate::{
+    bitmap::BitmapIndex,
+    SparseArray,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FastSparseArray<V> {
+    index: BitmapIndex,
+    data: Arc<SparseArray<V>>,
+}
+
+impl<V: Clone> FastSparseArray<V> {
+    pub fn new() -> Self {
+        Self {
+            index: BitmapIndex::new(),
+            data: Arc::new(SparseArray::new()),
+        }
+    }
+
+    pub fn with_capacity(capacity: u8) -> Self {
+        Self {
+            index: BitmapIndex::new(),
+            data: Arc::new(SparseArray::with_capacity(capacity)),
+        }
+    }
+
+    pub fn get(&self, idx: u8) -> Option<&V> {
+        if !self.index.get_index(idx) {
+            None
+        } else {
+            self.data.get(idx)
+        }
+    }
+
+    pub fn set(&mut self, idx: u8, value: V) {
+        match Arc::get_mut(&mut self.data) {
+            Some(d) => d.set(idx, value),
+            None => {
+                let mut new_sparse_array = SparseArray::new();
+                for (idx, value) in self.iter() {
+                    new_sparse_array.set(idx, (*value).clone());
+                }
+                new_sparse_array.set(idx, value);
+                self.data = Arc::new(new_sparse_array);
+            }
+        }
+        self.index.set_index(idx);
+    }
+
+    pub fn remove(&mut self, idx: u8) -> Option<V> {
+        if self.index.get_index(idx) {
+            self.index.remove_index(idx);
+            return self.data.get(idx).map(|x| (*x).clone());
+        }
+
+        None
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.index.is_empty()
+    }
+
+    pub fn contains_key(&self, idx: u8) -> bool {
+        self.index.get_index(idx)
+    }
+
+    pub fn iter(&self) -> FastSparseArrayIter<V> {
+        FastSparseArrayIter::new(&self)
+    }
+
+    pub fn shrink(&mut self) {
+        let mut new_sparse_array = SparseArray::new();
+        for (idx, value) in self.iter() {
+            new_sparse_array.set(idx, (*value).clone());
+        }
+        self.data = Arc::new(new_sparse_array);
+    }
+}
+
+pub struct FastSparseArrayIter<'a, V> {
+    bitmap: BitmapIndex,
+    sparse_array: &'a FastSparseArray<V>,
+}
+
+impl<'a, V> FastSparseArrayIter<'a, V> {
+    pub fn new(sparse_array: &'a FastSparseArray<V>) -> Self {
+        Self {
+            bitmap: sparse_array.index.clone(),
+            sparse_array,
+        }
+    }
+}
+
+impl<'a, V: Clone> Iterator for FastSparseArrayIter<'a, V> {
+    type Item = (u8, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.bitmap.get_first_index() {
+            Some(idx) => {
+                self.bitmap.remove_index(idx);
+                Some((idx, self.sparse_array.get(idx).unwrap()))
+            }
+            None => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[quickcheck]
+    fn add_test(data: Vec<(u8, u8)>) -> bool {
+        let mut data = data;
+        data.sort_by(|a, b| a.0.cmp(&b.0));
+        data.dedup_by(|a, b| a.0.eq(&b.0));
+
+        let mut sparse_array = FastSparseArray::new();
+        for (idx, value) in data.iter() {
+            sparse_array.set(*idx, value);
+        }
+
+        data.iter()
+            .all(|(idx, value)| sparse_array.get(*idx) == Some(&value))
+    }
+
+    #[quickcheck]
+    fn remove_test(data: Vec<(u8, u8)>) -> bool {
+        let mut data = data;
+        data.sort_by(|a, b| a.0.cmp(&b.0));
+        data.dedup_by(|a, b| a.0.eq(&b.0));
+
+        let mut sparse_array = FastSparseArray::new();
+        for (idx, value) in data.iter() {
+            sparse_array.set(*idx, value);
+        }
+
+        let (to_remove, to_set) = data.split_at(data.len() / 2);
+        for (idx, _) in to_remove.iter() {
+            sparse_array.remove(*idx);
+        }
+
+        sparse_array.shrink();
+
+        to_remove
+            .iter()
+            .all(|(idx, _)| sparse_array.get(*idx) == None)
+            && to_set
+                .iter()
+                .all(|(idx, value)| sparse_array.get(*idx) == Some(&value))
+    }
+
+    #[test]
+    fn test_original_copy_not_changed_add() {
+        let mut sparse_array = FastSparseArray::new();
+        
+        let original_value = 1;
+        let new_value = 2;
+        let original_idx = 10;
+        let new_idx = 15;
+
+        sparse_array.set(original_idx, original_value);
+        
+        let mut new_array = sparse_array.clone();
+        new_array.set(new_idx, new_value);
+
+        assert_eq!(sparse_array.get(new_idx), None);
+    }
+
+    #[test]
+    fn test_original_copy_not_changed_remove() {
+        let mut sparse_array = FastSparseArray::new();
+        
+        let original_value = 1;
+        let original_idx = 2;
+        sparse_array.set(original_idx, original_value);
+        
+        let mut new_array = sparse_array.clone();
+        new_array.remove(original_idx);
+
+        assert_eq!(sparse_array.get(original_idx), Some(&original_value));
+    }
+}

--- a/sparse-array/src/lib.rs
+++ b/sparse-array/src/lib.rs
@@ -1,0 +1,10 @@
+///! Implementation of a sparse array storing maximum of 256 elements
+
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+
+mod bitmap;
+mod sparse_array;
+
+pub use crate::sparse_array::{SparseArray, SparseArrayIter};

--- a/sparse-array/src/lib.rs
+++ b/sparse-array/src/lib.rs
@@ -8,5 +8,7 @@ mod bitmap;
 mod fast;
 mod sparse_array;
 
-pub use crate::fast::{FastSparseArray, FastSparseArrayIter};
-pub use crate::sparse_array::{SparseArray, SparseArrayIter};
+pub use crate::{
+    fast::{FastSparseArray, FastSparseArrayBuilder, FastSparseArrayIter},
+    sparse_array::{SparseArray, SparseArrayBuilder, SparseArrayIter},
+};

--- a/sparse-array/src/lib.rs
+++ b/sparse-array/src/lib.rs
@@ -5,6 +5,8 @@
 extern crate quickcheck_macros;
 
 mod bitmap;
+mod fast;
 mod sparse_array;
 
+pub use crate::fast::{FastSparseArray, FastSparseArrayIter};
 pub use crate::sparse_array::{SparseArray, SparseArrayIter};

--- a/sparse-array/src/sparse_array.rs
+++ b/sparse-array/src/sparse_array.rs
@@ -1,0 +1,133 @@
+use crate::bitmap::BitmapIndex;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SparseArray<V> {
+    index: BitmapIndex,
+    data: Vec<V>,
+}
+
+impl<V> SparseArray<V> {
+    pub fn new() -> Self {
+        Self {
+            index: BitmapIndex::new(),
+            data: Vec::new(),
+        }
+    }
+
+    pub fn with_capacity(capacity: u8) -> Self {
+        Self {
+            index: BitmapIndex::new(),
+            data: Vec::with_capacity(capacity as usize),
+        }
+    }
+
+    pub fn get(&self, idx: u8) -> Option<&V> {
+        self.index
+            .get_real_index(idx)
+            .map(|idx_real| self.data.get(idx_real as usize).unwrap())
+    }
+
+    pub fn set(&mut self, idx: u8, value: V) {
+        match self.index.get_real_index(idx) {
+            Some(idx_real) => self.data[idx_real as usize] = value,
+            None => {
+                self.index.set_index(idx);
+                let idx_real = self.index.get_real_index(idx).unwrap();
+                self.data.insert(idx_real as usize, value);
+            }
+        }
+    }
+
+    pub fn remove(&mut self, idx: u8) -> Option<V> {
+        let r = self
+            .index
+            .get_real_index(idx)
+            .map(|idx_real| self.data.remove(idx_real as usize));
+        self.index.remove_index(idx);
+        r
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.index.is_empty()
+    }
+
+    pub fn contains_key(&self, idx: u8) -> bool {
+        self.index.get_index(idx)
+    }
+
+    pub fn iter(&self) -> SparseArrayIter<V> {
+        SparseArrayIter::new(&self)
+    }
+}
+
+pub struct SparseArrayIter<'a, V> {
+    bitmap: BitmapIndex,
+    sparse_array: &'a SparseArray<V>,
+}
+
+impl<'a, V> SparseArrayIter<'a, V> {
+    pub fn new(sparse_array: &'a SparseArray<V>) -> Self {
+        Self {
+            bitmap: sparse_array.index.clone(),
+            sparse_array,
+        }
+    }
+}
+
+impl<'a, V> Iterator for SparseArrayIter<'a, V> {
+    type Item = (u8, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.bitmap.get_first_index() {
+            Some(idx) => {
+                self.bitmap.remove_index(idx);
+                Some((idx, self.sparse_array.get(idx).unwrap()))
+            }
+            None => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[quickcheck]
+    fn add_test(data: Vec<(u8, u8)>) -> bool {
+        let mut data = data;
+        data.sort_by(|a, b| a.0.cmp(&b.0));
+        data.dedup_by(|a, b| a.0.eq(&b.0));
+
+        let mut sparse_array = SparseArray::new();
+        for (idx, value) in data.iter() {
+            sparse_array.set(*idx, value);
+        }
+
+        data.iter()
+            .all(|(idx, value)| sparse_array.get(*idx) == Some(&value))
+    }
+
+    #[quickcheck]
+    fn remove_test(data: Vec<(u8, u8)>) -> bool {
+        let mut data = data;
+        data.sort_by(|a, b| a.0.cmp(&b.0));
+        data.dedup_by(|a, b| a.0.eq(&b.0));
+
+        let mut sparse_array = SparseArray::new();
+        for (idx, value) in data.iter() {
+            sparse_array.set(*idx, value);
+        }
+
+        let (to_remove, to_set) = data.split_at(data.len() / 2);
+        for (idx, _) in to_remove.iter() {
+            sparse_array.remove(*idx);
+        }
+
+        to_remove
+            .iter()
+            .all(|(idx, _)| sparse_array.get(*idx) == None)
+            && to_set
+                .iter()
+                .all(|(idx, value)| sparse_array.get(*idx) == Some(&value))
+    }
+}

--- a/sparse-array/src/sparse_array.rs
+++ b/sparse-array/src/sparse_array.rs
@@ -3,10 +3,78 @@ use crate::bitmap::BitmapIndex;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SparseArray<V> {
     index: BitmapIndex,
-    data: Vec<V>,
+    data: Box<[V]>,
 }
 
 impl<V> SparseArray<V> {
+    pub fn new() -> Self {
+        Self {
+            index: BitmapIndex::new(),
+            data: Box::new([]),
+        }
+    }
+
+    pub fn get(&self, idx: u8) -> Option<&V> {
+        self.index
+            .get_real_index(idx)
+            .map(|idx_real| self.data.get(idx_real as usize).unwrap())
+    }
+
+    pub fn set(self, idx: u8, value: V) -> Self {
+        match self.index.get_real_index(idx) {
+            Some(idx_real) => {
+                let mut r = self;
+                r.data[idx_real as usize] = value;
+                r
+            }
+            None => {
+                let mut index = self.index;
+                index.set_index(idx);
+                let idx_real = index.get_real_index(idx).unwrap();
+                let mut data = self.data.into_vec();
+                data.insert(idx_real as usize, value);
+                Self {
+                    index,
+                    data: data.into_boxed_slice(),
+                }
+            }
+        }
+    }
+
+    pub fn remove(self, idx: u8) -> (Self, Option<V>) {
+        let mut data = self.data.into_vec();
+        let v = self
+            .index
+            .get_real_index(idx)
+            .map(|idx_real| data.remove(idx_real as usize));
+        let mut index = self.index;
+        index.remove_index(idx);
+        let r = Self {
+            index,
+            data: data.into_boxed_slice(),
+        };
+        (r, v)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.index.is_empty()
+    }
+
+    pub fn contains_key(&self, idx: u8) -> bool {
+        self.index.get_index(idx)
+    }
+
+    pub fn iter(&self) -> SparseArrayIter<V> {
+        SparseArrayIter::new(&self)
+    }
+}
+
+pub struct SparseArrayBuilder<V> {
+    index: BitmapIndex,
+    data: Vec<V>,
+}
+
+impl<V> SparseArrayBuilder<V> {
     pub fn new() -> Self {
         Self {
             index: BitmapIndex::new(),
@@ -21,12 +89,6 @@ impl<V> SparseArray<V> {
         }
     }
 
-    pub fn get(&self, idx: u8) -> Option<&V> {
-        self.index
-            .get_real_index(idx)
-            .map(|idx_real| self.data.get(idx_real as usize).unwrap())
-    }
-
     pub fn set(&mut self, idx: u8, value: V) {
         match self.index.get_real_index(idx) {
             Some(idx_real) => self.data[idx_real as usize] = value,
@@ -38,25 +100,11 @@ impl<V> SparseArray<V> {
         }
     }
 
-    pub fn remove(&mut self, idx: u8) -> Option<V> {
-        let r = self
-            .index
-            .get_real_index(idx)
-            .map(|idx_real| self.data.remove(idx_real as usize));
-        self.index.remove_index(idx);
-        r
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.index.is_empty()
-    }
-
-    pub fn contains_key(&self, idx: u8) -> bool {
-        self.index.get_index(idx)
-    }
-
-    pub fn iter(&self) -> SparseArrayIter<V> {
-        SparseArrayIter::new(&self)
+    pub fn build(self) -> SparseArray<V> {
+        SparseArray {
+            index: self.index,
+            data: self.data.into_boxed_slice(),
+        }
     }
 }
 
@@ -100,7 +148,7 @@ mod tests {
 
         let mut sparse_array = SparseArray::new();
         for (idx, value) in data.iter() {
-            sparse_array.set(*idx, value);
+            sparse_array = sparse_array.set(*idx, value);
         }
 
         data.iter()
@@ -115,12 +163,12 @@ mod tests {
 
         let mut sparse_array = SparseArray::new();
         for (idx, value) in data.iter() {
-            sparse_array.set(*idx, value);
+            sparse_array = sparse_array.set(*idx, value);
         }
 
         let (to_remove, to_set) = data.split_at(data.len() / 2);
         for (idx, _) in to_remove.iter() {
-            sparse_array.remove(*idx);
+            sparse_array = sparse_array.remove(*idx).0;
         }
 
         to_remove


### PR DESCRIPTION
- Implement `SparseArray`.
- Implement wrapper (`FastSparse`) on top of sparse array that allows to share data between its instances and thus allows for faster clones.

Data under `FastSparseArray` is shared until `set` or `shrink` function is called. It is also possible to avoid copying the underlying structure when calling `set`, but actual use cases do not require that.

**TBD**

- [x] Faster popcount (utilize `POPCNT` instruction)
- [x] Faster trailing zeros count (`TZCNT`)
- [ ] Special bitmaps for small arrays (8, 16, ... elements) #157 

Resolves #52 