### PR TITLE
Specify old_utxo only works for Icarus-style old UTXOs

### DIFF
--- a/chain-impl-mockchain/src/transaction/witness.rs
+++ b/chain-impl-mockchain/src/transaction/witness.rs
@@ -128,7 +128,7 @@ impl Witness {
         Witness::Utxo(sig)
     }
 
-    pub fn new_old_utxo(
+    pub fn new_old_icarus_utxo(
         block0: &HeaderId,
         sign_data_hash: &TransactionSignDataHash,
         secret_key: &SecretKey<Ed25519Bip32>,


### PR DESCRIPTION
It may be that we don't want to merge https://github.com/input-output-hk/chain-libs/pull/165 to avoid introducing legacy functionality into this codebase. If that's the case, I propose this alternative PR that simply does a rename to make it clear that old UTXOs only work for Icarus-style UTXOs (since `ed25519bip32` does not work for legacy Daedalus-style UTXOs)

This should make the limitation clearer for anybody who reads this later