### PR TITLE
Implement fees for different certificate types

### DIFF
--- a/chain-impl-mockchain/src/fee.rs
+++ b/chain-impl-mockchain/src/fee.rs
@@ -9,6 +9,14 @@ pub struct LinearFee {
     pub constant: u64,
     pub coefficient: u64,
     pub certificate: u64,
+    pub per_certificate_fees: Option<PerCertificateFee>,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy)]
+pub struct PerCertificateFee {
+    pub certificate_pool_registration: u64,
+    pub certificate_stake_delegation: u64,
+    pub certificate_owner_stake_delegation: u64,
 }
 
 impl LinearFee {
@@ -17,6 +25,38 @@ impl LinearFee {
             constant,
             coefficient,
             certificate,
+            per_certificate_fees: None,
+        }
+    }
+
+    pub fn per_certificate_fees(&mut self, per_certificate_fees: PerCertificateFee) {
+        self.per_certificate_fees = Some(per_certificate_fees);
+    }
+}
+
+impl PerCertificateFee {
+    pub fn new(
+        certificate_pool_registration: u64,
+        certificate_stake_delegation: u64,
+        certificate_owner_stake_delegation: u64,
+    ) -> Self {
+        Self {
+            certificate_pool_registration,
+            certificate_stake_delegation,
+            certificate_owner_stake_delegation,
+        }
+    }
+
+    fn fees_for_certificate<'a>(&self, cert: CertificateSlice<'a>) -> Option<Value> {
+        match cert {
+            CertificateSlice::PoolRegistration(_) => {
+                Some(Value(self.certificate_pool_registration))
+            }
+            CertificateSlice::StakeDelegation(_) => Some(Value(self.certificate_stake_delegation)),
+            CertificateSlice::OwnerStakeDelegation(_) => {
+                Some(Value(self.certificate_owner_stake_delegation))
+            }
+            _ => None,
         }
     }
 }
@@ -45,13 +85,20 @@ impl FeeAlgorithm for LinearFee {
     fn baseline(&self) -> Value {
         Value(self.constant)
     }
+
     fn fees_for_inputs_outputs(&self, inputs: u8, outputs: u8) -> Value {
         Value(
             self.coefficient
                 .saturating_mul((inputs as u64) + (outputs as u64)),
         )
     }
-    fn fees_for_certificate<'a>(&self, _: CertificateSlice<'a>) -> Value {
+
+    fn fees_for_certificate<'a>(&self, cert_slice: CertificateSlice<'a>) -> Value {
+        if let Some(per_certificate_fees) = self.per_certificate_fees {
+            if let Some(fee) = per_certificate_fees.fees_for_certificate(cert_slice) {
+                return fee;
+            }
+        }
         Value(self.certificate)
     }
 }
@@ -67,6 +114,7 @@ mod test {
                 constant: Arbitrary::arbitrary(g),
                 coefficient: Arbitrary::arbitrary(g),
                 certificate: Arbitrary::arbitrary(g),
+                per_certificate_fees: None,
             }
         }
     }

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -63,6 +63,7 @@ impl Settings {
 
     pub fn apply(&self, changes: &ConfigParams) -> Result<Self, Error> {
         let mut new_state = self.clone();
+        let mut per_certificate_fees = None;
 
         for param in changes.iter() {
             match param {
@@ -125,7 +126,16 @@ impl Settings {
                 ConfigParam::TreasuryParams(rp) => {
                     new_state.treasury_params = Some(rp.clone());
                 }
+                ConfigParam::PerCertificateFees(pcf) => {
+                    per_certificate_fees = Some(pcf);
+                }
             }
+        }
+
+        if let Some(pcf) = per_certificate_fees {
+            Arc::get_mut(&mut new_state.linear_fees)
+                .unwrap()
+                .per_certificate_fees(*pcf);
         }
 
         Ok(new_state)

--- a/chain-impl-mockchain/src/testing/scenario/controller.rs
+++ b/chain-impl-mockchain/src/testing/scenario/controller.rs
@@ -118,7 +118,7 @@ mod tests {
             .with_config(
                 ConfigBuilder::new(0)
                     .with_discrimination(Discrimination::Test)
-                    .with_fee(LinearFee::new(1,1,1))
+                    .with_fee(LinearFee::new(1, 1, 1))
             )
             .with_initials(
                 vec![


### PR DESCRIPTION
Allow setting different fees for `PoolRegistration`, `StakeDelegation` and `OwnerStakeDelegation`. Fees for other types of certificates remain unchanged.

Resolves #9 