### PR TITLE
Network client API improvements

### DIFF
--- a/network-core/src/client/block.rs
+++ b/network-core/src/client/block.rs
@@ -105,7 +105,7 @@ pub trait BlockService: P2pService {
     /// a `NotFound` error.
     fn push_headers<S>(&mut self, headers: S) -> Self::PushHeadersFuture
     where
-        S: Stream<Item = <Self::Block as HasHeader>::Header> + Send + 'static;
+        S: Stream<Item = <Self::Block as HasHeader>::Header, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by method `upload_blocks`.
     type UploadBlocksFuture: Future<Item = (), Error = Error>;
@@ -115,7 +115,7 @@ pub trait BlockService: P2pService {
     /// The blocks to send are retrieved asynchronously from the passed stream.
     fn upload_blocks<S>(&mut self, blocks: S) -> Self::UploadBlocksFuture
     where
-        S: Stream<Item = Self::Block> + Send + 'static;
+        S: Stream<Item = Self::Block, Error = Error> + Send + 'static;
 
     /// The type of asynchronous futures returned by method `block_subscription`.
     ///
@@ -137,7 +137,7 @@ pub trait BlockService: P2pService {
     /// as a long-lived subscription handle.
     fn block_subscription<S>(&mut self, outbound: S) -> Self::BlockSubscriptionFuture
     where
-        S: Stream<Item = <Self::Block as HasHeader>::Header> + Send + 'static;
+        S: Stream<Item = <Self::Block as HasHeader>::Header, Error = Error> + Send + 'static;
 }
 
 /// An error that the future returned by `BlockService::handshake` can

--- a/network-core/src/client/fragment.rs
+++ b/network-core/src/client/fragment.rs
@@ -46,5 +46,5 @@ pub trait FragmentService: P2pService {
     /// as a long-lived subscription handle.
     fn fragment_subscription<S>(&mut self, outbound: S) -> Self::FragmentSubscriptionFuture
     where
-        S: Stream<Item = Self::Fragment> + Send + 'static;
+        S: Stream<Item = Self::Fragment, Error = Error> + Send + 'static;
 }

--- a/network-core/src/client/gossip.rs
+++ b/network-core/src/client/gossip.rs
@@ -29,5 +29,5 @@ pub trait GossipService: P2pService {
     /// as a long-lived subscription handle.
     fn gossip_subscription<S>(&mut self, outbound: S) -> Self::GossipSubscriptionFuture
     where
-        S: Stream<Item = Gossip<Self::Node>> + Send + 'static;
+        S: Stream<Item = Gossip<Self::Node>, Error = Error> + Send + 'static;
 }

--- a/network-core/src/error.rs
+++ b/network-core/src/error.rs
@@ -35,6 +35,10 @@ impl Error {
         }
     }
 
+    pub fn unimplemented() -> Self {
+        Error::new(Code::Unimplemented, "not yet implemented")
+    }
+
     pub fn code(&self) -> Code {
         self.code
     }

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -216,7 +216,7 @@ where
 
     fn push_headers<S>(&mut self, headers: S) -> Self::PushHeadersFuture
     where
-        S: Stream<Item = P::Header> + Send + 'static,
+        S: Stream<Item = P::Header, Error = core_error::Error> + Send + 'static,
     {
         let stream = RequestStream::new(headers);
         let req = Request::new(stream);
@@ -226,7 +226,7 @@ where
 
     fn upload_blocks<S>(&mut self, blocks: S) -> Self::UploadBlocksFuture
     where
-        S: Stream<Item = P::Block> + Send + 'static,
+        S: Stream<Item = P::Block, Error = core_error::Error> + Send + 'static,
     {
         let rs = RequestStream::new(blocks);
         let req = Request::new(rs);
@@ -236,7 +236,7 @@ where
 
     fn block_subscription<Out>(&mut self, outbound: Out) -> Self::BlockSubscriptionFuture
     where
-        Out: Stream<Item = P::Header> + Send + 'static,
+        Out: Stream<Item = P::Header, Error = core_error::Error> + Send + 'static,
     {
         let req = self.new_subscription_request(outbound);
         let future = self.service.block_subscription(req);
@@ -266,7 +266,7 @@ where
 
     fn fragment_subscription<Out>(&mut self, outbound: Out) -> Self::FragmentSubscriptionFuture
     where
-        Out: Stream<Item = P::Fragment> + Send + 'static,
+        Out: Stream<Item = P::Fragment, Error = core_error::Error> + Send + 'static,
     {
         let req = self.new_subscription_request(outbound);
         let future = self.service.fragment_subscription(req);
@@ -285,7 +285,7 @@ where
 
     fn gossip_subscription<Out>(&mut self, outbound: Out) -> Self::GossipSubscriptionFuture
     where
-        Out: Stream<Item = Gossip<P::Node>> + Send + 'static,
+        Out: Stream<Item = Gossip<P::Node>, Error = core_error::Error> + Send + 'static,
     {
         let req = self.new_subscription_request(outbound);
         let future = self.service.gossip_subscription(req);

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -1,25 +1,27 @@
 mod connect;
 mod handshake;
 
+pub mod client_streaming;
+pub mod server_streaming;
+pub mod subscription;
+pub mod unary;
+
+use client_streaming::RequestStream;
+
 use crate::{
-    convert::{
-        decode_node_id, encode_node_id, error_from_grpc, serialize_to_bytes,
-        serialize_to_repeated_bytes, FromProtobuf, IntoProtobuf,
-    },
+    convert::{encode_node_id, error_from_grpc, serialize_to_bytes, serialize_to_repeated_bytes},
     gen::{self, node::client as gen_client},
 };
 
 use chain_core::property;
 use network_core::client::{BlockService, Client, FragmentService, GossipService, P2pService};
 use network_core::error as core_error;
-use network_core::gossip::{self, Gossip, NodeId};
+use network_core::gossip::{self, Gossip};
 use network_core::subscription::BlockEvent;
 
 use futures::prelude::*;
-use tower_grpc::{BoxBody, Code, Request, Status, Streaming};
+use tower_grpc::{BoxBody, Request};
 use tower_request_modifier::{self, RequestModifier};
-
-use std::marker::PhantomData;
 
 pub use connect::{Connect, ConnectError, ConnectFuture};
 pub use handshake::HandshakeFuture;
@@ -112,199 +114,6 @@ where
     node_id: Option<<P::Node as gossip::Node>::Id>,
 }
 
-type GrpcUnaryFuture<R> = tower_grpc::client::unary::ResponseFuture<
-    R,
-    tower_hyper::client::ResponseFuture<hyper::client::conn::ResponseFuture>,
-    tower_hyper::Body,
->;
-
-type GrpcClientStreamingFuture<R> = tower_grpc::client::client_streaming::ResponseFuture<
-    R,
-    tower_hyper::client::ResponseFuture<hyper::client::conn::ResponseFuture>,
-    tower_hyper::Body,
->;
-
-type GrpcServerStreamingFuture<R> = tower_grpc::client::server_streaming::ResponseFuture<
-    R,
-    tower_hyper::client::ResponseFuture<hyper::client::conn::ResponseFuture>,
->;
-
-type GrpcBidiStreamingFuture<R> = tower_grpc::client::streaming::ResponseFuture<
-    R,
-    tower_hyper::client::ResponseFuture<hyper::client::conn::ResponseFuture>,
->;
-
-pub struct ResponseFuture<T, R> {
-    inner: GrpcUnaryFuture<R>,
-    _phantom: PhantomData<T>,
-}
-
-impl<T, R> ResponseFuture<T, R> {
-    fn new(inner: GrpcUnaryFuture<R>) -> Self {
-        ResponseFuture {
-            inner,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-pub struct ClientStreamingCompletionFuture<R> {
-    inner: GrpcClientStreamingFuture<R>,
-}
-
-impl<R> ClientStreamingCompletionFuture<R> {
-    fn new(inner: GrpcClientStreamingFuture<R>) -> Self {
-        ClientStreamingCompletionFuture { inner }
-    }
-}
-
-pub struct ResponseStreamFuture<T, R> {
-    inner: GrpcServerStreamingFuture<R>,
-    _phantom: PhantomData<T>,
-}
-
-impl<T, R> ResponseStreamFuture<T, R> {
-    fn new(inner: GrpcServerStreamingFuture<R>) -> Self {
-        ResponseStreamFuture {
-            inner,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-pub struct SubscriptionFuture<T, Id, R> {
-    inner: GrpcBidiStreamingFuture<R>,
-    _phantom: PhantomData<(T, Id)>,
-}
-
-impl<T, Id, R> SubscriptionFuture<T, Id, R> {
-    fn new(inner: GrpcBidiStreamingFuture<R>) -> Self {
-        SubscriptionFuture {
-            inner,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-pub struct ResponseStream<T, R> {
-    inner: Streaming<R, tower_hyper::Body>,
-    _phantom: PhantomData<T>,
-}
-
-impl<T, R> Future for ResponseFuture<T, R>
-where
-    R: prost::Message + Default,
-    T: FromProtobuf<R>,
-{
-    type Item = T;
-    type Error = core_error::Error;
-
-    fn poll(&mut self) -> Poll<T, core_error::Error> {
-        let res = try_ready!(self.inner.poll().map_err(error_from_grpc));
-        let item = T::from_message(res.into_inner())?;
-        Ok(Async::Ready(item))
-    }
-}
-
-impl<R> Future for ClientStreamingCompletionFuture<R>
-where
-    R: prost::Message + Default,
-{
-    type Item = ();
-    type Error = core_error::Error;
-
-    fn poll(&mut self) -> Poll<(), core_error::Error> {
-        try_ready!(self.inner.poll().map_err(error_from_grpc));
-        Ok(Async::Ready(()))
-    }
-}
-
-impl<T, R> Future for ResponseStreamFuture<T, R>
-where
-    R: prost::Message + Default,
-{
-    type Item = ResponseStream<T, R>;
-    type Error = core_error::Error;
-
-    fn poll(&mut self) -> Poll<ResponseStream<T, R>, core_error::Error> {
-        let res = try_ready!(self.inner.poll().map_err(error_from_grpc));
-        let stream = ResponseStream {
-            inner: res.into_inner(),
-            _phantom: PhantomData,
-        };
-        Ok(Async::Ready(stream))
-    }
-}
-
-impl<T, Id, R> Future for SubscriptionFuture<T, Id, R>
-where
-    R: prost::Message + Default,
-    Id: NodeId + property::Deserialize,
-{
-    type Item = (ResponseStream<T, R>, Id);
-    type Error = core_error::Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, core_error::Error> {
-        let res = try_ready!(self.inner.poll().map_err(error_from_grpc));
-        let id = decode_node_id(res.metadata())?;
-        let stream = ResponseStream {
-            inner: res.into_inner(),
-            _phantom: PhantomData,
-        };
-        Ok(Async::Ready((stream, id)))
-    }
-}
-
-impl<T, R> Stream for ResponseStream<T, R>
-where
-    R: prost::Message + Default,
-    T: FromProtobuf<R>,
-{
-    type Item = T;
-    type Error = core_error::Error;
-
-    fn poll(&mut self) -> Poll<Option<T>, core_error::Error> {
-        let maybe_msg = try_ready!(self.inner.poll().map_err(error_from_grpc));
-        let maybe_item = maybe_msg.map(|msg| T::from_message(msg)).transpose()?;
-        Ok(Async::Ready(maybe_item))
-    }
-}
-
-pub struct RequestStream<S, R> {
-    inner: S,
-    _phantom: PhantomData<R>,
-}
-
-impl<S, R> RequestStream<S, R>
-where
-    S: Stream,
-{
-    fn new(inner: S) -> Self {
-        RequestStream {
-            inner,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<S, R> Stream for RequestStream<S, R>
-where
-    S: Stream,
-    S::Item: IntoProtobuf<R>,
-{
-    type Item = R;
-    type Error = Status;
-
-    fn poll(&mut self) -> Poll<Option<R>, Status> {
-        let maybe_item = try_ready!(self
-            .inner
-            .poll()
-            .map_err(|_| Status::new(Code::Unknown, "request stream failure")));
-        let maybe_msg = maybe_item.map(|item| item.into_message()).transpose()?;
-        Ok(Async::Ready(maybe_msg))
-    }
-}
-
 impl<P> Connection<P>
 where
     P: ProtocolConfig,
@@ -351,24 +160,25 @@ where
 
     type HandshakeFuture = HandshakeFuture<P::BlockId>;
 
-    type TipFuture = ResponseFuture<P::Header, gen::node::TipResponse>;
+    type TipFuture = unary::ResponseFuture<P::Header, gen::node::TipResponse>;
 
-    type PullBlocksStream = ResponseStream<P::Block, gen::node::Block>;
-    type PullBlocksToTipFuture = ResponseStreamFuture<P::Block, gen::node::Block>;
+    type PullBlocksStream = server_streaming::ResponseStream<P::Block, gen::node::Block>;
+    type PullBlocksToTipFuture = server_streaming::ResponseFuture<P::Block, gen::node::Block>;
 
-    type PullHeadersStream = ResponseStream<P::Header, gen::node::Header>;
-    type PullHeadersFuture = ResponseStreamFuture<P::Header, gen::node::Header>;
+    type PullHeadersStream = server_streaming::ResponseStream<P::Header, gen::node::Header>;
+    type PullHeadersFuture = server_streaming::ResponseFuture<P::Header, gen::node::Header>;
 
-    type GetBlocksStream = ResponseStream<P::Block, gen::node::Block>;
-    type GetBlocksFuture = ResponseStreamFuture<P::Block, gen::node::Block>;
+    type GetBlocksStream = server_streaming::ResponseStream<P::Block, gen::node::Block>;
+    type GetBlocksFuture = server_streaming::ResponseFuture<P::Block, gen::node::Block>;
 
-    type BlockSubscription = ResponseStream<BlockEvent<P::Block>, gen::node::BlockEvent>;
+    type BlockSubscription =
+        server_streaming::ResponseStream<BlockEvent<P::Block>, gen::node::BlockEvent>;
     type BlockSubscriptionFuture =
-        SubscriptionFuture<BlockEvent<P::Block>, Self::NodeId, gen::node::BlockEvent>;
+        subscription::ResponseFuture<BlockEvent<P::Block>, Self::NodeId, gen::node::BlockEvent>;
 
-    type PushHeadersFuture = ClientStreamingCompletionFuture<gen::node::PushHeadersResponse>;
+    type PushHeadersFuture = client_streaming::ResponseFuture<gen::node::PushHeadersResponse>;
 
-    type UploadBlocksFuture = ClientStreamingCompletionFuture<gen::node::UploadBlocksResponse>;
+    type UploadBlocksFuture = client_streaming::ResponseFuture<gen::node::UploadBlocksResponse>;
 
     fn handshake(&mut self) -> Self::HandshakeFuture {
         let req = gen::node::HandshakeRequest {};
@@ -379,14 +189,14 @@ where
     fn tip(&mut self) -> Self::TipFuture {
         let req = gen::node::TipRequest {};
         let future = self.service.tip(Request::new(req));
-        ResponseFuture::new(future)
+        unary::ResponseFuture::new(future)
     }
 
     fn pull_blocks_to_tip(&mut self, from: &[P::BlockId]) -> Self::PullBlocksToTipFuture {
         let from = serialize_to_repeated_bytes(from).unwrap();
         let req = gen::node::PullBlocksToTipRequest { from };
         let future = self.service.pull_blocks_to_tip(Request::new(req));
-        ResponseStreamFuture::new(future)
+        server_streaming::ResponseFuture::new(future)
     }
 
     fn pull_headers(&mut self, from: &[P::BlockId], to: &P::BlockId) -> Self::PullHeadersFuture {
@@ -394,14 +204,14 @@ where
         let to = serialize_to_bytes(to).unwrap();
         let req = gen::node::PullHeadersRequest { from, to };
         let future = self.service.pull_headers(Request::new(req));
-        ResponseStreamFuture::new(future)
+        server_streaming::ResponseFuture::new(future)
     }
 
     fn get_blocks(&mut self, ids: &[P::BlockId]) -> Self::GetBlocksFuture {
         let ids = serialize_to_repeated_bytes(ids).unwrap();
         let req = gen::node::BlockIds { ids };
         let future = self.service.get_blocks(Request::new(req));
-        ResponseStreamFuture::new(future)
+        server_streaming::ResponseFuture::new(future)
     }
 
     fn push_headers<S>(&mut self, headers: S) -> Self::PushHeadersFuture
@@ -411,7 +221,7 @@ where
         let stream = RequestStream::new(headers);
         let req = Request::new(stream);
         let future = self.service.push_headers(req);
-        ClientStreamingCompletionFuture::new(future)
+        client_streaming::ResponseFuture::new(future)
     }
 
     fn upload_blocks<S>(&mut self, blocks: S) -> Self::UploadBlocksFuture
@@ -421,7 +231,7 @@ where
         let rs = RequestStream::new(blocks);
         let req = Request::new(rs);
         let future = self.service.upload_blocks(req);
-        ClientStreamingCompletionFuture::new(future)
+        client_streaming::ResponseFuture::new(future)
     }
 
     fn block_subscription<Out>(&mut self, outbound: Out) -> Self::BlockSubscriptionFuture
@@ -430,7 +240,7 @@ where
     {
         let req = self.new_subscription_request(outbound);
         let future = self.service.block_subscription(req);
-        SubscriptionFuture::new(future)
+        subscription::ResponseFuture::new(future)
     }
 }
 
@@ -440,18 +250,18 @@ where
 {
     type Fragment = P::Fragment;
 
-    type GetFragmentsStream = ResponseStream<P::Fragment, gen::node::Fragment>;
-    type GetFragmentsFuture = ResponseStreamFuture<P::Fragment, gen::node::Fragment>;
+    type GetFragmentsStream = server_streaming::ResponseStream<P::Fragment, gen::node::Fragment>;
+    type GetFragmentsFuture = server_streaming::ResponseFuture<P::Fragment, gen::node::Fragment>;
 
-    type FragmentSubscription = ResponseStream<P::Fragment, gen::node::Fragment>;
+    type FragmentSubscription = server_streaming::ResponseStream<P::Fragment, gen::node::Fragment>;
     type FragmentSubscriptionFuture =
-        SubscriptionFuture<P::Fragment, Self::NodeId, gen::node::Fragment>;
+        subscription::ResponseFuture<P::Fragment, Self::NodeId, gen::node::Fragment>;
 
     fn get_fragments(&mut self, ids: &[P::FragmentId]) -> Self::GetFragmentsFuture {
         let ids = serialize_to_repeated_bytes(ids).unwrap();
         let req = gen::node::FragmentIds { ids };
         let future = self.service.get_fragments(Request::new(req));
-        ResponseStreamFuture::new(future)
+        server_streaming::ResponseFuture::new(future)
     }
 
     fn fragment_subscription<Out>(&mut self, outbound: Out) -> Self::FragmentSubscriptionFuture
@@ -460,7 +270,7 @@ where
     {
         let req = self.new_subscription_request(outbound);
         let future = self.service.fragment_subscription(req);
-        SubscriptionFuture::new(future)
+        subscription::ResponseFuture::new(future)
     }
 }
 
@@ -469,9 +279,9 @@ where
     P: ProtocolConfig,
 {
     type Node = P::Node;
-    type GossipSubscription = ResponseStream<Gossip<P::Node>, gen::node::Gossip>;
+    type GossipSubscription = server_streaming::ResponseStream<Gossip<P::Node>, gen::node::Gossip>;
     type GossipSubscriptionFuture =
-        SubscriptionFuture<Gossip<P::Node>, Self::NodeId, gen::node::Gossip>;
+        subscription::ResponseFuture<Gossip<P::Node>, Self::NodeId, gen::node::Gossip>;
 
     fn gossip_subscription<Out>(&mut self, outbound: Out) -> Self::GossipSubscriptionFuture
     where
@@ -479,6 +289,6 @@ where
     {
         let req = self.new_subscription_request(outbound);
         let future = self.service.gossip_subscription(req);
-        SubscriptionFuture::new(future)
+        subscription::ResponseFuture::new(future)
     }
 }

--- a/network-grpc/src/client/client_streaming.rs
+++ b/network-grpc/src/client/client_streaming.rs
@@ -1,0 +1,71 @@
+use crate::convert::{error_from_grpc, IntoProtobuf};
+use network_core::error as core_error;
+
+use futures::prelude::*;
+use tower_grpc::{Code, Status};
+
+use std::marker::PhantomData;
+
+type GrpcFuture<R> = tower_grpc::client::client_streaming::ResponseFuture<
+    R,
+    tower_hyper::client::ResponseFuture<hyper::client::conn::ResponseFuture>,
+    tower_hyper::Body,
+>;
+
+pub struct ResponseFuture<R> {
+    inner: GrpcFuture<R>,
+}
+
+impl<R> ResponseFuture<R> {
+    pub(super) fn new(inner: GrpcFuture<R>) -> Self {
+        ResponseFuture { inner }
+    }
+}
+
+impl<R> Future for ResponseFuture<R>
+where
+    R: prost::Message + Default,
+{
+    type Item = ();
+    type Error = core_error::Error;
+
+    fn poll(&mut self) -> Poll<(), core_error::Error> {
+        try_ready!(self.inner.poll().map_err(error_from_grpc));
+        Ok(Async::Ready(()))
+    }
+}
+
+pub(super) struct RequestStream<S, R> {
+    inner: S,
+    _phantom: PhantomData<R>,
+}
+
+impl<S, R> RequestStream<S, R>
+where
+    S: Stream,
+{
+    pub(super) fn new(inner: S) -> Self {
+        RequestStream {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<S, R> Stream for RequestStream<S, R>
+where
+    S: Stream,
+    S::Item: IntoProtobuf<R>,
+{
+    type Item = R;
+    type Error = Status;
+
+    fn poll(&mut self) -> Poll<Option<R>, Status> {
+        let maybe_item = try_ready!(self
+            .inner
+            .poll()
+            .map_err(|_| Status::new(Code::Unknown, "request stream failure")));
+        let maybe_msg = maybe_item.map(|item| item.into_message()).transpose()?;
+        Ok(Async::Ready(maybe_msg))
+    }
+}

--- a/network-grpc/src/client/server_streaming.rs
+++ b/network-grpc/src/client/server_streaming.rs
@@ -1,0 +1,72 @@
+use crate::convert::{error_from_grpc, FromProtobuf};
+use network_core::error as core_error;
+
+use futures::prelude::*;
+use tower_grpc::Streaming;
+
+use std::marker::PhantomData;
+
+type GrpcFuture<R> = tower_grpc::client::server_streaming::ResponseFuture<
+    R,
+    tower_hyper::client::ResponseFuture<hyper::client::conn::ResponseFuture>,
+>;
+
+pub struct ResponseFuture<T, R> {
+    inner: GrpcFuture<R>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T, R> ResponseFuture<T, R> {
+    pub(super) fn new(inner: GrpcFuture<R>) -> Self {
+        ResponseFuture {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, R> Future for ResponseFuture<T, R>
+where
+    R: prost::Message + Default,
+{
+    type Item = ResponseStream<T, R>;
+    type Error = core_error::Error;
+
+    fn poll(&mut self) -> Poll<ResponseStream<T, R>, core_error::Error> {
+        let res = try_ready!(self.inner.poll().map_err(error_from_grpc));
+        let stream = ResponseStream {
+            inner: res.into_inner(),
+            _phantom: PhantomData,
+        };
+        Ok(Async::Ready(stream))
+    }
+}
+
+pub struct ResponseStream<T, R> {
+    inner: Streaming<R, tower_hyper::Body>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T, R> ResponseStream<T, R> {
+    pub(super) fn new(inner: Streaming<R, tower_hyper::Body>) -> Self {
+        ResponseStream {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, R> Stream for ResponseStream<T, R>
+where
+    R: prost::Message + Default,
+    T: FromProtobuf<R>,
+{
+    type Item = T;
+    type Error = core_error::Error;
+
+    fn poll(&mut self) -> Poll<Option<T>, core_error::Error> {
+        let maybe_msg = try_ready!(self.inner.poll().map_err(error_from_grpc));
+        let maybe_item = maybe_msg.map(|msg| T::from_message(msg)).transpose()?;
+        Ok(Async::Ready(maybe_item))
+    }
+}

--- a/network-grpc/src/client/subscription.rs
+++ b/network-grpc/src/client/subscription.rs
@@ -1,0 +1,44 @@
+use super::server_streaming::ResponseStream;
+use crate::convert::{decode_node_id, error_from_grpc};
+use chain_core::property;
+use network_core::error as core_error;
+use network_core::gossip::NodeId;
+
+use futures::prelude::*;
+
+use std::marker::PhantomData;
+
+type GrpcFuture<R> = tower_grpc::client::streaming::ResponseFuture<
+    R,
+    tower_hyper::client::ResponseFuture<hyper::client::conn::ResponseFuture>,
+>;
+
+pub struct ResponseFuture<T, Id, R> {
+    inner: GrpcFuture<R>,
+    _phantom: PhantomData<(T, Id)>,
+}
+
+impl<T, Id, R> ResponseFuture<T, Id, R> {
+    pub(super) fn new(inner: GrpcFuture<R>) -> Self {
+        ResponseFuture {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, Id, R> Future for ResponseFuture<T, Id, R>
+where
+    R: prost::Message + Default,
+    Id: NodeId + property::Deserialize,
+{
+    type Item = (ResponseStream<T, R>, Id);
+    type Error = core_error::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, core_error::Error> {
+        let res = try_ready!(self.inner.poll().map_err(error_from_grpc));
+        let id = decode_node_id(res.metadata())?;
+        let stream = ResponseStream::new(res.into_inner());
+        Ok(Async::Ready((stream, id)))
+    }
+}

--- a/network-grpc/src/client/unary.rs
+++ b/network-grpc/src/client/unary.rs
@@ -1,0 +1,41 @@
+use crate::convert::{error_from_grpc, FromProtobuf};
+use network_core::error as core_error;
+
+use futures::prelude::*;
+
+use std::marker::PhantomData;
+
+type GrpcFuture<R> = tower_grpc::client::unary::ResponseFuture<
+    R,
+    tower_hyper::client::ResponseFuture<hyper::client::conn::ResponseFuture>,
+    tower_hyper::Body,
+>;
+
+pub struct ResponseFuture<T, R> {
+    inner: GrpcFuture<R>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T, R> ResponseFuture<T, R> {
+    pub(super) fn new(inner: GrpcFuture<R>) -> Self {
+        ResponseFuture {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, R> Future for ResponseFuture<T, R>
+where
+    R: prost::Message + Default,
+    T: FromProtobuf<R>,
+{
+    type Item = T;
+    type Error = core_error::Error;
+
+    fn poll(&mut self) -> Poll<T, core_error::Error> {
+        let res = try_ready!(self.inner.poll().map_err(error_from_grpc));
+        let item = T::from_message(res.into_inner())?;
+        Ok(Async::Ready(item))
+    }
+}


### PR DESCRIPTION
- In `network-core`, add constructor `Error::unimplemented` to easily implement method stubs.
- In `network-grpc`, reorganize and rename async adapter types under `client`, decluttering the main module.
- Fix propagation of application-sent errors to the server in outbound client streams by restricting the error type of the generic stream parameters to `Error` from `network-core`.
