### PR TITLE
Stop using target_feature from the code

### DIFF
--- a/imhamt/src/bitmap.rs
+++ b/imhamt/src/bitmap.rs
@@ -68,14 +68,9 @@ impl SmallBitmap {
         self.0 == 0
     }
 
-    #[cfg_attr(target_arch = "x86", target_feature(enable = "popcnt"))]
-    unsafe fn present_fast(&self) -> usize {
-        self.0.count_ones() as usize
-    }
-
     #[inline]
     pub fn present(&self) -> usize {
-        unsafe { self.present_fast() }
+        self.0.count_ones() as usize
     }
 
     #[inline]
@@ -86,8 +81,7 @@ impl SmallBitmap {
 
     /// Get the sparse array index from a level index
     #[inline]
-    #[cfg_attr(target_arch = "x86", target_feature(enable = "popcnt"))]
-    unsafe fn get_index_sparse_fast(&self, b: LevelIndex) -> ArrayIndex {
+    pub fn get_index_sparse(&self, b: LevelIndex) -> ArrayIndex {
         let mask = b.mask();
         if self.0 & mask == 0 {
             ArrayIndex::not_found()
@@ -96,22 +90,11 @@ impl SmallBitmap {
         }
     }
 
-    #[inline]
-    pub fn get_index_sparse(&self, b: LevelIndex) -> ArrayIndex {
-        unsafe { self.get_index_sparse_fast(b) }
-    }
-
-    #[inline]
-    #[cfg_attr(target_arch = "x86", target_feature(enable = "popcnt"))]
-    unsafe fn get_sparse_pos_fast(&self, b: LevelIndex) -> ArrayIndex {
-        let mask = b.mask();
-        ArrayIndex::create((self.0 & (mask - 1)).count_ones() as usize)
-    }
-
     /// Get the position of a level index in the sparse array for insertion
     #[inline]
     pub fn get_sparse_pos(&self, b: LevelIndex) -> ArrayIndex {
-        unsafe { self.get_sparse_pos_fast(b) }
+        let mask = b.mask();
+        ArrayIndex::create((self.0 & (mask - 1)).count_ones() as usize)
     }
 
     /// Check if the element exist

--- a/sparse-array/src/bitmap.rs
+++ b/sparse-array/src/bitmap.rs
@@ -47,8 +47,7 @@ impl BitmapIndex {
     }
 
     #[inline]
-    #[cfg_attr(target_arch = "x86_64", target_feature(enable = "popcnt"))]
-    unsafe fn get_real_index_impl(&self, idx: u8) -> Option<u8> {
+    pub fn get_real_index(&self, idx: u8) -> Option<u8> {
         if !self.get_index(idx) {
             return None;
         }
@@ -65,18 +64,12 @@ impl BitmapIndex {
     }
 
     #[inline]
-    pub fn get_real_index(&self, idx: u8) -> Option<u8> {
-        unsafe { self.get_real_index_impl(idx) }
-    }
-
-    #[inline]
     pub fn is_empty(&self) -> bool {
         self.0 == 0 && self.1 == 0
     }
 
     #[inline]
-    // #[cfg_attr(target_arch = "x86_64", target_feature(enable = "bmi1"))]
-    unsafe fn get_first_index_impl(&self) -> Option<u8> {
+    pub fn get_first_index(&self) -> Option<u8> {
         let trailing_zeros0 = self.0.trailing_zeros();
         let trailing_zeros1 = self.1.trailing_zeros();
         if trailing_zeros0 < 128 {
@@ -86,11 +79,6 @@ impl BitmapIndex {
         } else {
             None
         }
-    }
-
-    #[inline]
-    pub fn get_first_index(&self) -> Option<u8> {
-        unsafe { self.get_first_index_impl() }
     }
 }
 


### PR DESCRIPTION
Users who want to build the project should use rustc flags instead.

Example: `-C target-feature=+popcnt,+bmi1`

This also reduces the amount of potentially unsafe code.