### PR TITLE
LeaderLog didn't increase the value when calling `increase_for` in the Ledger::apply_block

### DIFF
--- a/chain-impl-mockchain/src/block/leaderlog.rs
+++ b/chain-impl-mockchain/src/block/leaderlog.rs
@@ -23,13 +23,11 @@ impl LeadersParticipationRecord {
     }
 
     /// Add one count to a pool. if the pool doesn't exist, then set it to 1
-    pub fn increase_for(&self, pool: &PoolId) -> Self {
-        Self {
-            total: self.total + 1,
-            log: self
-                .log
-                .insert_or_update_simple(pool.clone(), 1, |v| Some(v + 1)),
-        }
+    pub fn increase_for(&mut self, pool: &PoolId) {
+        self.total = self.total + 1;
+        self.log = self
+            .log
+            .insert_or_update_simple(pool.clone(), 1, |v| Some(v + 1));
     }
 
     /// Set a pool id to a specific value.


### PR DESCRIPTION
Updating the function to match what is done in `set_for` and how it is used in the `Ledger::apply_block` function.

Without this, the rewards are not distributed at all.