### PR TITLE
[Tests]Repair ledger tests

### DIFF
--- a/chain-impl-mockchain/src/certificate/test.rs
+++ b/chain-impl-mockchain/src/certificate/test.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::accounting::account::DelegationType;
 use crate::leadership::genesis::GenesisPraosLeader;
 use crate::rewards::TaxType;
+use chain_core::mempack::{ReadBuf, Readable};
 use chain_crypto::{testing, Ed25519};
-use chain_core::mempack::{Readable, ReadBuf};
 use chain_time::DurationSeconds;
 use quickcheck::{Arbitrary, Gen, TestResult};
 use quickcheck_macros::quickcheck;
@@ -41,7 +41,7 @@ impl Arbitrary for PoolOwnersSigned {
         if signatoree == 0 {
             signatoree = 1;
         }
-        
+
         let mut signatures = Vec::new();
         for i in 0..signatoree {
             let s = Arbitrary::arbitrary(g);

--- a/chain-impl-mockchain/src/fragment/mod.rs
+++ b/chain-impl-mockchain/src/fragment/mod.rs
@@ -216,7 +216,6 @@ mod test {
         }
     }
 
-
     #[quickcheck]
     fn fragment_serialization_bijection(b: Fragment) -> TestResult {
         let b_got = Fragment::from_raw(&b.to_raw()).unwrap();

--- a/chain-impl-mockchain/src/ledger/iter.rs
+++ b/chain-impl-mockchain/src/ledger/iter.rs
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     pub fn iterate() {
         let testledger = LedgerBuilder::from_config(ConfigBuilder::new(0))
-            .faucet(Value(42000))
+            .faucet_value(Value(42000))
             .build()
             .expect("cannot build test ledger");
 

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -399,7 +399,8 @@ impl Ledger {
                             .account_id
                             .to_single_account()
                             .ok_or(Error::AccountIdentifierInvalid)?;
-                            signature.verify_slice(&account_pk.into(), &tx.transaction_binding_auth_data())
+                        signature
+                            .verify_slice(&account_pk.into(), &tx.transaction_binding_auth_data())
                     }
                     AccountBindingSignature::Multi(_) => {
                         // TODO
@@ -414,7 +415,6 @@ impl Ledger {
                 let (new_ledger_, _fee) =
                     new_ledger.apply_transaction(&fragment_id, &tx, &ledger_params)?;
                 new_ledger = new_ledger_.apply_stake_delegation(&payload)?;
-
             }
             Fragment::PoolRegistration(tx) => {
                 let tx = tx.as_slice();

--- a/chain-impl-mockchain/src/ledger/tests/mod.rs
+++ b/chain-impl-mockchain/src/ledger/tests/mod.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 mod macros;
-//pub mod discrimination_tests;
-//pub mod initial_funds_tests;
-//pub mod ledger_tests;
+pub mod discrimination_tests;
+pub mod initial_funds_tests;
+pub mod ledger_tests;
 pub mod update_tests;
 pub mod transaction_tests;

--- a/chain-impl-mockchain/src/ledger/tests/transaction_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/transaction_tests.rs
@@ -17,8 +17,8 @@ use chain_addr::Discrimination;
 
 #[test]
 pub fn transaction_fail_when_255_outputs() {
-    let mut testledger = LedgerBuilder::from_config(ConfigBuilder::new(0))
-        .faucet(Value(1000))
+    let mut test_ledger = LedgerBuilder::from_config(ConfigBuilder::new(0))
+        .faucet_value(Value(1000))
         .build()
         .expect("cannot build test ledger");
 
@@ -27,8 +27,8 @@ pub fn transaction_fail_when_255_outputs() {
     let output = Output { address: receiver.address, value: Value(1) };
     let outputs : Vec<_> = std::iter::repeat(output).take(255).collect();
 
-    let fragment = TestTxBuilder::new(&testledger.block0_hash)
-        .move_to_outputs_from_faucet(&mut testledger, &outputs).get_fragment();
+    let fragment = TestTxBuilder::new(&test_ledger.block0_hash)
+        .move_to_outputs_from_faucet(&mut test_ledger, &outputs).get_fragment();
 
     assert_err!(
         TransactionMalformed {
@@ -37,30 +37,30 @@ pub fn transaction_fail_when_255_outputs() {
                 actual: 255
             }
         },
-        testledger.apply_transaction(fragment)
+        test_ledger.apply_transaction(fragment)
     );
 }
 
 #[test]
 pub fn duplicated_account_transaction() {
-    let mut testledger = LedgerBuilder::from_config(ConfigBuilder::new(0))
-        .faucet(Value(1000))
+    let mut test_ledger = LedgerBuilder::from_config(ConfigBuilder::new(0))
+        .faucet_value(Value(1000))
         .build()
         .expect("cannot build test ledger");
 
     let receiver = AddressData::utxo(Discrimination::Test);
 
-    let fragment = TestTxBuilder::new(&testledger.block0_hash)
-        .move_from_faucet(&mut testledger, &receiver.address, Value(100)).get_fragment();
+    let fragment = TestTxBuilder::new(&test_ledger.block0_hash)
+        .move_from_faucet(&mut test_ledger, &receiver.address, &Value(100)).get_fragment();
     let fragment2 = fragment.clone();
-    let result = testledger.apply_transaction(fragment);
+    let result = test_ledger.apply_transaction(fragment);
 
     match result {
         Err(err) => panic!("first transaction should be succesful but {}", err),
-        Ok(()) => {
+        Ok(_) => {
             assert_err_match!(
-                ledger::Error::AccountInvalidSignature{..},
-                testledger.apply_transaction(fragment2)
+                &ledger::Error::AccountInvalidSignature{..},
+                test_ledger.apply_transaction(fragment2)
             );
         }
     }
@@ -72,21 +72,21 @@ pub fn transaction_nonexisting_account_input() {
 
     let mut kdb = KeysDb::new(TestCryptoGen(0));
 
-    let mut testledger = LedgerBuilder::from_config(ConfigBuilder::new(0))
-        .faucet(Value(1000))
+    let mut test_ledger = LedgerBuilder::from_config(ConfigBuilder::new(0))
+        .faucet_value(Value(1000))
         .build()
         .expect("cannot build test ledger");
 
     let unregistered_account = kdb.new_account_address();
     let value = Value(10);
-    let fragment = TestTxBuilder::new(&testledger.block0_hash)
-        .inputs_to_outputs(&mut kdb, &mut testledger,
+    let fragment = TestTxBuilder::new(&test_ledger.block0_hash)
+        .inputs_to_outputs(&mut kdb, &mut test_ledger,
             &[Output { address: unregistered_account, value }],
             &[Output { address: receiver.address, value }])
         .get_fragment();
 
     assert_err!(
         Account { source: NonExistent },
-        testledger.apply_transaction(fragment)
+        test_ledger.apply_transaction(fragment)
     );
 }

--- a/chain-impl-mockchain/src/multisig/mod.rs
+++ b/chain-impl-mockchain/src/multisig/mod.rs
@@ -18,8 +18,8 @@ mod test {
     use crate::transaction::{TransactionSignData, TransactionSignDataHash};
     use crate::{account, key};
     use chain_crypto::{PublicKey, SecretKey};
-    use rand_core::{CryptoRng, RngCore};
     use quickcheck::{Arbitrary, Gen};
+    use rand_core::{CryptoRng, RngCore};
 
     fn make_keypair<R: RngCore + CryptoRng>(
         rng: &mut R,

--- a/chain-impl-mockchain/src/testing/builders/tx_builder.rs
+++ b/chain-impl-mockchain/src/testing/builders/tx_builder.rs
@@ -2,12 +2,13 @@ use crate::{
     account::SpendingCounter,
     fragment::{Fragment, FragmentId},
     header::HeaderId,
-    testing::{ledger::TestLedger, KeysDb},
+    testing::{ledger::TestLedger, KeysDb, data::address::AddressDataValue},
     transaction::{
         Input, InputEnum, NoExtra, Output, Transaction, TxBuilder, UnspecifiedAccountIdentifier,
         UtxoPointer, Witness,
     },
     value::Value,
+    fee::FeeAlgorithm
 };
 use chain_addr::{Address, Kind};
 
@@ -41,16 +42,18 @@ impl TestTxBuilder {
         }
     }
 
-    pub fn move_from_faucet(self, testledger: &mut TestLedger, destination: &Address, value: Value) -> TestTx {
-        let faucet = testledger.faucet.as_mut().expect("test ledger with no faucet configured");
-        assert_eq!(faucet.block0_hash, self.block0_hash);
-        let inputs = vec![faucet.get_input_of(value)];
-        let outputs = vec![Output { address: destination.clone(), value: value }];
+    pub fn move_from_faucet(self, test_ledger: &mut TestLedger, destination: &Address, value: &Value) -> TestTx {
+        assert_eq!(test_ledger.faucets.len(),1,"method can be used only for single faucet ledger");
+        let mut faucet = test_ledger.faucets.iter().cloned().next().as_mut().expect("test ledger with no faucet configured").clone();
+        let fee = test_ledger.fee().fees_for_inputs_outputs(1u8,1u8);
+        let output_value = (*value - fee).expect("input value is smaller than fee");
+        let inputs = vec![faucet.clone().make_input_of(test_ledger.find_utxo_for_address(&faucet.clone().into()),&value)];
+        let outputs = vec![Output { address: destination.clone(), value: output_value }];
         let tx_builder = TxBuilder::new()
             .set_payload(&NoExtra)
             .set_ios(&inputs, &outputs);
 
-        let witness = faucet.make_witness(tx_builder.get_auth_data_for_witness());
+        let witness = faucet.make_witness(&self.block0_hash,tx_builder.get_auth_data_for_witness());
         let witnesses = vec![witness];
 
         let tx = tx_builder
@@ -59,28 +62,62 @@ impl TestTxBuilder {
         TestTx { tx }
     }
 
-    pub fn move_to_outputs_from_faucet(self, testledger: &mut TestLedger, destination: &[Output<Address>]) -> TestTx {
-        let faucet = testledger.faucet.as_mut().expect("test ledger with no faucet configured");
-        assert_eq!(faucet.block0_hash, self.block0_hash);
+    pub fn move_to_outputs_from_faucet(self, test_ledger: &mut TestLedger, destination: &[Output<Address>]) -> TestTx {
+        assert_eq!(test_ledger.faucets.len(),1,"method can be used only for single faucet ledger");
+        let mut faucet = test_ledger.faucets.iter().next().as_mut().expect("test ledger with no faucet configured").clone();
         let input_val = Value::sum(destination.iter().map(|o| o.value)).unwrap();
-        let inputs = vec![faucet.get_input_of(input_val)];
+        let inputs = vec![faucet.clone().make_input_of(test_ledger.find_utxo_for_address(&faucet.clone().into()),&input_val)];
         let tx_builder = TxBuilder::new()
             .set_payload(&NoExtra)
             .set_ios(&inputs, &destination);
 
-        let witness = faucet.make_witness(tx_builder.get_auth_data_for_witness());
+        let witness = faucet.make_witness(&self.block0_hash,tx_builder.get_auth_data_for_witness());
         let witnesses = vec![witness];
 
         let tx = tx_builder
             .set_witnesses(&witnesses)
             .set_payload_auth(&());
         TestTx { tx }
+    }
+
+    pub fn move_all_funds(self, test_ledger: &mut TestLedger, source: &AddressDataValue, destination: &AddressDataValue) -> TestTx {
+        let mut keys_db = KeysDb::empty();
+        keys_db.add_key(source.private_key());
+        keys_db.add_key(destination.private_key());
+        self.move_funds(test_ledger,&source,&destination,&source.value)
+    }
+
+    pub fn move_funds(self, test_ledger: &mut TestLedger, source: &AddressDataValue, destination: &AddressDataValue, value: &Value) -> TestTx {
+        let mut keys_db = KeysDb::empty();
+        keys_db.add_key(source.private_key());
+        keys_db.add_key(destination.private_key());
+
+        let fee = test_ledger.fee().fees_for_inputs_outputs(1u8,1u8);
+        let output_value = (*value - fee).expect("input value is smaller than fee");
+
+        self.inputs_to_outputs(&keys_db,test_ledger,&[source.make_output_of(&value)],&[destination.make_output_of(&output_value)])
+    }
+    
+    pub fn move_funds_multiple(self,test_ledger: &mut TestLedger, sources: &Vec<AddressDataValue>, destinations: &Vec<AddressDataValue>) -> TestTx {
+        let mut keys_db = KeysDb::empty();
+
+        for source in sources {
+            keys_db.add_key(source.private_key())
+        }
+        for destination in destinations {
+            keys_db.add_key(destination.private_key())
+        }
+
+        let source_outputs = sources.iter().cloned().map(|x| x.make_output()).collect::<Vec<Output<Address>>>();
+        let destination_outputs = destinations.iter().cloned().map(|x| x.make_output()).collect::<Vec<Output<Address>>>();
+
+        self.inputs_to_outputs(&keys_db,test_ledger,&source_outputs,&destination_outputs)
     }
 
     pub fn inputs_to_outputs(
         self,
         kdb: &KeysDb,
-        testledger: &mut TestLedger,
+        test_ledger: &mut TestLedger,
         sources: &[Output<Address>],
         destination: &[Output<Address>],
     ) -> TestTx {
@@ -89,7 +126,7 @@ impl TestTxBuilder {
             .map(|out| {
                 match out.address.kind() {
                     Kind::Single(_) | Kind::Group(..) => {
-                        let fragments = testledger.utxodb.find_fragments(&out);
+                        let fragments = test_ledger.utxodb.find_fragments(&out);
 
                         if fragments.len() == 0 {
                             panic!("trying to do a inputs_to_outputs with unknown single utxo")
@@ -136,7 +173,7 @@ impl TestTxBuilder {
                         Witness::new_account(&self.block0_hash, &auth_data_hash, &counter, sk)
                     }
                     InputEnum::UtxoInput(utxopointer) => {
-                        match testledger.utxodb.get(&(utxopointer.transaction_id, utxopointer.output_index)) {
+                        match test_ledger.utxodb.get(&(utxopointer.transaction_id, utxopointer.output_index)) {
                             None => {
                                 panic!("cannot find utxo input")
                             },

--- a/chain-impl-mockchain/src/testing/data/keys.rs
+++ b/chain-impl-mockchain/src/testing/data/keys.rs
@@ -12,12 +12,21 @@ pub struct KeysDb {
 
 impl KeysDb {
     /// Create a new keys DB
-    pub fn new(tcg: TestCryptoGen) -> KeysDb {
+    pub fn new(tcg: TestCryptoGen) -> Self {
         KeysDb {
             rng: 0,
             tcg: tcg,
             ed25519: HashMap::new(),
         }
+    }
+
+    pub fn empty() -> Self {
+       KeysDb::new(TestCryptoGen(0))
+    }
+
+    pub fn add_key(&mut self, sk: EitherEd25519SecretKey) {
+        let pk = sk.to_public();
+        self.ed25519.insert(pk,sk);
     }
 
     /// Create a new Ed25519 and record it

--- a/chain-impl-mockchain/src/testing/data/wallet.rs
+++ b/chain-impl-mockchain/src/testing/data/wallet.rs
@@ -45,11 +45,11 @@ impl Wallet {
         self.account.make_output()
     }
 
-    pub fn make_output_with_value(&self, value: Value) -> Output<Address> {
-        self.account.make_output_with_value(value)
+    pub fn make_output_with_value(&self, value: &Value) -> Output<Address> {
+        self.account.make_output_with_value(&value)
     }
 
-    pub fn make_input_with_value(&self, value: Value) -> Input {
+    pub fn make_input_with_value(&self, value: &Value) -> Input {
         self.account.make_input_with_value(None,value)
     }
 

--- a/chain-impl-mockchain/src/testing/ledger.rs
+++ b/chain-impl-mockchain/src/testing/ledger.rs
@@ -242,7 +242,7 @@ impl LedgerBuilder {
 
             // TODO subdivide utxo_declaration in group of 254 elements
             // and repeatdly create fragment
-            assert!(self.utxo_declaration.len() > 254);
+            assert!(self.utxo_declaration.len() < 254);
             let group = self.utxo_declaration;
             {
                 let tx = TxBuilder::new()
@@ -310,5 +310,31 @@ impl TestLedger {
                 panic!("test ledger apply transaction only supports transaction type for now")
             }
         }
+    }
+
+    pub fn total_funds(&self) -> Value {
+        let utxo_total = Value(self.ledger.utxos().map(|x| x.output.value.0).sum::<u64>());
+        let accounts_total = self.ledger.accounts().get_total_value().unwrap();
+        (utxo_total + accounts_total).unwrap()
+    }
+
+    pub fn find_utxo_for_address<'a>(
+        &'a self,
+        address_data: &AddressData
+    ) -> Option<Entry<'a, Address>> {
+        let entry = self.utxos().find(|x| x.output.address == address_data.address);
+        entry
+    }
+
+    pub fn accounts(&self) -> &AccountLedger {
+        &self.ledger.accounts()
+    }
+
+    pub fn utxos<'a>(&'a self) -> Iter<'a, Address> {
+        self.ledger.utxos()
+    }
+
+    pub fn fee(&self) -> LinearFee {
+        self.parameters.fees
     }
 }

--- a/chain-impl-mockchain/src/testing/ledger.rs
+++ b/chain-impl-mockchain/src/testing/ledger.rs
@@ -1,22 +1,20 @@
 use crate::{
-    account::{AccountAlg, SpendingCounter},
+    account::{AccountAlg,Ledger as AccountLedger},
     block::{ConsensusVersion, HeaderId},
     config::ConfigParam,
     fee::LinearFee,
     fragment::{config::ConfigParams, Fragment, FragmentId},
-    key::EitherEd25519SecretKey,
     leadership::bft::LeaderId,
     ledger::{Error, Ledger, LedgerParameters},
     milli::Milli,
-    transaction::{Input, Output, TxBuilder, TransactionAuthData, Witness},
+    transaction::{Output, TxBuilder},
     value::Value,
+    utxo::{Entry,Iter},
+    testing::data::address::{AddressData,AddressDataValue}
 };
 use chain_addr::{Address, Discrimination};
 use chain_crypto::*;
-use std::vec::Vec;
 use std::collections::HashMap;
-
-//use crate::testing::{data::AddressDataValue};
 
 #[derive(Clone)]
 pub struct ConfigBuilder {
@@ -114,36 +112,9 @@ pub struct LedgerBuilder {
     cfg_builder: ConfigBuilder,
     cfg_params: ConfigParams,
     fragments: Vec<Fragment>,
-    faucet_value: Option<Value>,
+    faucets: Vec<AddressDataValue>,
     utxo_declaration: Vec<UtxoDeclaration>,
     seed: u64,
-}
-
-pub struct Faucet {
-    pub block0_hash: HeaderId,
-    st: SpendingCounter,
-    discrimination: Discrimination,
-    secret_key: SecretKey<AccountAlg>,
-    pub initial_value: Value,
-}
-
-impl Faucet {
-    pub fn get_address(&self) -> Address {
-        let pk = self.secret_key.to_public();
-        Address(self.discrimination, chain_addr::Kind::Account(pk))
-    }
-
-    pub fn get_input_of(&self, value: Value) -> Input {
-        Input::from_account_public_key(self.secret_key.to_public(), value)
-    }
-
-    pub fn make_witness<'a>(&mut self, tad: TransactionAuthData<'a>) -> Witness {
-        let sc = self.st;
-        self.st = self.st.increment().expect("faucet use more than expected");
-
-        let sk = EitherEd25519SecretKey::Normal(self.secret_key.clone());
-        Witness::new_account(&self.block0_hash, &tad.hash(), &sc, &sk)
-    }
 }
 
 pub type UtxoDeclaration = Output<Address>;
@@ -173,7 +144,7 @@ impl LedgerBuilder {
             seed: cfg_builder.seed,
             cfg_builder,
             cfg_params,
-            faucet_value: None,
+            faucets: Vec::new(),
             utxo_declaration: Vec::new(),
             fragments: Vec::new(),
         }
@@ -225,8 +196,34 @@ impl LedgerBuilder {
         self.fragment(Fragment::Transaction(tx))
     }
 
-    pub fn faucet(mut self, faucet_value: Value) -> Self {
-        self.faucet_value = Some(faucet_value);
+    pub fn faucet_value(mut self, value: Value) -> Self {
+        self.faucets.push(AddressDataValue::account(self.cfg_builder.discrimination,value));
+        self
+    }
+
+    pub fn initial_fund(mut self, fund: &AddressDataValue) -> Self {
+        if fund.is_utxo() {
+            self = self.utxos(&[fund.make_output()]);
+        } else {
+            self = self.faucet(&fund);
+        }
+        self
+    }
+
+    pub fn initial_funds(mut self, funds: &Vec<AddressDataValue>) -> Self {
+        for fund in funds {
+            self = self.initial_fund(fund);
+        }
+        self
+    }
+
+    pub fn faucet(mut self, faucet: &AddressDataValue) -> Self {
+        self.faucets.push(faucet.clone());
+        self
+    }
+
+    pub fn faucets(mut self, faucets: &Vec<AddressDataValue>) -> Self {
+        self.faucets.extend(faucets.iter().cloned());
         self
     }
 
@@ -237,17 +234,8 @@ impl LedgerBuilder {
 
     pub fn build(mut self) -> Result<TestLedger, Error> {
         let block0_hash = HeaderId::hash_bytes(&[1, 2, 3]);
-
-        // push the faucet
-        let faucet = match self.faucet_value {
-            None => None,
-            Some(val) => {
-                let secret_key = self.account_secret_key();
-                let faucet = Faucet { block0_hash, st: SpendingCounter::zero(), discrimination: self.cfg_builder.discrimination, secret_key, initial_value: val };
-                self = self.prefill_address(faucet.get_address(), val);
-                Some(faucet) 
-            }
-        };
+        let outputs: Vec<Output<Address>> = self.faucets.iter().map(|x| x.make_output()).collect();
+        self = self.prefill_outputs(&outputs);
 
         let utxodb = if self.utxo_declaration.len() > 0 {
             let mut db = HashMap::new();
@@ -283,10 +271,11 @@ impl LedgerBuilder {
         fragments.push(Fragment::Initial(self.cfg_params));
         fragments.extend_from_slice(&self.fragments);
 
+        let faucets = self.faucets.clone();
         Ledger::new(block0_hash, &fragments).map(|ledger| {
             let parameters = ledger.get_ledger_parameters();
             TestLedger {
-                cfg, faucet, ledger, block0_hash, utxodb, parameters,
+                cfg, faucets, ledger, block0_hash, utxodb, parameters,
             }
         })
     }
@@ -295,7 +284,7 @@ impl LedgerBuilder {
 pub struct TestLedger {
     pub block0_hash: HeaderId, 
     pub cfg: ConfigParams,
-    pub faucet: Option<Faucet>,
+    pub faucets: Vec<AddressDataValue>,
     pub ledger: Ledger,
     pub parameters: LedgerParameters,
     pub utxodb: UtxoDb,

--- a/chain-impl-mockchain/src/testing/ledger.rs
+++ b/chain-impl-mockchain/src/testing/ledger.rs
@@ -10,7 +10,7 @@ use crate::{
     transaction::{Output, TxBuilder},
     value::Value,
     utxo::{Entry,Iter},
-    testing::data::address::{AddressData,AddressDataValue}
+    testing::data::{AddressData,AddressDataValue}
 };
 use chain_addr::{Address, Discrimination};
 use chain_crypto::*;

--- a/chain-impl-mockchain/src/testing/mod.rs
+++ b/chain-impl-mockchain/src/testing/mod.rs
@@ -8,7 +8,7 @@ pub use arbitrary::*;
 pub use builders::*;
 pub use cert_signer::CertificateSigner;
 pub use data::KeysDb;
-pub use ledger::{ConfigBuilder, LedgerBuilder, Faucet, TestLedger, UtxoDb};
+pub use ledger::{ConfigBuilder, LedgerBuilder, TestLedger, UtxoDb};
 
 pub use chain_crypto::testing::TestCryptoGen;
 

--- a/chain-impl-mockchain/src/testing/verifiers/ledger_verifier.rs
+++ b/chain-impl-mockchain/src/testing/verifiers/ledger_verifier.rs
@@ -113,7 +113,7 @@ pub struct LedgerStateVerifier {
                 .ledger
                 .utxos
                 .iter()
-                .find(|x| *x.output == address_data.make_output(value));
+                .find(|x| *x.output == address_data.make_output(&value));
             match value == Value::zero() {
                 true => {
                     assert!(utxo.is_none());

--- a/chain-impl-mockchain/src/transaction/element.rs
+++ b/chain-impl-mockchain/src/transaction/element.rs
@@ -57,15 +57,16 @@ pub enum AccountBindingSignature {
 }
 
 impl AccountBindingSignature {
-    pub fn new_single<'a>(sk: &EitherEd25519SecretKey, data: &TransactionBindingAuthData<'a>) -> Self {
+    pub fn new_single<'a>(
+        sk: &EitherEd25519SecretKey,
+        data: &TransactionBindingAuthData<'a>,
+    ) -> Self {
         AccountBindingSignature::Single(SingleAccountBindingSignature::new(sk, data))
     }
 
     pub fn serialize_in(&self, bb: ByteBuilder<Self>) -> ByteBuilder<Self> {
         match self {
-            AccountBindingSignature::Single(sig) => {
-                bb.u8(1).bytes(sig.as_ref())
-            }
+            AccountBindingSignature::Single(sig) => bb.u8(1).bytes(sig.as_ref()),
             AccountBindingSignature::Multi(_) => {
                 bb.u8(2);
                 unimplemented!()
@@ -81,12 +82,8 @@ impl Readable for AccountBindingSignature {
                 let sig = deserialize_signature(buf).map(SingleAccountBindingSignature)?;
                 Ok(AccountBindingSignature::Single(sig))
             }
-            2 => {
-                unimplemented!()
-            }
-            n => {
-                Err(ReadError::UnknownTag(n as u32))
-            }
+            2 => unimplemented!(),
+            n => Err(ReadError::UnknownTag(n as u32)),
         }
     }
 }

--- a/chain-impl-mockchain/src/utxo.rs
+++ b/chain-impl-mockchain/src/utxo.rs
@@ -323,7 +323,7 @@ mod tests {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
             let size = usize::arbitrary(g) % 50 + 1;
             let iter = iter::from_fn(|| {
-                Some(AddressData::arbitrary(g).make_output(AverageValue::arbitrary(g).into()))
+                Some(AddressData::arbitrary(g).make_output(&AverageValue::arbitrary(g).into()))
             })
             .enumerate()
             .take(size);
@@ -417,8 +417,8 @@ mod tests {
         let mut ledger = Ledger::new();
         let first_fragment_id = TestGen::hash();
         let second_fragment_id = TestGen::hash();
-        let first_address_data = AddressData::utxo(Discrimination::Test).make_output(Value(100));
-        let second_address_data = AddressData::utxo(Discrimination::Test).make_output(Value(100));
+        let first_address_data = AddressData::utxo(Discrimination::Test).make_output(&Value(100));
+        let second_address_data = AddressData::utxo(Discrimination::Test).make_output(&Value(100));
         let first_index = 0 as u8;
         let second_index = 1 as u8;
 


### PR DESCRIPTION
Repaired tests in `ledger/tests` modules after breaking changes. Mainly reused AddressDataValue struct instead of faucet, but preserved overall idea. Added some utils method to TestLedger and transaction builder. 