### PR TITLE
remove custom_error in favour of using thiserror

### DIFF
--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -25,10 +25,10 @@ imhamt = { path = "../imhamt" }
 sparse-array = { path = "../sparse-array" }
 strum = "0.15.0"
 strum_macros = "0.15.0"
-custom_error = "1.6"
 cfg-if = "0.1"
 quickcheck = { version = "0.8", optional = true }
 ed25519-bip32 = { version = "0.1", optional = true }
+thiserror = "1.0"
 
 cardano-legacy-address = { path= "../cardano-legacy-address" }
 

--- a/chain-impl-mockchain/src/accounting/account/mod.rs
+++ b/chain-impl-mockchain/src/accounting/account/mod.rs
@@ -4,26 +4,32 @@
 //! which contains a non negative value representing your balance with the
 //! identifier of this account as key.
 
+pub mod account_state;
+pub mod last_rewards;
+
 use crate::header::Epoch;
 use crate::value::*;
 use imhamt::{Hamt, InsertError, UpdateError};
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
-pub mod account_state;
-pub mod last_rewards;
+use thiserror::Error;
 
 pub use account_state::*;
 pub use last_rewards::LastRewards;
 
-custom_error! {
-    #[derive(Clone, PartialEq, Eq)]
-    pub LedgerError
-        NonExistent = "Account does not exist",
-        AlreadyExists = "Account already exists",
-        NeedTotalWithdrawal = "Operation counter reached its maximum and next operation must be full withdrawal",
-        NonZero = "Removed account is not empty",
-        ValueError{ source: ValueError } = "Value calculation failed",
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum LedgerError {
+    #[error("Account does not exist")]
+    NonExistent,
+    #[error("Account already exists")]
+    AlreadyExists,
+    #[error("Operation counter reached its maximum and next operation must be full withdrawal")]
+    NeedTotalWithdrawal,
+    #[error("Removed account is not empty")]
+    NonZero,
+    #[error("Value calculation failed")]
+    ValueError(#[from] ValueError),
 }
 
 impl From<UpdateError<LedgerError>> for LedgerError {

--- a/chain-impl-mockchain/src/leadership/genesis/mod.rs
+++ b/chain-impl-mockchain/src/leadership/genesis/mod.rs
@@ -14,6 +14,7 @@ use chain_crypto::Verification as SigningVerification;
 use chain_crypto::{
     digest::DigestOf, Blake2b256, Curve25519_2HashDH, PublicKey, SecretKey, SumEd25519_12,
 };
+use thiserror::Error;
 use typed_bytes::ByteBuilder;
 pub(crate) use vrfeval::witness_to_nonce;
 use vrfeval::VrfEvaluator;
@@ -48,9 +49,12 @@ pub struct LeadershipData {
     active_slots_coeff: ActiveSlotsCoeff,
 }
 
-custom_error! {GenesisError
-    InvalidEpoch { expected: Epoch, actual: Epoch } = "Wrong epoch, expected epoch {expected} but received block at epoch {actual}",
-    TotalStakeIsZero = "Total stake is null",
+#[derive(Debug, Error)]
+enum GenesisError {
+    #[error("Wrong epoch, expected epoch {expected} but received block at epoch {actual}")]
+    InvalidEpoch { expected: Epoch, actual: Epoch },
+    #[error("Total stake is null")]
+    TotalStakeIsZero,
 }
 
 impl LeadershipData {

--- a/chain-impl-mockchain/src/ledger/tests/apply_block_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/apply_block_tests.rs
@@ -167,11 +167,7 @@ pub fn apply_block_incorrect_fragment() {
         .build(&stake_pool, ledger.era());
 
     assert_err!(
-        Account {
-            source: ValueError {
-                source: NegativeAmount
-            }
-        },
+        Account(ValueError(NegativeAmount)),
         ledger.apply_block(block)
     );
 }

--- a/chain-impl-mockchain/src/ledger/tests/ledger_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/ledger_tests.rs
@@ -110,9 +110,7 @@ pub fn test_first_initial_fragment_empty() {
     let content = Vec::new();
     assert_eq!(
         Ledger::new(header_id, content).err().unwrap(),
-        Block0 {
-            source: Block0Error::InitialMessageMissing,
-        }
+        Block0(Block0Error::InitialMessageMissing)
     );
 }
 
@@ -141,9 +139,7 @@ pub fn ledger_new_no_block_start_time() {
         Ledger::new(header_id, vec![&Fragment::Initial(ie)])
             .err()
             .unwrap(),
-        Block0 {
-            source: Block0Error::InitialMessageNoDate,
-        }
+        Block0(Block0Error::InitialMessageNoDate)
     );
 }
 
@@ -162,9 +158,7 @@ pub fn ledger_new_no_discrimination() {
         Ledger::new(header_id, vec![&Fragment::Initial(ie)])
             .err()
             .unwrap(),
-        Block0 {
-            source: Block0Error::InitialMessageNoDiscrimination,
-        }
+        Block0(Block0Error::InitialMessageNoDiscrimination)
     );
 }
 
@@ -183,9 +177,7 @@ pub fn ledger_new_no_slot_duration() {
         Ledger::new(header_id, vec![&Fragment::Initial(ie)])
             .err()
             .unwrap(),
-        Block0 {
-            source: Block0Error::InitialMessageNoSlotDuration,
-        }
+        Block0(Block0Error::InitialMessageNoSlotDuration)
     );
 }
 
@@ -204,9 +196,7 @@ pub fn ledger_new_no_slots_per_epoch() {
         Ledger::new(header_id, vec![&Fragment::Initial(ie)])
             .err()
             .unwrap(),
-        Block0 {
-            source: Block0Error::InitialMessageNoSlotsPerEpoch,
-        }
+        Block0(Block0Error::InitialMessageNoSlotsPerEpoch)
     );
 }
 
@@ -225,9 +215,7 @@ pub fn ledger_new_no_kes_update_speed() {
         Ledger::new(header_id, vec![&Fragment::Initial(ie)])
             .err()
             .unwrap(),
-        Block0 {
-            source: Block0Error::InitialMessageNoKesUpdateSpeed,
-        }
+        Block0(Block0Error::InitialMessageNoKesUpdateSpeed)
     );
 }
 
@@ -245,8 +233,6 @@ pub fn ledger_new_no_bft_leader() {
         Ledger::new(header_id, vec![&Fragment::Initial(ie)])
             .err()
             .unwrap(),
-        Block0 {
-            source: Block0Error::InitialMessageNoConsensusLeaderId,
-        }
+        Block0(Block0Error::InitialMessageNoConsensusLeaderId)
     );
 }

--- a/chain-impl-mockchain/src/ledger/tests/transaction_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/transaction_tests.rs
@@ -36,12 +36,10 @@ pub fn transaction_fail_when_255_outputs() {
         .get_fragment();
 
     assert_err!(
-        TransactionMalformed {
-            source: TxVerifyError::TooManyOutputs {
-                expected: 254,
-                actual: 255
-            }
-        },
+        TransactionMalformed(TxVerifyError::TooManyOutputs {
+            expected: 254,
+            actual: 255
+        }),
         test_ledger.apply_transaction(fragment)
     );
 }
@@ -87,9 +85,7 @@ pub fn transaction_nonexisting_account_input() {
         .get_fragment();
 
     assert_err!(
-        Account {
-            source: NonExistent
-        },
+        Account(NonExistent),
         test_ledger.apply_transaction(fragment)
     );
 }

--- a/chain-impl-mockchain/src/lib.rs
+++ b/chain-impl-mockchain/src/lib.rs
@@ -1,8 +1,6 @@
 #[cfg(any(test, feature = "property-test-api"))]
 #[macro_use]
 extern crate quickcheck;
-#[macro_use(custom_error)]
-extern crate custom_error;
 
 pub mod account;
 pub mod accounting;

--- a/chain-impl-mockchain/src/multisig/declaration.rs
+++ b/chain-impl-mockchain/src/multisig/declaration.rs
@@ -3,6 +3,7 @@ use chain_crypto::{PublicKey, Signature};
 
 use super::index::{Index, TreeIndex, LEVEL_MAXLIMIT};
 pub use crate::transaction::WitnessMultisigData;
+use thiserror::Error;
 
 /// Account Identifier (also used as Public Key)
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -26,13 +27,16 @@ impl From<Identifier> for [u8; 32] {
     }
 }
 
-custom_error! {
-    #[derive(Clone, PartialEq, Eq)]
-    pub DeclarationError
-        ThresholdInvalid = "Invalid threshold",
-        HasNotEnoughOwners = "Not enough owners",
-        HasTooManyOwners = "Too many owners",
-        SubNotImplemented = "Sub not implemented",
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum DeclarationError {
+    #[error("Invalid threshold")]
+    ThresholdInvalid,
+    #[error("Not enough owners")]
+    HasNotEnoughOwners,
+    #[error("Too many owners")]
+    HasTooManyOwners,
+    #[error("Sub not implemented")]
+    SubNotImplemented,
 }
 
 impl std::fmt::Display for Identifier {

--- a/chain-impl-mockchain/src/testing/arbitrary/transaction.rs
+++ b/chain-impl-mockchain/src/testing/arbitrary/transaction.rs
@@ -14,6 +14,7 @@ use chain_addr::{Address, Kind};
 use chain_crypto::{Ed25519, PublicKey};
 use quickcheck::{Arbitrary, Gen};
 use std::iter;
+use thiserror::Error;
 
 #[derive(Clone, Debug)]
 pub struct ArbitraryValidTransactionData {
@@ -159,12 +160,23 @@ impl ArbitraryValidTransactionData {
 
 pub struct AccountStatesVerifier(pub ArbitraryValidTransactionData);
 
-custom_error! {
-    #[derive(Clone, PartialEq, Eq)]
-    pub Error
-        AccountNotFound { element: PublicKey<Ed25519> } = "Cannot find coresponding account address for expected {element}",
-        UtxoNotFound { output: PublicKey<Ed25519>, value: Value} = "Cannot find expected output: {output} with value: {value}",
-        WrongValue { element: PublicKey<Ed25519>, expected: Value, actual: Value } = "Address funds are different for {element} than expected: {expected}, but got: {actual}",
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum Error {
+    #[error("Cannot find coresponding account address for expected {element}")]
+    AccountNotFound { element: PublicKey<Ed25519> },
+    #[error("Cannot find expected output: {output} with value: {value}")]
+    UtxoNotFound {
+        output: PublicKey<Ed25519>,
+        value: Value,
+    },
+    #[error(
+        "Address funds are different for {element} than expected: {expected}, but got: {actual}"
+    )]
+    WrongValue {
+        element: PublicKey<Ed25519>,
+        expected: Value,
+        actual: Value,
+    },
 }
 
 impl AccountStatesVerifier {

--- a/chain-impl-mockchain/src/testing/scenario/controller.rs
+++ b/chain-impl-mockchain/src/testing/scenario/controller.rs
@@ -13,11 +13,14 @@ use super::{
 };
 use chain_addr::Discrimination;
 
-custom_error! {
-    #[derive(Clone, PartialEq, Eq)]
-    pub ControllerError
-        UnknownWallet { alias: String } = "cannot find wallet with alias {alias}",
-        UnknownStakePool { alias: String } = "cannot find stake pool with alias {alias}",
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ControllerError {
+    #[error("cannot find wallet with alias {alias}")]
+    UnknownWallet { alias: String },
+    #[error("cannot find stake pool with alias {alias}")]
+    UnknownStakePool { alias: String },
 }
 
 pub struct Controller {

--- a/chain-impl-mockchain/src/testing/scenario/scenario_builder.rs
+++ b/chain-impl-mockchain/src/testing/scenario/scenario_builder.rs
@@ -20,13 +20,18 @@ use super::{
     Controller,
 };
 
-custom_error! {
-    #[derive(Clone, PartialEq, Eq)]
-    pub ScenarioBuilderError
-        UndefinedConfig = " no config defined",
-        UndefinedInitials =  "no initials defined",
-        NoOwnersForStakePool{ alias: String} = "stake pool '{alias}' must have at least one owner",
-        UndefinedValueForWallet { alias: String }= "with(...) method must be used for '{alias}' wallet in scenario builder. "
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ScenarioBuilderError {
+    #[error("no config defined")]
+    UndefinedConfig,
+    #[error("no initials defined")]
+    UndefinedInitials,
+    #[error("stake pool '{alias}' must have at least one owner")]
+    NoOwnersForStakePool { alias: String },
+    #[error("with(...) method must be used for '{alias}' wallet in scenario builder. ")]
+    UndefinedValueForWallet { alias: String },
 }
 
 pub struct ScenarioBuilder {

--- a/chain-impl-mockchain/src/transaction/element.rs
+++ b/chain-impl-mockchain/src/transaction/element.rs
@@ -3,6 +3,7 @@ use crate::transaction::TransactionBindingAuthData;
 use crate::value::{Value, ValueError};
 use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_crypto::{digest::DigestOf, Blake2b256, Ed25519, PublicKey, Signature, Verification};
+use thiserror::Error;
 use typed_bytes::ByteBuilder;
 
 pub struct TransactionSignData(Box<[u8]>);
@@ -98,19 +99,12 @@ pub enum Balance {
     Zero,
 }
 
-type Filler = ();
-#[allow(unused_variables)]
-custom_error! {
-    #[derive(Clone, PartialEq, Eq)]
-    pub BalanceError
-        InputsTotalFailed { source: ValueError, filler: Filler } = @{{
-            let _ = (source, filler);
-            "failed to compute total input"
-        }},
-        OutputsTotalFailed { source: ValueError, filler: Filler } = @{{
-            let _ = (source, filler);
-            "failed to compute total output"
-        }},
-        NotBalanced { inputs: Value, outputs: Value }
-            = "transaction value not balanced, has inputs sum {inputs} and outputs sum {outputs}",
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum BalanceError {
+    #[error("failed to compute total input")]
+    InputsTotalFailed(#[source] ValueError),
+    #[error("failed to compute total output")]
+    OutputsTotalFailed(#[source] ValueError),
+    #[error("transaction value not balanced, has inputs sum {inputs} and outputs sum {outputs}")]
+    NotBalanced { inputs: Value, outputs: Value },
 }

--- a/chain-impl-mockchain/src/transaction/transaction.rs
+++ b/chain-impl-mockchain/src/transaction/transaction.rs
@@ -392,11 +392,11 @@ impl<P> Transaction<P> {
     pub fn verify_strictly_balanced(&self, fee: Value) -> Result<(), BalanceError> {
         let inputs = self
             .total_input()
-            .map_err(|source| BalanceError::InputsTotalFailed { source, filler: () })?;
+            .map_err(BalanceError::InputsTotalFailed)?;
         let outputs = self
             .total_output()
             .and_then(|out| out + fee)
-            .map_err(|source| BalanceError::OutputsTotalFailed { source, filler: () })?;
+            .map_err(BalanceError::OutputsTotalFailed)?;
         if inputs != outputs {
             Err(BalanceError::NotBalanced { inputs, outputs })?;
         };
@@ -406,10 +406,10 @@ impl<P> Transaction<P> {
     pub fn verify_possibly_balanced(&self) -> Result<(), BalanceError> {
         let inputs = self
             .total_input()
-            .map_err(|source| BalanceError::InputsTotalFailed { source, filler: () })?;
+            .map_err(BalanceError::InputsTotalFailed)?;
         let outputs = self
             .total_output()
-            .map_err(|source| BalanceError::OutputsTotalFailed { source, filler: () })?;
+            .map_err(BalanceError::OutputsTotalFailed)?;
         if inputs < outputs {
             Err(BalanceError::NotBalanced { inputs, outputs })?;
         };
@@ -501,11 +501,11 @@ impl<'a, P> TransactionSlice<'a, P> {
     pub fn verify_strictly_balanced(&self, fee: Value) -> Result<(), BalanceError> {
         let inputs = self
             .total_input()
-            .map_err(|source| BalanceError::InputsTotalFailed { source, filler: () })?;
+            .map_err(BalanceError::InputsTotalFailed)?;
         let outputs = self
             .total_output()
             .and_then(|out| out + fee)
-            .map_err(|source| BalanceError::OutputsTotalFailed { source, filler: () })?;
+            .map_err(BalanceError::OutputsTotalFailed)?;
         if inputs != outputs {
             Err(BalanceError::NotBalanced { inputs, outputs })?;
         };

--- a/chain-impl-mockchain/src/txbuilder.rs
+++ b/chain-impl-mockchain/src/txbuilder.rs
@@ -16,6 +16,7 @@ use crate::transaction::{self as tx, Balance};
 use crate::value::{Value, ValueError};
 use chain_addr::Address;
 use std::{error, fmt};
+use thiserror::Error;
 
 #[derive(Clone, Debug)]
 /// Transaction builder is an object to construct
@@ -177,10 +178,13 @@ pub struct TransactionFinalizer {
     witnesses: Vec<Option<tx::Witness>>,
 }
 
-custom_error! {pub BuildError
-    WitnessOutOfBound { index: usize, max: usize } = "Witness index {index} out of bound (max {max})",
-    WitnessMismatch { index: usize } = "Invalid witness type at index {index}",
-    MissingWitnessAt { index: usize } = "Missing a witness for input at index {index}",
+pub enum BuildError {
+    #[error("Witness index {index} out of bound (max {max})")]
+    WitnessOutOfBound { index: usize, max: usize },
+    #[error("Invalid witness type at index {index}")]
+    WitnessMismatch { index: usize },
+    #[error("Missing a witness for input at index {index}")]
+    MissingWitnessAt { index: usize },
 }
 
 impl TransactionFinalizer {

--- a/chain-impl-mockchain/src/utxo.rs
+++ b/chain-impl-mockchain/src/utxo.rs
@@ -10,15 +10,18 @@ use chain_addr::Address;
 use sparse_array::{FastSparseArray, FastSparseArrayBuilder, FastSparseArrayIter};
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
+use thiserror::Error;
 
 use imhamt::{Hamt, HamtIter, InsertError, RemoveError, ReplaceError, UpdateError};
 
-custom_error! {
-    #[derive(Clone, PartialEq, Eq)]
-    pub Error
-        AlreadyExists = "Transaction ID Already exist",
-        TransactionNotFound = "Transaction is not found",
-        IndexNotFound = "Index not found",
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum Error {
+    #[error("Transaction ID Already exist")]
+    AlreadyExists,
+    #[error("Transaction is not found")]
+    TransactionNotFound,
+    #[error("Index not found")]
+    IndexNotFound,
 }
 
 impl From<InsertError> for Error {

--- a/chain-impl-mockchain/src/value.rs
+++ b/chain-impl-mockchain/src/value.rs
@@ -3,6 +3,7 @@ use chain_core::mempack::{ReadBuf, ReadError, Readable};
 use chain_core::property;
 use std::convert::TryFrom;
 use std::ops;
+use thiserror::Error;
 
 /// Unspent transaction value.
 #[cfg_attr(feature = "generic-serialization", derive(serde_derive::Serialize))]
@@ -71,13 +72,16 @@ impl Value {
     }
 }
 
-custom_error! {
-    #[derive(Clone, PartialEq, Eq)]
-    pub ValueError
-        NegativeAmount = "Value cannot be negative",
-        Overflow = "Value overflowed its maximum value",
-        FromSliceTooSmall = "Value from too small slice",
-        FromSliceTooBig = "Value from too big slice",
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ValueError {
+    #[error("Value cannot be negative")]
+    NegativeAmount,
+    #[error("Value overflowed its maximum value")]
+    Overflow,
+    #[error("Value from too small slice")]
+    FromSliceTooSmall,
+    #[error("Value from too big slice")]
+    FromSliceTooBig,
 }
 
 impl ops::Add for Value {


### PR DESCRIPTION
- Code becomes easier to navigate because now it uses the native enum syntax
- For the same reason it can be formatted with `rustfmt`
- More consistent error handling

Related to input-output-hk/jormungandr#1165