### PR TITLE
network-core: More detailed Display impl for Error

### DIFF
--- a/network-core/src/error.rs
+++ b/network-core/src/error.rs
@@ -63,6 +63,6 @@ impl fmt::Display for Error {
             Code::Internal => "internal processing error",
             Code::Unavailable => "the service is unavailable",
         };
-        f.write_str(msg)
+        write!(f, "{} ({})", msg, self.source)
     }
 }


### PR DESCRIPTION
Report the source error information in addition to the code-derived generic message.