### PR TITLE
chain-storage: add the MissingParent error

### DIFF
--- a/chain-storage/src/error.rs
+++ b/chain-storage/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     BackendError(Box<dyn std::error::Error + Send + Sync>),
     Block0InFuture,
     BlockAlreadyPresent,
+    MissingParent,
 }
 
 impl fmt::Display for Error {
@@ -17,6 +18,7 @@ impl fmt::Display for Error {
             Error::BackendError(err) => write!(f, "{}", err),
             Error::Block0InFuture => write!(f, "block0 is in the future"),
             Error::BlockAlreadyPresent => write!(f, "Block already present in DB"),
+            Error::MissingParent => write!(f, "the parent block is missing for the required write"),
         }
     }
 }

--- a/chain-storage/src/store.rs
+++ b/chain-storage/src/store.rs
@@ -65,7 +65,10 @@ pub trait BlockStore {
         let depth = if parent_hash == <Self::Block as Block>::Id::zero() {
             1
         } else {
-            let parent_info = self.get_block_info(&parent_hash)?;
+            let parent_info = self.get_block_info(&parent_hash).map_err(|e| match e {
+                Error::BlockNotFound => Error::MissingParent,
+                e => e,
+            })?;
             assert!(parent_info.depth > 0);
             let depth = 1 + parent_info.depth;
             let fast_link = compute_fast_link(depth);


### PR DESCRIPTION
Return the new `MissingParent` error from `put_block` instead of `BlockNotFound` which doesn't make any sense in this place.