### PR TITLE
Incentive tweaks

### DIFF
--- a/chain-impl-mockchain/src/block/leaderlog.rs
+++ b/chain-impl-mockchain/src/block/leaderlog.rs
@@ -14,6 +14,10 @@ impl LeadersParticipationRecord {
         self.total
     }
 
+    pub fn nb_participants(&self) -> usize {
+        self.log.size()
+    }
+
     /// new empty leader log
     pub fn new() -> Self {
         Self {

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -413,11 +413,35 @@ impl Ledger {
         swap(&mut new_ledger.leaders_log, &mut leaders_log);
 
         if total_reward > Value::zero() {
+            // pool capping only exists if there's enough participants
+            let pool_capper = match ledger_params.reward_params.pool_participation_capping {
+                None => None,
+                Some((threshold, expected_nb_pools)) => {
+                    let nb_participants = leaders_log.nb_participants();
+                    if nb_participants >= threshold.get() as usize {
+                        Some(Value(total_reward.0 / expected_nb_pools.get() as u64))
+                    } else {
+                        None
+                    }
+                }
+            };
+
             let total_blocks = leaders_log.total();
             let reward_unit = total_reward.split_in(total_blocks);
 
             for (pool_id, pool_blocks) in leaders_log.iter() {
-                let pool_total_reward = reward_unit.parts.scale(*pool_blocks).unwrap();
+                // possibly cap the reward for a given pool.
+                // if this is capped, then the overflow amount is send to treasury
+                let pool_total_reward_uncapped = reward_unit.parts.scale(*pool_blocks).unwrap();
+                let pool_total_reward = match pool_capper {
+                    None => pool_total_reward_uncapped,
+                    Some(pool_cap) => {
+                        let actual_pool_total = std::cmp::min(pool_cap, pool_total_reward_uncapped);
+                        let forfeited = (pool_total_reward_uncapped - actual_pool_total).unwrap();
+                        new_ledger.pots.treasury_add(forfeited)?;
+                        actual_pool_total
+                    }
+                };
 
                 match (
                     new_ledger

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -368,8 +368,15 @@ impl Ledger {
 
         let epoch = new_ledger.date.epoch + 1;
 
-        let expected_epoch_reward =
-            rewards::rewards_contribution_calculation(epoch, &ledger_params.reward_params);
+        let system_info = rewards::SystemInformation {
+            declared_stake: distribution.get_total_stake(),
+        };
+
+        let expected_epoch_reward = rewards::rewards_contribution_calculation(
+            epoch,
+            &ledger_params.reward_params,
+            &system_info,
+        );
 
         let drawn = new_ledger.pots.draw_reward(expected_epoch_reward);
 

--- a/chain-impl-mockchain/src/rewards.rs
+++ b/chain-impl-mockchain/src/rewards.rs
@@ -1,4 +1,5 @@
 use crate::block::Epoch;
+use crate::stake::Stake;
 use crate::value::{Value, ValueError};
 use chain_core::mempack::{ReadBuf, ReadError};
 use std::num::{NonZeroU32, NonZeroU64};
@@ -81,6 +82,13 @@ impl TaxType {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Limit {
+    /// The drawn value will be limited by the absoluted stake in the system
+    /// with a given ratio.
+    ByStakeAbsolute(Ratio),
+}
+
 /// Parameters for rewards calculation. This controls:
 ///
 /// * Rewards contributions
@@ -100,6 +108,8 @@ pub struct Parameters {
     pub epoch_rate: NonZeroU32,
     /// When to start
     pub epoch_start: Epoch,
+    /// Max Drawing limit
+    pub reward_drawing_limit_max: Option<Limit>,
 }
 
 impl Parameters {
@@ -110,6 +120,7 @@ impl Parameters {
             compounding_type: CompoundingType::Linear,
             epoch_rate: NonZeroU32::new(u32::max_value()).unwrap(),
             epoch_start: 0,
+            reward_drawing_limit_max: None,
         }
     }
 }
@@ -121,11 +132,20 @@ pub struct TaxDistribution {
     pub after_tax: Value,
 }
 
+#[derive(Debug, Clone)]
+pub struct SystemInformation {
+    pub declared_stake: Stake,
+}
+
 /// Calculate the reward contribution from the parameters
 ///
 /// Note that the contribution in the system is still bounded by the remaining
 /// rewards pot, which is not taken in considering for this calculation.
-pub fn rewards_contribution_calculation(epoch: Epoch, params: &Parameters) -> Value {
+pub fn rewards_contribution_calculation(
+    epoch: Epoch,
+    params: &Parameters,
+    system_info: &SystemInformation,
+) -> Value {
     assert!(params.epoch_rate.get() != 0);
 
     if epoch < params.epoch_start {
@@ -133,7 +153,7 @@ pub fn rewards_contribution_calculation(epoch: Epoch, params: &Parameters) -> Va
     }
 
     let zone = ((epoch - params.epoch_start) / params.epoch_rate.get()) as u64;
-    match params.compounding_type {
+    let drawn = match params.compounding_type {
         CompoundingType::Linear => {
             // C - rratio * (#epoch / erate)
             let rr = &params.compounding_ratio;
@@ -159,6 +179,15 @@ pub fn rewards_contribution_calculation(epoch: Epoch, params: &Parameters) -> Va
             }
 
             Value((acc / SCALE) as u64)
+        }
+    };
+
+    match params.reward_drawing_limit_max {
+        None => drawn,
+        Some(Limit::ByStakeAbsolute(ratio)) => {
+            let x = (u64::from(system_info.declared_stake) as u128 * ratio.numerator as u128)
+                / ratio.denominator.get() as u128;
+            std::cmp::min(drawn, Value(x as u64))
         }
     }
 }
@@ -243,8 +272,11 @@ mod tests {
         let mut params = Parameters::zero();
         params.epoch_start = 1;
         let epoch = 0;
+        let system_info = SystemInformation {
+            declared_stake: Stake::from_value(Value(100)),
+        };
         assert_eq!(
-            rewards_contribution_calculation(epoch, &params),
+            rewards_contribution_calculation(epoch, &params, &system_info),
             Value::zero()
         );
     }
@@ -283,6 +315,7 @@ mod tests {
                 compounding_type: CompoundingType::arbitrary(g),
                 epoch_rate: epoch_rate,
                 epoch_start: Arbitrary::arbitrary(g),
+                reward_drawing_limit_max: None,
             }
         }
     }

--- a/chain-impl-mockchain/src/rewards.rs
+++ b/chain-impl-mockchain/src/rewards.rs
@@ -84,6 +84,9 @@ impl TaxType {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Limit {
+    /// the drawn value will not be limited
+    None,
+
     /// The drawn value will be limited by the absoluted stake in the system
     /// with a given ratio.
     ByStakeAbsolute(Ratio),
@@ -109,7 +112,7 @@ pub struct Parameters {
     /// When to start
     pub epoch_start: Epoch,
     /// Max Drawing limit
-    pub reward_drawing_limit_max: Option<Limit>,
+    pub reward_drawing_limit_max: Limit,
 }
 
 impl Parameters {
@@ -120,7 +123,7 @@ impl Parameters {
             compounding_type: CompoundingType::Linear,
             epoch_rate: NonZeroU32::new(u32::max_value()).unwrap(),
             epoch_start: 0,
-            reward_drawing_limit_max: None,
+            reward_drawing_limit_max: Limit::None,
         }
     }
 }
@@ -183,8 +186,8 @@ pub fn rewards_contribution_calculation(
     };
 
     match params.reward_drawing_limit_max {
-        None => drawn,
-        Some(Limit::ByStakeAbsolute(ratio)) => {
+        Limit::None => drawn,
+        Limit::ByStakeAbsolute(ratio) => {
             let x = (u64::from(system_info.declared_stake) as u128 * ratio.numerator as u128)
                 / ratio.denominator.get() as u128;
             std::cmp::min(drawn, Value(x as u64))

--- a/chain-impl-mockchain/src/rewards.rs
+++ b/chain-impl-mockchain/src/rewards.rs
@@ -113,6 +113,9 @@ pub struct Parameters {
     pub epoch_start: Epoch,
     /// Max Drawing limit
     pub reward_drawing_limit_max: Limit,
+    /// Pool Capping
+    /// This doesn't really make sense
+    pub pool_participation_capping: Option<(NonZeroU32, NonZeroU32)>,
 }
 
 impl Parameters {
@@ -124,6 +127,7 @@ impl Parameters {
             epoch_rate: NonZeroU32::new(u32::max_value()).unwrap(),
             epoch_start: 0,
             reward_drawing_limit_max: Limit::None,
+            pool_participation_capping: None,
         }
     }
 }
@@ -329,6 +333,7 @@ mod tests {
                 epoch_rate: epoch_rate,
                 epoch_start: Arbitrary::arbitrary(g),
                 reward_drawing_limit_max: Limit::arbitrary(g),
+                pool_participation_capping: None,
             }
         }
     }

--- a/chain-impl-mockchain/src/rewards.rs
+++ b/chain-impl-mockchain/src/rewards.rs
@@ -302,6 +302,16 @@ mod tests {
         }
     }
 
+    impl Arbitrary for Limit {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            if bool::arbitrary(g) {
+                Limit::None
+            } else {
+                Limit::ByStakeAbsolute(Ratio::arbitrary(g))
+            }
+        }
+    }
+
     impl Arbitrary for Parameters {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
             let epoch_rate = {
@@ -318,7 +328,7 @@ mod tests {
                 compounding_type: CompoundingType::arbitrary(g),
                 epoch_rate: epoch_rate,
                 epoch_start: Arbitrary::arbitrary(g),
-                reward_drawing_limit_max: None,
+                reward_drawing_limit_max: Limit::arbitrary(g),
             }
         }
     }

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -34,7 +34,7 @@ pub struct Settings {
     pub reward_params: Option<RewardParams>,
     pub treasury_params: Option<rewards::TaxType>,
     pub fees_goes_to: FeesGoesTo,
-    pub rewards_limit: Option<rewards::Limit>,
+    pub rewards_limit: rewards::Limit,
 }
 
 /// Fees nSettings
@@ -71,7 +71,7 @@ impl Settings {
             reward_params: None,
             treasury_params: None,
             fees_goes_to: FeesGoesTo::Rewards,
-            rewards_limit: None,
+            rewards_limit: rewards::Limit::None,
         }
     }
 
@@ -148,9 +148,9 @@ impl Settings {
                         FeesGoesTo::Rewards
                     };
                 }
-                ConfigParam::RewardLimitNone => new_state.rewards_limit = None,
+                ConfigParam::RewardLimitNone => new_state.rewards_limit = rewards::Limit::None,
                 ConfigParam::RewardLimitByAbsoluteStake(ratio) => {
-                    new_state.rewards_limit = Some(rewards::Limit::ByStakeAbsolute(ratio.clone()))
+                    new_state.rewards_limit = rewards::Limit::ByStakeAbsolute(ratio.clone())
                 }
             }
         }

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -34,6 +34,7 @@ pub struct Settings {
     pub reward_params: Option<RewardParams>,
     pub treasury_params: Option<rewards::TaxType>,
     pub fees_goes_to: FeesGoesTo,
+    pub rewards_limit: Option<rewards::Limit>,
 }
 
 /// Fees nSettings
@@ -70,6 +71,7 @@ impl Settings {
             reward_params: None,
             treasury_params: None,
             fees_goes_to: FeesGoesTo::Rewards,
+            rewards_limit: None,
         }
     }
 
@@ -146,6 +148,10 @@ impl Settings {
                         FeesGoesTo::Rewards
                     };
                 }
+                ConfigParam::RewardLimitNone => new_state.rewards_limit = None,
+                ConfigParam::RewardLimitByAbsoluteStake(ratio) => {
+                    new_state.rewards_limit = Some(rewards::Limit::ByStakeAbsolute(ratio.clone()))
+                }
             }
         }
 
@@ -192,6 +198,8 @@ impl Settings {
     }
 
     pub fn to_reward_params(&self) -> rewards::Parameters {
+        let reward_drawing_limit_max = self.rewards_limit.clone();
+
         match self.reward_params {
             None => rewards::Parameters::zero(),
             Some(RewardParams::Halving {
@@ -205,6 +213,7 @@ impl Settings {
                 compounding_type: rewards::CompoundingType::Halvening,
                 epoch_start,
                 epoch_rate,
+                reward_drawing_limit_max,
             },
             Some(RewardParams::Linear {
                 constant,
@@ -217,6 +226,7 @@ impl Settings {
                 compounding_type: rewards::CompoundingType::Linear,
                 epoch_start,
                 epoch_rate,
+                reward_drawing_limit_max,
             },
         }
     }

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -13,6 +13,7 @@ use crate::{
     rewards,
 };
 use std::convert::TryFrom;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -35,6 +36,7 @@ pub struct Settings {
     pub treasury_params: Option<rewards::TaxType>,
     pub fees_goes_to: FeesGoesTo,
     pub rewards_limit: rewards::Limit,
+    pub pool_participation_capping: Option<(NonZeroU32, NonZeroU32)>,
 }
 
 /// Fees nSettings
@@ -72,6 +74,7 @@ impl Settings {
             treasury_params: None,
             fees_goes_to: FeesGoesTo::Rewards,
             rewards_limit: rewards::Limit::None,
+            pool_participation_capping: None,
         }
     }
 
@@ -152,6 +155,9 @@ impl Settings {
                 ConfigParam::RewardLimitByAbsoluteStake(ratio) => {
                     new_state.rewards_limit = rewards::Limit::ByStakeAbsolute(ratio.clone())
                 }
+                ConfigParam::PoolRewardParticipationCapping(r) => {
+                    new_state.pool_participation_capping = Some(r.clone())
+                }
             }
         }
 
@@ -199,6 +205,7 @@ impl Settings {
 
     pub fn to_reward_params(&self) -> rewards::Parameters {
         let reward_drawing_limit_max = self.rewards_limit.clone();
+        let pool_participation_capping = self.pool_participation_capping.clone();
 
         match self.reward_params {
             None => rewards::Parameters::zero(),
@@ -214,6 +221,7 @@ impl Settings {
                 epoch_start,
                 epoch_rate,
                 reward_drawing_limit_max,
+                pool_participation_capping,
             },
             Some(RewardParams::Linear {
                 constant,
@@ -227,6 +235,7 @@ impl Settings {
                 epoch_start,
                 epoch_rate,
                 reward_drawing_limit_max,
+                pool_participation_capping,
             },
         }
     }

--- a/chain-impl-mockchain/src/stake/distribution.rs
+++ b/chain-impl-mockchain/src/stake/distribution.rs
@@ -20,6 +20,12 @@ pub struct StakeDistribution {
     pub to_pools: HashMap<PoolId, PoolStakeInformation>,
 }
 
+impl StakeDistribution {
+    pub fn get_total_stake(&self) -> Stake {
+        Stake::sum(self.to_pools.values().map(|psi| psi.total.total_stake))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PoolStakeInformation {
     pub total: PoolStakeTotal,


### PR DESCRIPTION
Add random incentive levers/configuration knobs

* Add support for applying arbitrary maximum limit in how much is drawn from the reward pot at every given epoch. For now the only policy configurable, taken from #203, is a policy that compare a ratio of the declared stake in the system and cap the reward to the minimum of the two (comparing apples and oranges).
* taken from #203: Add ability to cap per pool reward to a maximum of the `total / set-value-of-pool-number`, but *only* if the threshold of the epoch participants is reached. It doesn't really make sense since it create an incentive to not go over the threshold in the(so that the reward are not capped), and then if the threshold is reached, the pool doesn't really have incentive to create more blocks than `1 / set-value-of-pools` % of stake.

clean rewrite of #203 