### PR TITLE
Add missing cert methods

### DIFF
--- a/chain-impl-mockchain/src/certificate/delegation.rs
+++ b/chain-impl-mockchain/src/certificate/delegation.rs
@@ -10,7 +10,7 @@ use chain_core::{
     property,
 };
 use std::marker::PhantomData;
-use typed_bytes::ByteBuilder;
+use typed_bytes::{ByteArray, ByteBuilder};
 
 /// A self delegation to a specific StakePoolId.
 ///
@@ -24,6 +24,9 @@ pub struct OwnerStakeDelegation {
 impl OwnerStakeDelegation {
     pub fn serialize_in(&self, bb: ByteBuilder<Self>) -> ByteBuilder<Self> {
         bb.sub(|sb| serialize_delegation_type(&self.delegation, sb))
+    }
+    pub fn serialize(&self) -> ByteArray<Self> {
+        self.serialize_in(ByteBuilder::new()).finalize()
     }
 
     pub fn get_delegation_type(&self) -> &DelegationType {
@@ -41,6 +44,9 @@ impl StakeDelegation {
     pub fn serialize_in(&self, bb: ByteBuilder<Self>) -> ByteBuilder<Self> {
         bb.bytes(self.account_id.as_ref())
             .sub(|sb| serialize_delegation_type(&self.delegation, sb))
+    }
+    pub fn serialize(&self) -> ByteArray<Self> {
+        self.serialize_in(ByteBuilder::new()).finalize()
     }
 
     pub fn get_delegation_type(&self) -> &DelegationType {

--- a/chain-impl-mockchain/src/certificate/mod.rs
+++ b/chain-impl-mockchain/src/certificate/mod.rs
@@ -8,7 +8,7 @@ use crate::transaction::{Payload, PayloadData, PayloadSlice};
 
 pub use delegation::{OwnerStakeDelegation, StakeDelegation};
 pub use pool::{
-    GenesisProasLeaderHash, IndexSignatures, ManagementThreshold, PoolId, PoolOwnersSigned,
+    GenesisPraosLeaderHash, IndexSignatures, ManagementThreshold, PoolId, PoolOwnersSigned,
     PoolPermissions, PoolRegistration, PoolRetirement, PoolSignature, PoolUpdate,
 };
 

--- a/chain-impl-mockchain/src/certificate/mod.rs
+++ b/chain-impl-mockchain/src/certificate/mod.rs
@@ -9,7 +9,7 @@ use crate::transaction::{Payload, PayloadData, PayloadSlice};
 pub use delegation::{OwnerStakeDelegation, StakeDelegation};
 pub use pool::{
     IndexSignatures, ManagementThreshold, PoolId, PoolOwnersSigned, PoolPermissions,
-    PoolRegistration, PoolRetirement, PoolSignature, PoolUpdate,
+    PoolRegistration, PoolRetirement, PoolSignature, PoolUpdate, GenesisProasLeaderHash,
 };
 
 pub enum CertificateSlice<'a> {

--- a/chain-impl-mockchain/src/certificate/mod.rs
+++ b/chain-impl-mockchain/src/certificate/mod.rs
@@ -8,8 +8,8 @@ use crate::transaction::{Payload, PayloadData, PayloadSlice};
 
 pub use delegation::{OwnerStakeDelegation, StakeDelegation};
 pub use pool::{
-    IndexSignatures, ManagementThreshold, PoolId, PoolOwnersSigned, PoolPermissions,
-    PoolRegistration, PoolRetirement, PoolSignature, PoolUpdate, GenesisProasLeaderHash,
+    GenesisProasLeaderHash, IndexSignatures, ManagementThreshold, PoolId, PoolOwnersSigned,
+    PoolPermissions, PoolRegistration, PoolRetirement, PoolSignature, PoolUpdate,
 };
 
 pub enum CertificateSlice<'a> {

--- a/chain-impl-mockchain/src/certificate/pool.rs
+++ b/chain-impl-mockchain/src/certificate/pool.rs
@@ -19,7 +19,7 @@ use typed_bytes::{ByteArray, ByteBuilder};
 pub type PoolId = DigestOf<Blake2b256, PoolRegistration>;
 
 /// Hash of keys used for pool
-pub type GenesisProasLeaderHash = DigestOf<Blake2b256, GenesisPraosLeader>;
+pub type GenesisPraosLeaderHash = DigestOf<Blake2b256, GenesisPraosLeader>;
 
 /// signatures with indices
 pub type IndexSignatures = Vec<(u8, SingleAccountBindingSignature)>;
@@ -82,7 +82,7 @@ impl PoolPermissions {
 pub struct PoolUpdate {
     pub pool_id: PoolId,
     pub start_validity: TimeOffsetSeconds,
-    pub previous_keys: GenesisProasLeaderHash,
+    pub previous_keys: GenesisPraosLeaderHash,
     pub updated_keys: GenesisPraosLeader,
 }
 

--- a/chain-impl-mockchain/src/certificate/pool.rs
+++ b/chain-impl-mockchain/src/certificate/pool.rs
@@ -18,6 +18,9 @@ use typed_bytes::{ByteArray, ByteBuilder};
 /// Pool ID
 pub type PoolId = DigestOf<Blake2b256, PoolRegistration>;
 
+/// Hash of keys used for pool
+pub type GenesisProasLeaderHash = DigestOf<Blake2b256, GenesisPraosLeader>;
+
 /// signatures with indices
 pub type IndexSignatures = Vec<(u8, SingleAccountBindingSignature)>;
 
@@ -79,7 +82,7 @@ impl PoolPermissions {
 pub struct PoolUpdate {
     pub pool_id: PoolId,
     pub start_validity: TimeOffsetSeconds,
-    pub previous_keys: DigestOf<Blake2b256, GenesisPraosLeader>,
+    pub previous_keys: GenesisProasLeaderHash,
     pub updated_keys: GenesisPraosLeader,
 }
 


### PR DESCRIPTION
Two small things added in this PR

# 1 - Missing `serialize` methods on certificates

Some certificates had a `serialize` function and others only had `serizalize_in`. We need `serialize` because `typed_bytes` isn't available from the WASM bindings (which is why I assume the other certs have `serialize_in` in the first place)

# 2 - GenesisProasLeaderHash as a type

I need this because it's an argument for creating a `PoolUpdate` certificate from the WASM.