### PR TITLE
Add fees-to-treasury setting

### DIFF
--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -74,6 +74,7 @@ pub enum ConfigParam {
     RewardPot(Value),
     RewardParams(RewardParams),
     PerCertificateFees(PerCertificateFee),
+    FeesInTreasury(bool),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -131,6 +132,8 @@ pub enum Tag {
     RewardParams = 20,
     #[strum(to_string = "per-certificate-fees")]
     PerCertificateFees = 21,
+    #[strum(to_string = "fees-in-treasury")]
+    FeesInTreasury = 22,
 }
 
 impl Tag {
@@ -154,6 +157,7 @@ impl Tag {
             19 => Some(Tag::RewardPot),
             20 => Some(Tag::RewardParams),
             21 => Some(Tag::PerCertificateFees),
+            22 => Some(Tag::FeesInTreasury),
             _ => None,
         }
     }
@@ -182,6 +186,7 @@ impl<'a> From<&'a ConfigParam> for Tag {
             ConfigParam::RewardPot(_) => Tag::RewardPot,
             ConfigParam::RewardParams(_) => Tag::RewardParams,
             ConfigParam::PerCertificateFees(_) => Tag::PerCertificateFees,
+            ConfigParam::FeesInTreasury(_) => Tag::FeesInTreasury,
         }
     }
 }
@@ -238,6 +243,9 @@ impl Readable for ConfigParam {
             Tag::PerCertificateFees => {
                 ConfigParamVariant::from_payload(bytes).map(ConfigParam::PerCertificateFees)
             }
+            Tag::FeesInTreasury => {
+                ConfigParamVariant::from_payload(bytes).map(ConfigParam::FeesInTreasury)
+            }
         }
         .map_err(Into::into)
     }
@@ -267,6 +275,7 @@ impl property::Serialize for ConfigParam {
             ConfigParam::RewardPot(data) => data.to_payload(),
             ConfigParam::RewardParams(data) => data.to_payload(),
             ConfigParam::PerCertificateFees(data) => data.to_payload(),
+            ConfigParam::FeesInTreasury(data) => data.to_payload(),
         };
         let taglen = TagLen::new(tag, bytes.len()).ok_or_else(|| {
             io::Error::new(
@@ -671,7 +680,7 @@ mod test {
 
     impl Arbitrary for ConfigParam {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            match u8::arbitrary(g) % 15 {
+            match u8::arbitrary(g) % 16 {
                 0 => ConfigParam::Block0Date(Arbitrary::arbitrary(g)),
                 1 => ConfigParam::Discrimination(Arbitrary::arbitrary(g)),
                 2 => ConfigParam::ConsensusVersion(Arbitrary::arbitrary(g)),
@@ -687,6 +696,7 @@ mod test {
                 12 => ConfigParam::RewardPot(Arbitrary::arbitrary(g)),
                 13 => ConfigParam::RewardParams(Arbitrary::arbitrary(g)),
                 14 => ConfigParam::PerCertificateFees(Arbitrary::arbitrary(g)),
+                15 => ConfigParam::FeesInTreasury(Arbitrary::arbitrary(g)),
                 _ => unreachable!(),
             }
         }

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -33,6 +33,23 @@ pub struct Settings {
     pub proposal_expiration: u32,
     pub reward_params: Option<RewardParams>,
     pub treasury_params: Option<rewards::TaxType>,
+    pub fees_goes_to: FeesGoesTo,
+}
+
+/// Fees nSettings
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FeesGoesTo {
+    /// Move the fees to the rewards; this is the common mode of blockchain operation.
+    Rewards,
+    /// Move the fees directly to treasury. this is not a recommended settings, as
+    /// it fundamentally change the dynamic of the blockchain operation.
+    Treasury,
+}
+
+impl Default for FeesGoesTo {
+    fn default() -> Self {
+        FeesGoesTo::Rewards
+    }
 }
 
 pub const SLOTS_PERCENTAGE_RANGE: u8 = 100;
@@ -52,6 +69,7 @@ impl Settings {
             proposal_expiration: 100,
             reward_params: None,
             treasury_params: None,
+            fees_goes_to: FeesGoesTo::Rewards,
         }
     }
 
@@ -120,6 +138,13 @@ impl Settings {
                 }
                 ConfigParam::PerCertificateFees(pcf) => {
                     per_certificate_fees = Some(pcf);
+                }
+                ConfigParam::FeesInTreasury(value) => {
+                    new_state.fees_goes_to = if *value {
+                        FeesGoesTo::Treasury
+                    } else {
+                        FeesGoesTo::Rewards
+                    };
                 }
             }
         }
@@ -199,8 +224,18 @@ impl Settings {
 
 #[cfg(test)]
 mod tests {
-    use super::Settings;
+    use super::{FeesGoesTo, Settings};
     use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for FeesGoesTo {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            if Arbitrary::arbitrary(g) {
+                FeesGoesTo::Treasury
+            } else {
+                FeesGoesTo::Rewards
+            }
+        }
+    }
 
     impl Arbitrary for Settings {
         fn arbitrary<G: Gen>(_: &mut G) -> Self {


### PR DESCRIPTION
Allow configuring moving the fees directly to treasury without affecting
the rewarding at each epoch. This is useful for testing purpose,
although it is not a recommended settings as it mess with the
blockchain's dynamic.