### PR TITLE
Fix linear rewards reset to inintial after reduction to 0

### DIFF
--- a/chain-impl-mockchain/src/rewards.rs
+++ b/chain-impl-mockchain/src/rewards.rs
@@ -141,7 +141,7 @@ pub fn rewards_contribution_calculation(epoch: Epoch, params: &Parameters) -> Va
             if params.initial_value >= reduce_by {
                 Value(params.initial_value - reduce_by)
             } else {
-                Value(params.initial_value)
+                Value::zero()
             }
         }
         CompoundingType::Halvening => {


### PR DESCRIPTION
I'm quite certain that this is a bug