### PR TITLE
storage: put_block error if block exists

### DIFF
--- a/chain-storage/src/store.rs
+++ b/chain-storage/src/store.rs
@@ -51,7 +51,7 @@ pub trait BlockStore {
         let block_hash = block.id();
 
         if self.block_exists(&block_hash)? {
-            return Ok(());
+            return Err(Error::BlockAlreadyPresent);
         }
 
         let parent_hash = block.parent_id();


### PR DESCRIPTION
Do not ignore duplicate blocks in `put_block`.
The error is useful to detect when multiple streams of blocks are applied concurrently from different peers.