### PR TITLE
On some architecture, the get_first_index_impl fails to returns a valid value

### DIFF
--- a/sparse-array/src/bitmap.rs
+++ b/sparse-array/src/bitmap.rs
@@ -75,7 +75,7 @@ impl BitmapIndex {
     }
 
     #[inline]
-    #[cfg_attr(target_arch = "x86_64", target_feature(enable = "bmi1"))]
+    // #[cfg_attr(target_arch = "x86_64", target_feature(enable = "bmi1"))]
     unsafe fn get_first_index_impl(&self) -> Option<u8> {
         let trailing_zeros0 = self.0.trailing_zeros();
         let trailing_zeros1 = self.1.trailing_zeros();

--- a/sparse-array/src/fast.rs
+++ b/sparse-array/src/fast.rs
@@ -124,7 +124,14 @@ impl<'a, V> Iterator for FastSparseArrayIter<'a, V> {
         match self.bitmap.get_first_index() {
             Some(idx) => {
                 self.bitmap.remove_index(idx);
-                Some((idx, self.sparse_array.get(idx).unwrap()))
+                if let Some(item) = self.sparse_array.get(idx) {
+                    Some((idx, item))
+                } else {
+                    panic!(
+                        "FastSparseArray does not contains item at index {idx}",
+                        idx = idx
+                    )
+                }
             }
             None => None,
         }


### PR DESCRIPTION
see error in https://travis-ci.org/input-output-hk/jormungandr/jobs/618020686

The error:

```
Error: thread 'main' panicked at 'FastSparseArray does not contains item at index 65', chain-deps/sparse-array/src/fast.rs:130:21
```

There was only one entry in the utxos

Removing `bmi1` fixes the problem