### PR TITLE
require explicit sqlite connections creation

### DIFF
--- a/chain-storage-sqlite-old/src/lib.rs
+++ b/chain-storage-sqlite-old/src/lib.rs
@@ -19,6 +19,10 @@ pub struct SQLiteBlockStore {
     persistent_connection: Option<Connection>,
 }
 
+// persistent_connection does not implement Sync but is never actually used
+// which makes it safe to be shared
+unsafe impl Sync for SQLiteBlockStore {}
+
 pub struct SQLiteBlockStoreConnection<B>
 where
     B: Block,

--- a/chain-storage-sqlite-old/src/lib.rs
+++ b/chain-storage-sqlite-old/src/lib.rs
@@ -82,9 +82,7 @@ impl SQLiteBlockStore {
             .execute_batch("pragma journal_mode = WAL")
             .unwrap();
 
-        if let StoreType::Memory = store.store_type {
-            store.persistent_connection = Some(connection);
-        }
+        store.persistent_connection = Some(connection);
 
         store
     }
@@ -318,7 +316,7 @@ mod tests {
     #[test]
     fn simultaneous_read_write() {
         let mut rng = OsRng;
-        let mut store =
+        let store =
             SQLiteBlockStore::file("file:test_simultaneous_read_write?mode=memory&cache=shared");
 
         let mut conn = store.connect::<TestBlock>().unwrap();

--- a/chain-storage-sqlite-old/src/lib.rs
+++ b/chain-storage-sqlite-old/src/lib.rs
@@ -116,6 +116,17 @@ fn blob_to_hash<Id: BlockId>(blob: Vec<u8>) -> Id {
     Id::deserialize(&blob[..]).unwrap()
 }
 
+impl<B> SQLiteBlockStoreConnection<B>
+where
+    B: Block,
+{
+    pub fn ping(&self) -> Result<(), Error> {
+        self.inner
+            .execute_batch("")
+            .map_err(|e| Error::BackendError(Box::new(e)))
+    }
+}
+
 impl<B> BlockStore for SQLiteBlockStoreConnection<B>
 where
     B: Block,

--- a/chain-storage-sqlite-old/src/lib.rs
+++ b/chain-storage-sqlite-old/src/lib.rs
@@ -86,7 +86,7 @@ where
         }
     }
 
-    pub fn connect(&mut self) -> Result<SQLiteBlockStoreConnection<B>, Error> {
+    pub fn connect(&self) -> Result<SQLiteBlockStoreConnection<B>, Error> {
         Ok(SQLiteBlockStoreConnection {
             connection: self
                 .pool


### PR DESCRIPTION
This is required for more efficient connection pool usage. Now users are
required to explicitly create database connections which are then reused
for database operations instead of getting them from the connection pool
for each operation.

Breaking change: SQLiteBlockStoreConnection implements BlockStore
instead of SQLiteBlockStore.