### PR TITLE
add peers message in protobuf

### DIFF
--- a/network-core/src/client/gossip.rs
+++ b/network-core/src/client/gossip.rs
@@ -1,7 +1,7 @@
 use super::p2p::P2pService;
 use crate::{
     error::Error,
-    gossip::{Gossip, Node},
+    gossip::{Gossip, Node, PeersResponse},
 };
 
 use futures::prelude::*;
@@ -22,6 +22,8 @@ pub trait GossipService: P2pService {
         Error = Error,
     >;
 
+    type PeersFuture: Future<Item = PeersResponse, Error = Error> + Send + 'static;
+
     /// Establishes a bidirectional stream of notifications for gossip
     /// messages.
     ///
@@ -30,4 +32,6 @@ pub trait GossipService: P2pService {
     fn gossip_subscription<S>(&mut self, outbound: S) -> Self::GossipSubscriptionFuture
     where
         S: Stream<Item = Gossip<Self::Node>, Error = Error> + Send + 'static;
+
+    fn peers(&mut self) -> Self::PeersFuture;
 }

--- a/network-core/src/gossip.rs
+++ b/network-core/src/gossip.rs
@@ -22,6 +22,21 @@ pub trait Node {
 }
 
 #[derive(Clone, Debug)]
+pub struct Peer {
+    pub addr: SocketAddr,
+}
+
+#[derive(Clone, Debug)]
+pub struct PeersRequest {
+    pub limit: u32,
+}
+
+#[derive(Clone, Debug)]
+pub struct PeersResponse {
+    pub peers: Vec<Peer>,
+}
+
+#[derive(Clone, Debug)]
 pub struct Gossip<T: Node> {
     nodes: Vec<T>,
 }

--- a/network-core/src/server/gossip.rs
+++ b/network-core/src/server/gossip.rs
@@ -2,7 +2,7 @@
 use super::{request_stream, P2pService};
 use crate::{
     error::Error,
-    gossip::{Gossip, Node},
+    gossip::{Gossip, Node, PeersResponse},
 };
 
 use futures::prelude::*;
@@ -31,6 +31,8 @@ pub trait GossipService: P2pService {
         + Send
         + 'static;
 
+    type PeersFuture: Future<Item = PeersResponse, Error = Error> + Send + 'static;
+
     /// Establishes a bidirectional subscription for node gossip messages.
     ///
     /// The network protocol implementation passes the node identifier of
@@ -41,4 +43,6 @@ pub trait GossipService: P2pService {
     /// outbound gossip messages, and as an asynchrounous sink for inbound
     /// gossip messages.
     fn gossip_subscription(&mut self, subscriber: Self::NodeId) -> Self::GossipSubscriptionFuture;
+
+    fn peers(&mut self) -> Self::PeersFuture;
 }

--- a/network-grpc/proto/node.proto
+++ b/network-grpc/proto/node.proto
@@ -36,6 +36,37 @@ message FragmentIds {
   repeated bytes ids = 1;
 }
 
+// Request for peers
+message PeersRequest {
+  uint32 limit = 1;
+}
+
+// Responses as a bunch of peers
+message PeersResponse {
+  repeated Peer peers = 1;
+}
+
+// A Peer on the network
+message Peer {
+  oneof peer {
+    PeerV4 v4 = 1;
+    PeerV6 v6 = 2;
+  }
+}
+
+// An ipv4 peer
+message PeerV4 {
+  fixed32 ip = 1;
+  fixed32 port = 2;
+}
+
+// An ipv6 peer
+message PeerV6 {
+  fixed64 ip_high = 1;
+  fixed64 ip_low = 2;
+  fixed32 port = 3;
+}
+
 // Request message for method PullHeaders.
 // This message can also be send by the service as a BlockEvent variant.
 message PullHeadersRequest {
@@ -101,6 +132,10 @@ message BlockEvent {
 service Node {
   rpc Handshake(HandshakeRequest) returns (HandshakeResponse);
   rpc Tip(TipRequest) returns (TipResponse);
+
+  // Requests for some peers
+  rpc Peers(PeersRequest) returns (PeersResponse);
+
   rpc GetBlocks(BlockIds) returns (stream Block) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }

--- a/network-grpc/src/client.rs
+++ b/network-grpc/src/client.rs
@@ -16,7 +16,7 @@ use crate::{
 use chain_core::property;
 use network_core::client::{BlockService, Client, FragmentService, GossipService, P2pService};
 use network_core::error as core_error;
-use network_core::gossip::{self, Gossip};
+use network_core::gossip::{self, Gossip, PeersResponse};
 use network_core::subscription::BlockEvent;
 
 use futures::prelude::*;
@@ -282,6 +282,7 @@ where
     type GossipSubscription = server_streaming::ResponseStream<Gossip<P::Node>, gen::node::Gossip>;
     type GossipSubscriptionFuture =
         subscription::ResponseFuture<Gossip<P::Node>, Self::NodeId, gen::node::Gossip>;
+    type PeersFuture = unary::ResponseFuture<PeersResponse, gen::node::PeersResponse>;
 
     fn gossip_subscription<Out>(&mut self, outbound: Out) -> Self::GossipSubscriptionFuture
     where
@@ -290,5 +291,11 @@ where
         let req = self.new_subscription_request(outbound);
         let future = self.service.gossip_subscription(req);
         subscription::ResponseFuture::new(future)
+    }
+
+    fn peers(&mut self) -> Self::PeersFuture {
+        let req = gen::node::PeersRequest { limit: 128 };
+        let future = self.service.peers(Request::new(req));
+        unary::ResponseFuture::new(future)
     }
 }

--- a/network-grpc/src/service.rs
+++ b/network-grpc/src/service.rs
@@ -107,6 +107,10 @@ where
         gen::node::TipResponse,
         <<T as Node>::BlockService as BlockService>::TipFuture,
     >;
+
+    type PeersFuture =
+        ResponseFuture<gen::node::PeersResponse, <T::GossipService as GossipService>::PeersFuture>;
+
     type GetBlocksStream = ResponseStream<
         gen::node::Block,
         <<T as Node>::BlockService as BlockService>::GetBlocksStream,
@@ -207,6 +211,11 @@ where
     fn tip(&mut self, _request: Request<gen::node::TipRequest>) -> Self::TipFuture {
         let service = try_get_service!(self.inner.block_service());
         ResponseFuture::new(service.tip())
+    }
+
+    fn peers(&mut self, _request: Request<gen::node::PeersRequest>) -> Self::PeersFuture {
+        let service = try_get_service!(self.inner.gossip_service());
+        ResponseFuture::new(service.peers())
     }
 
     fn get_blocks(&mut self, req: Request<gen::node::BlockIds>) -> Self::GetBlocksFuture {


### PR DESCRIPTION
Add the peers message to get a list of peers from a distant node

* PeersRequest is not really used anywhere, we just hardcode some value for now

please review for any major issues; the minor issues will be not be addresses on this one but later
