### PR TITLE
network: protocol method ExchangeGossip

### DIFF
--- a/network-core/src/client/gossip.rs
+++ b/network-core/src/client/gossip.rs
@@ -9,6 +9,12 @@ use futures::prelude::*;
 pub trait GossipService: P2pService {
     type Node: Node<Id = Self::NodeId>;
 
+    /// The type of asynchronous futures returned by method `gossip_exchange`.
+    type ExchangeGossipFuture: Future<Item = Gossip<Self::Node>, Error = Error>;
+
+    /// A one-off gossip exchange with the remote peer.
+    fn exchange_gossip(&mut self, gossip: Gossip<Self::Node>) -> Self::ExchangeGossipFuture;
+
     /// The type of an asynchronous stream that provides node gossip messages
     /// sent by the peer.
     type GossipSubscription: Stream<Item = Gossip<Self::Node>, Error = Error>;

--- a/network-core/src/server/gossip.rs
+++ b/network-core/src/server/gossip.rs
@@ -13,6 +13,9 @@ pub trait GossipService: P2pService {
     /// Gossip message describing a network node.
     type Node: Node<Id = Self::NodeId>;
 
+    /// The type of asynchronous futures returned by method `exchange_gossip`.
+    type ExchangeGossipFuture: Future<Item = Gossip<Self::Node>, Error = Error> + Send + 'static;
+
     /// The type of a bidirectional subscription object that is used as:
     ///
     /// - a stream for outbound gossip;
@@ -30,6 +33,9 @@ pub trait GossipService: P2pService {
     type GossipSubscriptionFuture: Future<Item = Self::GossipSubscription, Error = Error>
         + Send
         + 'static;
+
+    /// Responds to an incoming one-off gossip exchange request from a peer.
+    fn exchange_gossip(&mut self, gossip: Gossip<Self::Node>) -> Self::ExchangeGossipFuture;
 
     /// Establishes a bidirectional subscription for node gossip messages.
     ///

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -111,6 +111,9 @@ service Node {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 
+  // A one-off gossip exchange.
+  rpc ExchangeGossip(Gossip) returns (Gossip);
+
   // Requests headers of blocks in the chain in the chronological order,
   // given a selection of possible starting blocks known by the requester,
   // and the identifier of the end block to be included in the returned


### PR DESCRIPTION
Add network protocol method `ExchangeGossip` to facilitate one-off gossip exchanges.
This can be used during bootstrap to get the initial gossip from a trusted peer and then disconnect, offloading the trusted peers for serving other nodes.