### PR TITLE
Pass old_utxo key as reference

### DIFF
--- a/chain-impl-mockchain/src/transaction/witness.rs
+++ b/chain-impl-mockchain/src/transaction/witness.rs
@@ -131,7 +131,7 @@ impl Witness {
     pub fn new_old_utxo(
         block0: &HeaderId,
         sign_data_hash: &TransactionSignDataHash,
-        secret_key: SecretKey<Ed25519Bip32>,
+        secret_key: &SecretKey<Ed25519Bip32>,
     ) -> Self {
         let wud = WitnessUtxoData::new(block0, sign_data_hash);
         Witness::OldUtxo(secret_key.to_public(), secret_key.sign(&wud))


### PR DESCRIPTION
For some reason this is the only key that is not passed as a reference so I changed it so it's the same as all the others