### PR TITLE
Lockless Multiverse

### DIFF
--- a/chain-impl-mockchain/src/header/components.rs
+++ b/chain-impl-mockchain/src/header/components.rs
@@ -25,6 +25,11 @@ impl ChainLength {
     pub fn increase(&self) -> Self {
         ChainLength(self.0.checked_add(1).unwrap())
     }
+
+    #[inline]
+    pub fn nth_ancestor(&self, depth: u32) -> Option<ChainLength> {
+        self.0.checked_sub(depth).map(ChainLength)
+    }
 }
 
 impl std::fmt::Display for ChainLength {

--- a/chain-impl-mockchain/src/header/components.rs
+++ b/chain-impl-mockchain/src/header/components.rs
@@ -22,6 +22,7 @@ impl From<ChainLength> for u32 {
 }
 
 impl ChainLength {
+    #[inline]
     pub fn increase(&self) -> Self {
         ChainLength(self.0.checked_add(1).unwrap())
     }

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -38,6 +38,7 @@ const SUFFIX_TO_KEEP: u32 = 50;
 
 /// A RAII wrapper around a block identifier and the state pointer
 /// that keeps the state corresponding to the block pinned in memory.
+#[derive(Clone)]
 pub struct Ref<State> {
     hash: HeaderId,
     state: Arc<State>,

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -56,6 +56,10 @@ impl<State> Ref<State> {
     pub fn state(&self) -> &State {
         &self.state
     }
+
+    pub fn state_arc(&self) -> Arc<State> {
+        self.state.clone()
+    }
 }
 
 impl<State> Multiverse<State> {


### PR DESCRIPTION
Remove internal locking from the `Multiverse` collection, reimplemented garbage collection with `Arc`/`Weak` pointers.