### PR TITLE
Move heap allocations to mmap slices

### DIFF
--- a/btree/Cargo.toml
+++ b/btree/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 byteorder = "1.3.2"
 thiserror = "1.0.9"
 memmap = "0.7.0"
+parking_lot = "0.10.0"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/btree/src/btreeindex/metadata.rs
+++ b/btree/src/btreeindex/metadata.rs
@@ -33,7 +33,7 @@ impl StaticSettings {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Metadata {
     pub root: PageId,
     pub page_manager: PageManager,

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -2,7 +2,6 @@ mod metadata;
 mod node;
 mod page_manager;
 mod pages;
-#[allow(dead_code)]
 mod version_management;
 
 use version_management::transaction::{InsertTransaction, ReadTransaction};

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -26,14 +26,6 @@ where
     K: Key,
     T: AsMut<[u8]> + AsRef<[u8]> + 'b,
 {
-    pub(crate) fn from_raw_mut(data: T, key_buffer_size: usize) -> Node<K, T> {
-        Node {
-            data,
-            key_buffer_size,
-            phantom: PhantomData,
-        }
-    }
-
     pub(crate) fn new_internal(key_buffer_size: usize, buffer: T) -> Node<K, T> {
         let mut buffer = buffer;
         buffer.as_mut()[0..TAG_SIZE].copy_from_slice(&0u64.to_le_bytes());
@@ -164,7 +156,7 @@ mod tests {
         let i2 = insertions[1];
         let i3 = insertions[2];
 
-        let buffer = MemPage::new(dbg!(mem_size));
+        let buffer = MemPage::new(mem_size);
         buffer.as_ref().len();
         let mut node: Node<U64Key, MemPage> =
             Node::new_internal(std::mem::size_of::<U64Key>(), buffer);
@@ -186,7 +178,6 @@ mod tests {
             _ => panic!("second insertion shouldn't split"),
         };
 
-        println!("Inserting splitting key");
         match node
             .as_internal_mut()
             .unwrap()

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use leaf_node::{LeafInsertStatus, LeafNode};
 const LEN_SIZE: usize = 8;
 const TAG_SIZE: usize = 8;
 
-pub(crate) struct Node<K, T> {
+pub struct Node<K, T> {
     data: T,
     key_buffer_size: usize,
     phantom: PhantomData<[K]>,

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -1,175 +1,156 @@
 use crate::btreeindex::node::Node;
 use crate::btreeindex::PageId;
-use crate::storage::{MmapStorage, Storage};
+use crate::storage::MmapStorage;
 use crate::Key;
-use crate::MemPage;
-use byteorder::{ByteOrder, LittleEndian};
-use std::convert::{TryFrom, TryInto};
-use std::sync::{Arc, RwLock};
+use std::marker::PhantomData;
 
 /// An abstraction over a paged file, Pages is kind of an array but backed from disk. Page represents at the moment
 /// a heap allocated read/write page, while PageRef is a wrapper to share a read only page in an Arc
 /// when we move to mmap, this things may change to take advantage of zero copy.
 
-#[derive(Clone)]
-pub(crate) struct Pages {
-    storage: Arc<RwLock<MmapStorage>>,
+pub struct Pages {
+    storage: MmapStorage,
     page_size: u16,
-    // TODO: we need to remove this from here
-    key_buffer_size: u32,
 }
 
 // TODO: move this unsafe impls to MmapStorage? although what is most safe is saying that RwLock<MmapStorage> is Sync + Send
 unsafe impl Send for Pages {}
 unsafe impl Sync for Pages {}
 
-pub(crate) struct PagesInitializationParams {
-    pub(crate) storage: MmapStorage,
-    pub(crate) page_size: u16,
-    pub(crate) key_buffer_size: u32,
+pub struct PagesInitializationParams {
+    pub storage: MmapStorage,
+    pub page_size: u16,
+    pub key_buffer_size: u32,
 }
 
 impl Pages {
-    pub(crate) fn new(params: PagesInitializationParams) -> Self {
+    pub fn new(params: PagesInitializationParams) -> Self {
         let PagesInitializationParams {
             storage,
             page_size,
-            key_buffer_size,
+            key_buffer_size: _,
         } = params;
 
-        let storage = Arc::new(RwLock::new(storage));
+        Pages { storage, page_size }
+    }
 
-        Pages {
-            storage,
-            page_size,
-            key_buffer_size,
+    pub fn get_page<'a>(&'a self, id: PageId) -> Option<PageHandle<'a, borrow::Immutable>> {
+        // TODO: Check the page is actually in range
+        // TODO: check mutable aliasing
+        let storage = &self.storage;
+        let from = u64::from(id.checked_sub(1).expect("0 page is used as a null ptr"))
+            * u64::from(self.page_size);
+
+        let page = unsafe { storage.get(from, u64::from(self.page_size)) };
+        let handle = PageHandle {
+            id,
+            borrow: borrow::Immutable { borrow: page },
+            page_marker: PhantomData,
+        };
+
+        Some(handle)
+    }
+
+    pub fn mut_page<'a>(&'a self, id: PageId) -> Result<PageHandle<'a, borrow::Mutable>, ()> {
+        // TODO: add checks so the same page is not mutated more than once
+        let storage = &self.storage;
+        let from = u64::from(id.checked_sub(1).expect("0 page is used as a null ptr"))
+            * u64::from(self.page_size);
+
+        // Make sure there is a mapped area for this page
+        match unsafe { storage.get_mut(from, u64::from(self.page_size)) } {
+            Ok(page) => Ok(PageHandle {
+                id,
+                borrow: borrow::Mutable { borrow: page },
+                page_marker: PhantomData,
+            }),
+            Err(_) => Err(()),
         }
     }
 
-    fn read_page(&self, id: PageId) -> MemPage {
-        let storage = self.storage.read().unwrap();
-        let buf = storage
-            .get(
-                u64::from(id.checked_sub(1).expect("0 page is used as a null ptr"))
-                    * u64::from(self.page_size),
-                self.page_size.into(),
-            )
-            .unwrap();
+    pub fn make_shadow(&self, old_id: PageId, new_id: PageId) -> Result<(), ()> {
+        assert!(old_id != new_id);
+        let page_old = self
+            .get_page(old_id)
+            .expect("tried to shadow non existing page");
 
-        let page_size = self.page_size.try_into().unwrap();
-        let mut page = MemPage::new(page_size);
+        let mut page_new = self.mut_page(new_id)?;
 
-        // Ideally, we don't want to make any copies here, but that would require making the mmaped
-        // storage thread safe (specially if the mmap gets remapped)
-        page.as_mut().copy_from_slice(&buf[..page_size]);
-
-        page
-    }
-
-    pub(crate) fn write_page(&self, page: Page) -> Result<(), std::io::Error> {
-        let mem_page = &page.mem_page;
-        let page_id = page.page_id;
-
-        let mut storage = self.storage.write().unwrap();
-
-        storage
-            .put(
-                u64::from(page_id.checked_sub(1).unwrap()) * u64::try_from(mem_page.len()).unwrap(),
-                &mem_page.as_ref(),
-            )
-            .unwrap();
+        page_new.as_slice(|slice| slice.copy_from_slice(page_old.borrow.borrow));
 
         Ok(())
     }
 
-    pub(crate) fn get_page<'a>(&'a self, id: PageId) -> Option<PageRef> {
-        // TODO: Check the id is in range?
-        let page = self.read_page(id);
+    pub fn extend(&mut self, to: PageId) -> Result<(), std::io::Error> {
+        let storage = &mut self.storage;
 
-        let page_ref = PageRef::new(Page {
-            page_id: id,
-            key_buffer_size: self.key_buffer_size,
-            mem_page: page,
-        });
+        let from = u64::from(to.checked_sub(1).expect("0 page is used as a null ptr"))
+            * u64::from(self.page_size);
 
-        Some(page_ref.clone())
+        storage.resize(from + u64::from(self.page_size))
     }
 
     pub(crate) fn sync_file(&self) -> Result<(), std::io::Error> {
-        self.storage
-            .write()
-            .expect("Coulnd't acquire tree index lock")
-            .sync()
+        self.storage.sync()
     }
 }
 
-use std::fmt;
-impl fmt::Debug for Page {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let tag = LittleEndian::read_u64(&self.mem_page.as_ref()[0..8]);
-        write!(f, "Page {{ page_id: {}, tag: {} }}", self.page_id, tag)
+pub mod borrow {
+
+    pub struct Immutable<'a> {
+        pub borrow: &'a [u8],
+    }
+    pub struct Mutable<'a> {
+        pub borrow: &'a mut [u8],
     }
 }
 
-pub struct Page {
-    pub page_id: PageId,
-    pub key_buffer_size: u32,
-    pub mem_page: MemPage,
+pub struct PageHandle<'a, Borrow: 'a> {
+    id: PageId,
+    borrow: Borrow,
+    page_marker: PhantomData<&'a Borrow>,
 }
 
-#[derive(Clone)]
-pub(crate) struct PageRef(Arc<Page>);
-
-unsafe impl Send for PageRef {}
-unsafe impl Sync for PageRef {}
-
-impl std::ops::Deref for PageRef {
-    type Target = Arc<Page>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl<'a, T> PageHandle<'a, T> {
+    pub fn id(&self) -> PageId {
+        self.id
     }
 }
 
-impl Page {
-    pub(crate) fn as_node<K, R>(&self, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+impl<'a> PageHandle<'a, borrow::Immutable<'a>> {
+    pub fn as_node<K, R>(
+        &self,
+        _page_size: u64,
+        key_buffer_size: usize,
+        f: impl FnOnce(Node<K, &[u8]>) -> R,
+    ) -> R
     where
         K: Key,
     {
-        let page: &[u8] = self.mem_page.as_ref();
-        let node =
-            Node::<K, &[u8]>::from_raw(page.as_ref(), self.key_buffer_size.try_into().unwrap());
-        f(node)
-    }
+        let page = self.borrow.borrow;
 
-    pub(crate) fn as_node_mut<K, R>(&mut self, f: impl FnOnce(Node<K, &mut [u8]>) -> R) -> R
-    where
-        K: Key,
-    {
-        let page = self.mem_page.as_mut();
-        let node = Node::<K, &mut [u8]>::from_raw_mut(
-            page.as_mut(),
-            self.key_buffer_size.try_into().unwrap(),
-        );
-        f(node)
-    }
+        let node = Node::<K, &[u8]>::from_raw(page.as_ref(), key_buffer_size);
 
-    pub(crate) fn id(&self) -> PageId {
-        self.page_id
+        f(node)
     }
 }
 
-impl PageRef {
-    pub(crate) fn new(page: Page) -> Self {
-        PageRef(Arc::new(page))
+impl<'a> PageHandle<'a, borrow::Mutable<'a>> {
+    pub fn as_node_mut<K, R>(
+        &mut self,
+        _page_size: u64,
+        key_buffer_size: usize,
+        f: impl FnOnce(Node<K, &mut [u8]>) -> R,
+    ) -> R
+    where
+        K: Key,
+    {
+        let node = Node::<K, &mut [u8]>::from_raw(self.borrow.borrow, key_buffer_size);
+        f(node)
     }
 
-    pub(crate) fn get_mut(&self) -> Page {
-        let page = &self.0;
-        Page {
-            page_id: page.page_id,
-            key_buffer_size: page.key_buffer_size,
-            mem_page: page.mem_page.clone(),
-        }
+    pub fn as_slice(&mut self, f: impl FnOnce(&mut [u8])) {
+        f(self.borrow.borrow);
     }
 }
 

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -1,13 +1,19 @@
-use super::metadata::Metadata;
-use super::page_manager::PageManager;
-
+pub mod transaction;
 use super::pages::*;
+use super::Metadata;
 use super::Node;
 use super::PageId;
+use crate::btreeindex::page_manager::PageManager;
 use crate::mem_page::MemPage;
 use crate::Key;
+use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::marker::PhantomData;
+use transaction::{
+    borrow::{Immutable, Mutable},
+    traits::{ReadTransaction as _, WriteTransaction as _},
+    InsertTransaction, PageHandle, ReadTransaction,
+};
 
 use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
@@ -37,36 +43,19 @@ pub(crate) struct Checkpoint<'a> {
 }
 
 impl Version {
-    pub(crate) fn root(&self) -> PageId {
+    pub fn root(&self) -> PageId {
         self.root
     }
 }
 
-pub(crate) enum WriteTransactionBuilder<'a, 'index> {
-    Insert(InsertTransactionBuilder<'a, 'index>),
-}
-
-/// staging area for batched insertions, it will keep track of pages already shadowed and reuse them,
-/// it can be used to create a new `Version` at the end with all the insertions done atomically
-pub(crate) struct InsertTransactionBuilder<'index, 'locks: 'index> {
-    pages: &'index Pages,
-    current_root: PageId,
-    extra: HashMap<PageId, Page>,
-    old_ids: Vec<PageId>,
-    current: Option<usize>,
-    page_manager: MutexGuard<'locks, PageManager>,
-    versions: MutexGuard<'locks, VecDeque<Arc<Version>>>,
-    current_version: Arc<RwLock<Arc<Version>>>,
-}
-
 /// this is basically a stack, but it will rename pointers and interact with the builder in order to reuse
 /// already cloned pages
-pub(crate) struct InsertBacktrack<'txbuilder, 'txmanager: 'txbuilder, 'index: 'txmanager, K>
+pub struct InsertBacktrack<'txbuilder, 'txmanager: 'txbuilder, K>
 where
     K: Key,
 {
-    builder: &'txbuilder mut InsertTransactionBuilder<'txmanager, 'index>,
-    backtrack: Vec<(Option<PageId>, Page)>,
+    builder: &'txbuilder mut transaction::InsertTransaction<'txmanager>,
+    backtrack: Vec<PageId>,
     new_root: Option<PageId>,
     phantom_key: PhantomData<[K]>,
 }
@@ -96,26 +85,28 @@ impl TransactionManager {
         self.latest_version.read().unwrap().clone()
     }
 
-    pub fn read_transaction(&self) -> Arc<Version> {
-        self.latest_version()
+    pub fn read_transaction(&self, pages: Pages) -> ReadTransaction {
+        ReadTransaction::new(self.latest_version(), pages)
     }
 
     pub fn insert_transaction<'me, 'index: 'me>(
         &'me self,
         pages: &'index Pages,
-    ) -> InsertTransactionBuilder<'me, 'me> {
+    ) -> InsertTransaction<'me> {
         let page_manager = self.page_manager.lock().unwrap();
         let versions = self.versions.lock().unwrap();
 
-        InsertTransactionBuilder {
+        InsertTransaction {
             current_root: self.latest_version().root(),
             extra: HashMap::new(),
             old_ids: vec![],
-            pages,
+            pages: pages.clone(),
             current: None,
             page_manager,
             versions,
             current_version: self.latest_version.clone(),
+            version: self.latest_version(),
+            borrowed: std::collections::HashSet::new(),
         }
     }
 
@@ -166,139 +157,42 @@ impl TransactionManager {
     }
 }
 
-impl<'txmanager, 'index: 'txmanager> InsertTransactionBuilder<'txmanager, 'index> {
-    /// create a staging area for a single insert
-    pub(crate) fn backtrack<'me, K>(&'me mut self) -> InsertBacktrack<'me, 'txmanager, 'index, K>
-    where
-        K: Key,
-    {
-        InsertBacktrack {
-            builder: self,
-            backtrack: vec![],
-            new_root: None,
-            phantom_key: PhantomData,
-        }
-    }
-
-    pub(crate) fn delete_node(&mut self, id: PageId) {
-        self.old_ids.push(id);
-    }
-
-    pub(crate) fn add_new_node(
-        &mut self,
-        mem_page: crate::mem_page::MemPage,
-        key_buffer_size: u32,
-    ) -> PageId {
-        let id = self.page_manager.new_id();
-        let page = Page {
-            page_id: id,
-            mem_page,
-            key_buffer_size,
-        };
-
-        // TODO: handle this error
-        self.extra.insert(page.page_id, page);
-        id
-    }
-
-    pub(crate) fn current_root(&self) -> PageId {
-        self.current_root
-    }
-
-    pub(crate) fn mut_page(&mut self, id: PageId) -> Option<(Option<PageId>, Page)> {
-        match self.extra.remove(&id) {
-            Some(page) => Some((None, page)),
-            None => {
-                let page = match self.pages.get_page(id).map(|page| page.get_mut()) {
-                    Some(page) => page,
-                    None => return None,
-                };
-
-                let mut shadow = page;
-                let old_id = shadow.page_id;
-                shadow.page_id = self.page_manager.new_id();
-
-                Some((Some(old_id), shadow))
-            }
-        }
-    }
-
-    pub(crate) fn add_shadow(&mut self, old_id: PageId, shadow: Page) {
-        self.extra.insert(shadow.page_id, shadow);
-        self.old_ids.push(old_id);
-    }
-
-    pub(crate) fn has_next(&self) -> bool {
-        self.current.is_some()
-    }
-
-    /// commit creates a new version of the tree, it doesn't sync the file, but it makes the version
-    /// available to new readers
-    pub(crate) fn commit<K>(mut self)
-    where
-        K: Key,
-    {
-        let pages = self.pages;
-
-        for (_id, page) in self.extra.drain() {
-            pages.write_page(page).unwrap();
-        }
-
-        let transaction = WriteTransaction {
-            new_root: self.current_root,
-            shadowed_pages: self.old_ids,
-            // Pages allocated at the end, basically
-            next_page_id: self.page_manager.next_page(),
-        };
-
-        let mut current_version = self.current_version.write().unwrap();
-
-        self.versions.push_back(current_version.clone());
-
-        *current_version = Arc::new(Version {
-            root: self.current_root,
-            transaction,
-        });
-    }
-
-    // not really needed because the destructor has basically the same effect right now
-    pub(crate) fn abort(self) {
-        unimplemented!()
-    }
-}
-
 impl<'txbuilder, 'txmanager: 'txbuilder, 'index: 'txmanager, K>
-    InsertBacktrack<'txbuilder, 'txmanager, 'index, K>
+    InsertBacktrack<'txbuilder, 'txmanager, K>
 where
     K: Key,
 {
     pub(crate) fn search_for(&mut self, key: &K) {
-        let mut current = self.builder.current_root();
+        let mut current = self.builder.root();
 
         loop {
-            let (old_id, page) = self.builder.mut_page(current).unwrap();
+            let page = self.builder.get_page(current).unwrap();
 
-            let found_leaf = page.as_node(|node: Node<K, &[u8]>| {
-                if let Some(inode) = node.as_internal() {
-                    let upper_pivot = match inode.keys().binary_search(key) {
-                        Ok(pos) => Some(pos + 1),
-                        Err(pos) => Some(pos),
-                    }
-                    .filter(|pos| pos < &inode.children().len());
+            let found_leaf = page.as_node(
+                self.page_size,
+                self.key_buffer_size,
+                |node: Node<K, &[u8]>| {
+                    if let Some(inode) = node.as_internal() {
+                        let upper_pivot = match inode.keys().binary_search(key) {
+                            Ok(pos) => Some(pos + 1),
+                            Err(pos) => Some(pos),
+                        }
+                        .filter(|pos| pos < &inode.children().len());
 
-                    if let Some(upper_pivot) = upper_pivot {
-                        current = inode.children().get(upper_pivot).unwrap().clone();
+                        if let Some(upper_pivot) = upper_pivot {
+                            current = inode.children().get(upper_pivot).unwrap().clone();
+                        } else {
+                            let last = inode.children().len().checked_sub(1).unwrap();
+                            current = inode.children().get(last).unwrap().clone();
+                        }
+                        false
                     } else {
-                        let last = inode.children().len().checked_sub(1).unwrap();
-                        current = inode.children().get(last).unwrap().clone();
+                        true
                     }
-                    false
-                } else {
-                    true
-                }
-            });
+                },
+            );
 
-            self.backtrack.push((old_id, page));
+            self.backtrack.push(page);
 
             if found_leaf {
                 break;
@@ -306,27 +200,26 @@ where
         }
     }
 
-    pub(crate) fn get_next(&mut self) -> Option<&mut Page> {
-        let (old_id, last) = match self.backtrack.pop() {
-            Some(pair) => pair,
+    pub(crate) fn get_next(&mut self) -> Option<PageHandle<Mutable>> {
+        let id = match self.backtrack.pop() {
+            Some(id) => id,
             None => return None,
         };
-
-        let id = last.page_id;
 
         if self.backtrack.is_empty() {
             assert!(self.new_root.is_none());
             self.new_root = Some(id);
         }
 
-        if let Some(old_id) = old_id {
-            self.rename_parent(old_id, id);
-            self.builder.add_shadow(old_id, last);
-        } else {
-            self.builder.extra.insert(id, last);
-        }
+        let mut_page = self.builder.mut_page(id).unwrap();
 
-        self.builder.extra.get_mut(&id)
+        match mut_page {
+            transaction::MutPage::NeedsShadow { old_id, page } => {
+                self.rename_parent(old_id, id);
+                Some(page)
+            }
+            transaction::MutPage::AlreadyInTransaction(handle) => handle,
+        };
     }
 
     pub(crate) fn rename_parent(&mut self, old_id: PageId, new_id: PageId) {
@@ -364,13 +257,12 @@ where
     }
 }
 
-impl<'txbuilder, 'txmanager: 'txbuilder, 'index: 'txmanager, K> Drop
-    for InsertBacktrack<'txbuilder, 'txmanager, 'index, K>
+impl<'txbuilder, 'txmanager: 'txbuilder, K> Drop for InsertBacktrack<'txbuilder, 'txmanager, K>
 where
     K: Key,
 {
     fn drop(&mut self) {
-        while let Some(_) = InsertBacktrack::<'txbuilder, 'txmanager, 'index, K>::get_next(self) {
+        while let Some(_) = InsertBacktrack::<'txbuilder, 'txmanager, K>::get_next(self) {
             ()
         }
 

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -1,260 +1,299 @@
 use super::Version;
-use crate::btreeindex::{page_manager::PageManager, Node, Page, PageId, Pages};
-use crate::mem_page::MemPage;
+use crate::btreeindex::{
+    borrow::{Immutable, Mutable},
+    page_manager::PageManager,
+    Node, PageHandle, PageId, Pages,
+};
 use crate::Key;
-use std::cell::RefCell;
+use parking_lot::lock_api;
+use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::marker::PhantomData;
-use std::sync::{atomic::AtomicBool, Arc, MutexGuard, RwLock};
-use traits::ReadTransaction as _;
+use std::sync::{Arc, MutexGuard};
 
-pub mod borrow {
-    use super::*;
-    pub struct Immutable {}
-    pub struct Mutable {
-        signal: Arc<AtomicBool>,
-    }
-}
-pub struct PageHandle<'a, Borrow> {
-    id: PageId,
-    raw_ptr: *mut u8,
-    _lifetime_marker: PhantomData<&'a Page>,
-    borrow: Borrow,
+pub enum MutablePage<'a, 'b: 'a, 'c: 'b> {
+    NewShadowingPage(RenamePointers<'a, 'b, 'c>),
+    InTransaction(PageHandle<'a, Mutable<'a>>),
 }
 
-impl<'a> PageHandle<'a, borrow::Immutable> {
-    pub fn as_node<K, R>(
-        &self,
-        page_size: usize,
+pub struct RenamePointers<'a, 'b: 'a, 'c: 'a> {
+    tx: &'a mut InsertTransaction<'b, 'c>,
+    last_old_id: PageId,
+    last_new_id: PageId,
+    shadowed_page: PageId,
+}
+
+impl<'a, 'b: 'a, 'c: 'b> RenamePointers<'a, 'b, 'c> {
+    pub fn rename_parent<K: Key>(
+        self,
+        page_size: u64,
         key_buffer_size: usize,
-        f: impl FnOnce(Node<K, &[u8]>) -> R,
-    ) -> R
-    where
-        K: Key,
-    {
-        let page: &'a [u8] = unsafe { std::slice::from_raw_parts(self.raw_ptr, page_size) };
-        let node = Node::<K, &[u8]>::from_raw(page.as_ref(), key_buffer_size);
-        f(node)
+        parent_id: PageId,
+    ) -> Result<MutablePage<'a, 'b, 'c>, std::io::Error> {
+        let (parent_needs_shadowing, mut parent) = self.tx.mut_page_unchecked(parent_id)?;
+
+        let old_id = self.last_old_id;
+        let new_id = self.last_new_id;
+        parent.as_node_mut(
+            page_size,
+            key_buffer_size,
+            |mut node: Node<K, &mut [u8]>| {
+                let mut node = node.as_internal_mut().unwrap();
+                let pos_to_update = match node.children().linear_search(old_id) {
+                    Some(pos) => pos,
+                    None => unreachable!(),
+                };
+
+                node.children_mut().update(pos_to_update, &new_id).unwrap();
+            },
+        );
+
+        let parent_new_id = parent.id();
+        if parent_needs_shadowing {
+            Ok(MutablePage::NewShadowingPage(RenamePointers {
+                tx: self.tx,
+                last_old_id: parent_id,
+                last_new_id: parent_new_id,
+                shadowed_page: self.shadowed_page,
+            }))
+        } else {
+            Ok(MutablePage::InTransaction(self.finish()))
+        }
     }
 
-    unsafe fn make_mut(self, signal: Arc<AtomicBool>) -> PageHandle<'a, borrow::Mutable> {
-        let PageHandle { id, raw_ptr, .. } = self;
-
-        PageHandle {
-            id,
-            raw_ptr,
-            _lifetime_marker: PhantomData,
-            borrow: borrow::Mutable { signal },
+    pub fn finish(self) -> PageHandle<'a, Mutable<'a>> {
+        match self.tx.mut_page(self.shadowed_page).unwrap() {
+            MutablePage::InTransaction(handle) => handle,
+            _ => unreachable!(),
         }
     }
 }
 
-pub enum MutPage<'a> {
-    NeedsShadow {
-        old_id: PageId,
-        page: PageHandle<'a, borrow::Mutable>,
-    },
-    AlreadyInTransaction(PageHandle<'a, borrow::Mutable>),
-}
-
-pub mod traits {
-    use super::*;
-    pub trait ReadTransaction {
-        fn root(&self) -> PageId;
-        fn get_page<'a>(&'a self, id: PageId) -> Option<PageHandle<'a, borrow::Immutable>>;
-    }
-
-    pub trait WriteTransaction: ReadTransaction {
-        fn add_new_node(&mut self, mem_page: MemPage, key_buffer_size: u32) -> PageId;
-
-        fn mut_page(&mut self, id: PageId) -> Option<MutPage>;
-
-        fn delete_node(&mut self, id: PageId);
-
-        /// commit creates a new version of the tree, it doesn't sync the file, but it makes the version
-        /// available to new readers
-        fn commit<K: Key>(self);
-    }
-}
-
-pub struct ReadTransaction {
+pub struct ReadTransaction<'a> {
     version: Arc<Version>,
-    pages: Pages,
-    ownership: RefCell<HashMap<PageId, Page>>,
+    pages: RwLockReadGuard<'a, Pages>,
 }
 
-impl ReadTransaction {
-    pub(super) fn new(version: Arc<Version>, pages: Pages) -> Self {
-        ReadTransaction {
-            version,
-            pages,
-            ownership: RefCell::new(HashMap::new()),
-        }
+impl<'a> ReadTransaction<'a> {
+    pub(super) fn new(version: Arc<Version>, pages: RwLockReadGuard<Pages>) -> ReadTransaction {
+        ReadTransaction { version, pages }
     }
-}
 
-impl traits::ReadTransaction for ReadTransaction {
-    fn root(&self) -> PageId {
+    pub fn root(&self) -> PageId {
         self.version.root
     }
 
-    fn get_page(&self, id: PageId) -> Option<PageHandle<borrow::Immutable>> {
-        if let Some(page) = self.ownership.borrow_mut().get_mut(&id) {
-            let id = page.id();
-            let raw_ptr = page.mem_page.as_mut().as_mut_ptr();
-            return Some(PageHandle {
-                id,
-                raw_ptr,
-                _lifetime_marker: PhantomData,
-                borrow: borrow::Immutable,
-            });
-        }
-
-        let page = self.pages.get_page(id);
-
-        if let Some(page) = page {
-            {
-                let page = page.get_mut();
-                self.ownership.borrow_mut().insert(id, page);
-            }
-            self.get_page(id)
-        } else {
-            None
-        }
+    pub fn get_page(&self, id: PageId) -> Option<PageHandle<Immutable>> {
+        self.pages.get_page(id)
     }
 }
 
 /// staging area for batched insertions, it will keep track of pages already shadowed and reuse them,
 /// it can be used to create a new `Version` at the end with all the insertions done atomically
-pub(crate) struct InsertTransaction<'locks> {
+pub(crate) struct InsertTransaction<'locks, 'storage: 'locks> {
     pub current_root: PageId,
-    pub extra: HashMap<PageId, Page>,
-    pub old_ids: Vec<PageId>,
+    pub shadows: HashMap<PageId, PageId>,
+    pub shadows_image: HashSet<PageId>,
     pub current: Option<usize>,
     pub page_manager: MutexGuard<'locks, PageManager>,
+    pub pages: Option<RwLockUpgradableReadGuard<'storage, Pages>>,
     pub versions: MutexGuard<'locks, VecDeque<Arc<Version>>>,
     pub current_version: Arc<RwLock<Arc<Version>>>,
     pub version: Arc<Version>,
-    pub pages: Pages,
-    borrowed: HashMap<PageId, Arc<()>>,
+    pub key_buffer_size: u32,
+    pub page_size: u64,
 }
 
-impl<'locks> traits::ReadTransaction for InsertTransaction<'locks> {
-    fn root(&self) -> PageId {
-        self.current_root
+impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
+    pub fn root(&self) -> PageId {
+        self.shadows
+            .get(&self.current_root)
+            .map(|root| *root)
+            .unwrap_or(self.current_root)
     }
 
-    fn get_page(&self, id: PageId) -> Option<PageHandle<borrow::Immutable>> {
-        if let Some(page) = self.extra.get_mut(&id) {
-            let id = page.id();
-            let raw_ptr = page.mem_page.as_mut().as_mut_ptr();
-            return Some(PageHandle {
-                id,
-                raw_ptr,
-                _lifetime_marker: PhantomData,
-                borrow: Immutable,
-            });
-        }
-
-        let page = self.pages.get_page(id);
-
-        if let Some(page) = page {
-            {
-                let page = page.get_mut();
-                self.extra.insert(id, page);
-            }
-            self.get_page(id)
-        } else {
-            None
-        }
+    pub fn get_page(&self, id: PageId) -> Option<PageHandle<Immutable>> {
+        self.shadows_image
+            .get(&id)
+            .or_else(|| self.shadows.get(&id))
+            .or_else(|| Some(&id))
+            .and_then(|id| self.pages.as_ref().unwrap().get_page(*id))
     }
-}
 
-impl<'locks> traits::WriteTransaction for InsertTransaction<'locks> {
-    fn add_new_node(&mut self, mem_page: crate::mem_page::MemPage, key_buffer_size: u32) -> PageId {
+    pub fn add_new_node(
+        &mut self,
+        mem_page: crate::mem_page::MemPage,
+        _key_buffer_size: u32,
+    ) -> Result<PageId, std::io::Error> {
         let id = self.page_manager.new_id();
-        let page = Page {
-            page_id: id,
-            mem_page,
-            key_buffer_size,
+
+        let result = self.pages.as_ref().unwrap().mut_page(id);
+
+        let mut page_handle = match result {
+            Ok(page_handle) => page_handle,
+            Err(()) => {
+                self.extend_storage(id)?;
+                // infallible now, after extending the storage
+                self.pages.as_ref().unwrap().mut_page(id).unwrap()
+            }
         };
 
-        // TODO: handle this error
-        self.extra.insert(page.page_id, page);
-        id
+        page_handle.as_slice(|page| page.copy_from_slice(mem_page.as_ref()));
+
+        Ok(id)
     }
 
-    fn mut_page(&mut self, id: PageId) -> Option<MutPage> {
-        if self.borrowed.contains(&id) {
-            panic!("tried to borrow page mutably twice");
-        }
+    pub fn mut_page(
+        &mut self,
+        id: PageId,
+    ) -> Result<MutablePage<'_, 'locks, 'storage>, std::io::Error> {
+        match self
+            .shadows_image
+            .get(&id)
+            .or_else(|| self.shadows.get(&id))
+        {
+            Some(id) => {
+                let handle = self
+                    .pages
+                    .as_ref()
+                    .unwrap()
+                    .mut_page(*id)
+                    .expect("already fetched transaction was not allocated");
 
-        let already_fetched = self.extra.contains_key(&id);
-
-        let handle = self
-            .get_page(id)
-            .map(|inmutable_handle| inmutable_handle.make_mut());
-
-        handle.map(|handle| {
-            if already_fetched {
-                MutPage::AlreadyInTransaction(handle)
-            } else {
-                let old_id = handle.id;
-                self.old_ids.push(old_id);
-                handle.id = self.page_manager.new_id();
-                MutPage::NeedsShadow {
-                    old_id,
-                    page: handle,
-                }
+                Ok(MutablePage::InTransaction(handle))
             }
-        })
+            None => {
+                let old_id = id;
+                let new_id = self.page_manager.new_id();
+
+                let result = self.pages.as_ref().unwrap().make_shadow(old_id, new_id);
+
+                self.shadows.insert(old_id, new_id);
+                self.shadows_image.insert(new_id);
+
+                match result {
+                    Ok(()) => (),
+                    Err(()) => {
+                        self.extend_storage(new_id)?;
+                        self.pages
+                            .as_ref()
+                            .unwrap()
+                            .make_shadow(old_id, new_id)
+                            .unwrap();
+                    }
+                }
+
+                Ok(MutablePage::NewShadowingPage(RenamePointers {
+                    tx: self,
+                    last_old_id: old_id,
+                    last_new_id: new_id,
+                    shadowed_page: old_id,
+                }))
+            }
+        }
     }
 
-    fn delete_node(&mut self, id: PageId) {
-        self.old_ids.push(id);
+    fn mut_page_unchecked(
+        &mut self,
+        id: PageId,
+    ) -> Result<(bool, PageHandle<Mutable>), std::io::Error> {
+        match self
+            .shadows_image
+            .get(&id)
+            .or_else(|| self.shadows.get(&id))
+        {
+            Some(id) => {
+                let handle = self
+                    .pages
+                    .as_ref()
+                    .unwrap()
+                    .mut_page(*id)
+                    .expect("already fetched transaction was not allocated");
+
+                Ok((false, handle))
+            }
+            None => {
+                let old_id = id;
+                let new_id = self.page_manager.new_id();
+
+                let result = self.pages.as_ref().unwrap().make_shadow(old_id, new_id);
+
+                self.shadows.insert(old_id, new_id);
+                self.shadows_image.insert(new_id);
+
+                match result {
+                    Ok(()) => (),
+                    Err(()) => {
+                        self.extend_storage(new_id)?;
+                        // Infallible after extending
+                        self.pages
+                            .as_ref()
+                            .unwrap()
+                            .make_shadow(old_id, new_id)
+                            .unwrap();
+                    }
+                }
+
+                let handle = self.pages.as_ref().unwrap().mut_page(new_id).unwrap();
+
+                Ok((true, handle))
+            }
+        }
+    }
+
+    fn extend_storage(&mut self, including: PageId) -> Result<(), std::io::Error> {
+        let mut write_guard =
+            lock_api::RwLockUpgradableReadGuard::upgrade(self.pages.take().unwrap());
+
+        (*write_guard).extend(including)?;
+
+        let new_guard = lock_api::RwLockWriteGuard::downgrade_to_upgradable(write_guard);
+        self.pages = Some(new_guard);
+
+        Ok(())
     }
 
     /// commit creates a new version of the tree, it doesn't sync the file, but it makes the version
     /// available to new readers
-    fn commit<K>(mut self)
+    pub fn commit<K>(mut self)
     where
         K: Key,
     {
-        let pages = self.pages;
-
-        for (_id, page) in self.extra.drain() {
-            pages.write_page(page).unwrap();
-        }
-
         let transaction = super::WriteTransaction {
-            new_root: self.current_root,
-            shadowed_pages: self.old_ids,
+            new_root: self.root(),
+            shadowed_pages: self.shadows.keys().cloned().collect(),
             // Pages allocated at the end, basically
             next_page_id: self.page_manager.next_page(),
         };
 
-        let mut current_version = self.current_version.write().unwrap();
-
-        self.versions.push_back(current_version.clone());
+        let mut current_version = self.current_version.write();
 
         *current_version = Arc::new(Version {
-            root: self.current_root,
+            root: self.root(),
             transaction,
         });
+
+        self.versions.push_back(current_version.clone());
     }
 }
 
-impl<'txmanager> InsertTransaction<'txmanager> {
+impl<'txmanager, 'storage> InsertTransaction<'txmanager, 'storage> {
     /// create a staging area for a single insert
-    pub(crate) fn backtrack<'me, K>(&'me mut self) -> super::InsertBacktrack<'me, 'txmanager, K>
+    pub(crate) fn backtrack<'me, K>(
+        &'me mut self,
+    ) -> super::InsertBacktrack<'me, 'txmanager, 'storage, K>
     where
         K: Key,
     {
+        let key_buffer_size = self.key_buffer_size.clone();
+        let page_size = self.page_size.clone();
         super::InsertBacktrack {
             builder: self,
             backtrack: vec![],
             new_root: None,
             phantom_key: PhantomData,
+            key_buffer_size,
+            page_size,
         }
     }
 

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -9,70 +9,36 @@ use parking_lot::lock_api;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::sync::{Arc, MutexGuard};
-
-pub enum MutablePage<'a, 'b: 'a, 'c: 'b> {
-    NewShadowingPage(RenamePointers<'a, 'b, 'c>),
-    InTransaction(PageHandle<'a, Mutable<'a>>),
-}
-
-pub struct RenamePointers<'a, 'b: 'a, 'c: 'a> {
-    tx: &'a mut InsertTransaction<'b, 'c>,
-    last_old_id: PageId,
-    last_new_id: PageId,
-    shadowed_page: PageId,
-}
-
-impl<'a, 'b: 'a, 'c: 'b> RenamePointers<'a, 'b, 'c> {
-    pub fn rename_parent<K: Key>(
-        self,
-        page_size: u64,
-        key_buffer_size: usize,
-        parent_id: PageId,
-    ) -> Result<MutablePage<'a, 'b, 'c>, std::io::Error> {
-        let (parent_needs_shadowing, mut parent) = self.tx.mut_page_unchecked(parent_id)?;
-
-        let old_id = self.last_old_id;
-        let new_id = self.last_new_id;
-        parent.as_node_mut(
-            page_size,
-            key_buffer_size,
-            |mut node: Node<K, &mut [u8]>| {
-                let mut node = node.as_internal_mut().unwrap();
-                let pos_to_update = match node.children().linear_search(old_id) {
-                    Some(pos) => pos,
-                    None => unreachable!(),
-                };
-
-                node.children_mut().update(pos_to_update, &new_id).unwrap();
-            },
-        );
-
-        let parent_new_id = parent.id();
-        if parent_needs_shadowing {
-            Ok(MutablePage::NewShadowingPage(RenamePointers {
-                tx: self.tx,
-                last_old_id: parent_id,
-                last_new_id: parent_new_id,
-                shadowed_page: self.shadowed_page,
-            }))
-        } else {
-            Ok(MutablePage::InTransaction(self.finish()))
-        }
-    }
-
-    pub fn finish(self) -> PageHandle<'a, Mutable<'a>> {
-        match self.tx.mut_page(self.shadowed_page).unwrap() {
-            MutablePage::InTransaction(handle) => handle,
-            _ => unreachable!(),
-        }
-    }
-}
 
 pub struct ReadTransaction<'a> {
     version: Arc<Version>,
     pages: RwLockReadGuard<'a, Pages>,
 }
+
+/// staging area for batched insertions, it will keep track of pages already shadowed and reuse them,
+/// it can be used to create a new `Version` at the end with all the insertions done atomically
+pub(crate) struct InsertTransaction<'locks, 'storage: 'locks> {
+    pub current_root: PageId,
+    /// maps old_id -> new_id
+    shadows: HashMap<PageId, PageId>,
+    /// in order to find shadows by the new_id (as we already redirected pointers to this)
+    shadows_image: HashSet<PageId>,
+    page_manager: MutexGuard<'locks, PageManager>,
+    versions: MutexGuard<'locks, VecDeque<Arc<Version>>>,
+    pages: ExtendablePages<'storage>,
+    current_version: Arc<RwLock<Arc<Version>>>,
+    key_buffer_size: u32,
+    page_size: u64,
+}
+
+// in most cases, we can access the storage with read only access, but in the (rare) cases
+// where we need to extend the underlying mmaped file, we need to get exclusive access to the storage
+// it is actually not needed for the guard to be atomically upgraded, as there can only be one write
+// transaction at a time, but it's useful to not have to implement the drop read guard -> take write guard
+// -> drop write guard -> take read guard ourselves
+struct ExtendablePages<'storage>(Option<RwLockUpgradableReadGuard<'storage, Pages>>);
 
 impl<'a> ReadTransaction<'a> {
     pub(super) fn new(version: Arc<Version>, pages: RwLockReadGuard<Pages>) -> ReadTransaction {
@@ -88,23 +54,30 @@ impl<'a> ReadTransaction<'a> {
     }
 }
 
-/// staging area for batched insertions, it will keep track of pages already shadowed and reuse them,
-/// it can be used to create a new `Version` at the end with all the insertions done atomically
-pub(crate) struct InsertTransaction<'locks, 'storage: 'locks> {
-    pub current_root: PageId,
-    pub shadows: HashMap<PageId, PageId>,
-    pub shadows_image: HashSet<PageId>,
-    pub current: Option<usize>,
-    pub page_manager: MutexGuard<'locks, PageManager>,
-    pub pages: Option<RwLockUpgradableReadGuard<'storage, Pages>>,
-    pub versions: MutexGuard<'locks, VecDeque<Arc<Version>>>,
-    pub current_version: Arc<RwLock<Arc<Version>>>,
-    pub version: Arc<Version>,
-    pub key_buffer_size: u32,
-    pub page_size: u64,
-}
-
 impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
+    pub fn new(
+        root: PageId,
+        pages: &'storage RwLock<Pages>,
+        page_manager: MutexGuard<'locks, PageManager>,
+        versions: MutexGuard<'locks, VecDeque<Arc<Version>>>,
+        current_version: Arc<RwLock<Arc<Version>>>,
+        key_buffer_size: u32,
+        page_size: u64,
+    ) -> InsertTransaction<'locks, 'storage> {
+        let current_root = root;
+        InsertTransaction {
+            current_root,
+            page_manager,
+            versions,
+            current_version,
+            key_buffer_size,
+            page_size,
+            shadows: HashMap::new(),
+            shadows_image: HashSet::new(),
+            pages: ExtendablePages::new(pages),
+        }
+    }
+
     pub fn root(&self) -> PageId {
         self.shadows
             .get(&self.current_root)
@@ -117,7 +90,7 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
             .get(&id)
             .or_else(|| self.shadows.get(&id))
             .or_else(|| Some(&id))
-            .and_then(|id| self.pages.as_ref().unwrap().get_page(*id))
+            .and_then(|id| self.pages.get_page(*id))
     }
 
     pub fn add_new_node(
@@ -127,14 +100,14 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
     ) -> Result<PageId, std::io::Error> {
         let id = self.page_manager.new_id();
 
-        let result = self.pages.as_ref().unwrap().mut_page(id);
+        let result = self.pages.mut_page(id);
 
         let mut page_handle = match result {
             Ok(page_handle) => page_handle,
             Err(()) => {
-                self.extend_storage(id)?;
+                self.pages.extend(id)?;
                 // infallible now, after extending the storage
-                self.pages.as_ref().unwrap().mut_page(id).unwrap()
+                self.pages.mut_page(id).unwrap()
             }
         };
 
@@ -143,6 +116,8 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
         Ok(id)
     }
 
+    // TODO: mut_page and mut_page_internal are basically the same thing, but I can't find
+    // a straight forward way of reusing the code because of borrowing rules, so I will ignore it for now
     pub fn mut_page(
         &mut self,
         id: PageId,
@@ -155,8 +130,6 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
             Some(id) => {
                 let handle = self
                     .pages
-                    .as_ref()
-                    .unwrap()
                     .mut_page(*id)
                     .expect("already fetched transaction was not allocated");
 
@@ -166,7 +139,7 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
                 let old_id = id;
                 let new_id = self.page_manager.new_id();
 
-                let result = self.pages.as_ref().unwrap().make_shadow(old_id, new_id);
+                let result = self.pages.make_shadow(old_id, new_id);
 
                 self.shadows.insert(old_id, new_id);
                 self.shadows_image.insert(new_id);
@@ -174,16 +147,12 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
                 match result {
                     Ok(()) => (),
                     Err(()) => {
-                        self.extend_storage(new_id)?;
-                        self.pages
-                            .as_ref()
-                            .unwrap()
-                            .make_shadow(old_id, new_id)
-                            .unwrap();
+                        self.pages.extend(new_id)?;
+                        self.pages.make_shadow(old_id, new_id).unwrap();
                     }
                 }
 
-                Ok(MutablePage::NewShadowingPage(RenamePointers {
+                Ok(MutablePage::NeedsParentRedirect(RedirectPointers {
                     tx: self,
                     last_old_id: old_id,
                     last_new_id: new_id,
@@ -193,7 +162,7 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
         }
     }
 
-    fn mut_page_unchecked(
+    fn mut_page_internal(
         &mut self,
         id: PageId,
     ) -> Result<(bool, PageHandle<Mutable>), std::io::Error> {
@@ -205,8 +174,6 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
             Some(id) => {
                 let handle = self
                     .pages
-                    .as_ref()
-                    .unwrap()
                     .mut_page(*id)
                     .expect("already fetched transaction was not allocated");
 
@@ -216,7 +183,7 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
                 let old_id = id;
                 let new_id = self.page_manager.new_id();
 
-                let result = self.pages.as_ref().unwrap().make_shadow(old_id, new_id);
+                let result = self.pages.make_shadow(old_id, new_id);
 
                 self.shadows.insert(old_id, new_id);
                 self.shadows_image.insert(new_id);
@@ -224,33 +191,17 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
                 match result {
                     Ok(()) => (),
                     Err(()) => {
-                        self.extend_storage(new_id)?;
+                        self.pages.extend(new_id)?;
                         // Infallible after extending
-                        self.pages
-                            .as_ref()
-                            .unwrap()
-                            .make_shadow(old_id, new_id)
-                            .unwrap();
+                        self.pages.make_shadow(old_id, new_id).unwrap();
                     }
                 }
 
-                let handle = self.pages.as_ref().unwrap().mut_page(new_id).unwrap();
+                let handle = self.pages.mut_page(new_id).unwrap();
 
                 Ok((true, handle))
             }
         }
-    }
-
-    fn extend_storage(&mut self, including: PageId) -> Result<(), std::io::Error> {
-        let mut write_guard =
-            lock_api::RwLockUpgradableReadGuard::upgrade(self.pages.take().unwrap());
-
-        (*write_guard).extend(including)?;
-
-        let new_guard = lock_api::RwLockWriteGuard::downgrade_to_upgradable(write_guard);
-        self.pages = Some(new_guard);
-
-        Ok(())
     }
 
     /// commit creates a new version of the tree, it doesn't sync the file, but it makes the version
@@ -277,6 +228,68 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
     }
 }
 
+pub enum MutablePage<'a, 'b: 'a, 'c: 'b> {
+    NeedsParentRedirect(RedirectPointers<'a, 'b, 'c>),
+    InTransaction(PageHandle<'a, Mutable<'a>>),
+}
+
+/// recursive helper for the shadowing process when we need to clone and redirect pointers
+pub struct RedirectPointers<'a, 'b: 'a, 'c: 'a> {
+    tx: &'a mut InsertTransaction<'b, 'c>,
+    /// id that we need to change in the next step, at some point, we could optimize this to be
+    /// an index instead of the id (so we don't need to perform the search)
+    last_old_id: PageId,
+    last_new_id: PageId,
+    /// this is the page that we will return at the end
+    shadowed_page: PageId,
+}
+
+impl<'a, 'b: 'a, 'c: 'b> RedirectPointers<'a, 'b, 'c> {
+    pub fn rename_parent<K: Key>(
+        self,
+        page_size: u64,
+        key_buffer_size: usize,
+        parent_id: PageId,
+    ) -> Result<MutablePage<'a, 'b, 'c>, std::io::Error> {
+        let (parent_needs_shadowing, mut parent) = self.tx.mut_page_internal(parent_id)?;
+
+        let old_id = self.last_old_id;
+        let new_id = self.last_new_id;
+        parent.as_node_mut(
+            page_size,
+            key_buffer_size,
+            |mut node: Node<K, &mut [u8]>| {
+                let mut node = node.as_internal_mut().unwrap();
+                let pos_to_update = match node.children().linear_search(old_id) {
+                    Some(pos) => pos,
+                    None => unreachable!(),
+                };
+
+                node.children_mut().update(pos_to_update, &new_id).unwrap();
+            },
+        );
+
+        let parent_new_id = parent.id();
+        if parent_needs_shadowing {
+            Ok(MutablePage::NeedsParentRedirect(RedirectPointers {
+                tx: self.tx,
+                last_old_id: parent_id,
+                last_new_id: parent_new_id,
+                shadowed_page: self.shadowed_page,
+            }))
+        } else {
+            Ok(MutablePage::InTransaction(self.finish()))
+        }
+    }
+
+    pub fn finish(self) -> PageHandle<'a, Mutable<'a>> {
+        match self.tx.mut_page(self.shadowed_page).unwrap() {
+            MutablePage::InTransaction(handle) => handle,
+            _ => unreachable!(),
+        }
+    }
+}
+
 impl<'txmanager, 'storage> InsertTransaction<'txmanager, 'storage> {
     /// create a staging area for a single insert
     pub(crate) fn backtrack<'me, K>(
@@ -288,7 +301,7 @@ impl<'txmanager, 'storage> InsertTransaction<'txmanager, 'storage> {
         let key_buffer_size = self.key_buffer_size.clone();
         let page_size = self.page_size.clone();
         super::InsertBacktrack {
-            builder: self,
+            tx: self,
             backtrack: vec![],
             new_root: None,
             phantom_key: PhantomData,
@@ -296,8 +309,29 @@ impl<'txmanager, 'storage> InsertTransaction<'txmanager, 'storage> {
             page_size,
         }
     }
+}
 
-    pub(crate) fn current_root(&self) -> PageId {
-        self.current_root
+impl<'storage> Deref for ExtendablePages<'storage> {
+    type Target = Pages;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().unwrap()
+    }
+}
+
+impl<'storage> ExtendablePages<'storage> {
+    fn new(pages: &'storage RwLock<Pages>) -> ExtendablePages<'storage> {
+        Self(Some(pages.upgradable_read()))
+    }
+
+    fn extend(&mut self, to: PageId) -> Result<(), std::io::Error> {
+        let mut write_guard = lock_api::RwLockUpgradableReadGuard::upgrade(self.0.take().unwrap());
+
+        (*write_guard).extend(to)?;
+
+        let new_guard = lock_api::RwLockWriteGuard::downgrade_to_upgradable(write_guard);
+        self.0 = Some(new_guard);
+
+        Ok(())
     }
 }

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -1,0 +1,264 @@
+use super::Version;
+use crate::btreeindex::{page_manager::PageManager, Node, Page, PageId, Pages};
+use crate::mem_page::MemPage;
+use crate::Key;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::marker::PhantomData;
+use std::sync::{atomic::AtomicBool, Arc, MutexGuard, RwLock};
+use traits::ReadTransaction as _;
+
+pub mod borrow {
+    use super::*;
+    pub struct Immutable {}
+    pub struct Mutable {
+        signal: Arc<AtomicBool>,
+    }
+}
+pub struct PageHandle<'a, Borrow> {
+    id: PageId,
+    raw_ptr: *mut u8,
+    _lifetime_marker: PhantomData<&'a Page>,
+    borrow: Borrow,
+}
+
+impl<'a> PageHandle<'a, borrow::Immutable> {
+    pub fn as_node<K, R>(
+        &self,
+        page_size: usize,
+        key_buffer_size: usize,
+        f: impl FnOnce(Node<K, &[u8]>) -> R,
+    ) -> R
+    where
+        K: Key,
+    {
+        let page: &'a [u8] = unsafe { std::slice::from_raw_parts(self.raw_ptr, page_size) };
+        let node = Node::<K, &[u8]>::from_raw(page.as_ref(), key_buffer_size);
+        f(node)
+    }
+
+    unsafe fn make_mut(self, signal: Arc<AtomicBool>) -> PageHandle<'a, borrow::Mutable> {
+        let PageHandle { id, raw_ptr, .. } = self;
+
+        PageHandle {
+            id,
+            raw_ptr,
+            _lifetime_marker: PhantomData,
+            borrow: borrow::Mutable { signal },
+        }
+    }
+}
+
+pub enum MutPage<'a> {
+    NeedsShadow {
+        old_id: PageId,
+        page: PageHandle<'a, borrow::Mutable>,
+    },
+    AlreadyInTransaction(PageHandle<'a, borrow::Mutable>),
+}
+
+pub mod traits {
+    use super::*;
+    pub trait ReadTransaction {
+        fn root(&self) -> PageId;
+        fn get_page<'a>(&'a self, id: PageId) -> Option<PageHandle<'a, borrow::Immutable>>;
+    }
+
+    pub trait WriteTransaction: ReadTransaction {
+        fn add_new_node(&mut self, mem_page: MemPage, key_buffer_size: u32) -> PageId;
+
+        fn mut_page(&mut self, id: PageId) -> Option<MutPage>;
+
+        fn delete_node(&mut self, id: PageId);
+
+        /// commit creates a new version of the tree, it doesn't sync the file, but it makes the version
+        /// available to new readers
+        fn commit<K: Key>(self);
+    }
+}
+
+pub struct ReadTransaction {
+    version: Arc<Version>,
+    pages: Pages,
+    ownership: RefCell<HashMap<PageId, Page>>,
+}
+
+impl ReadTransaction {
+    pub(super) fn new(version: Arc<Version>, pages: Pages) -> Self {
+        ReadTransaction {
+            version,
+            pages,
+            ownership: RefCell::new(HashMap::new()),
+        }
+    }
+}
+
+impl traits::ReadTransaction for ReadTransaction {
+    fn root(&self) -> PageId {
+        self.version.root
+    }
+
+    fn get_page(&self, id: PageId) -> Option<PageHandle<borrow::Immutable>> {
+        if let Some(page) = self.ownership.borrow_mut().get_mut(&id) {
+            let id = page.id();
+            let raw_ptr = page.mem_page.as_mut().as_mut_ptr();
+            return Some(PageHandle {
+                id,
+                raw_ptr,
+                _lifetime_marker: PhantomData,
+                borrow: borrow::Immutable,
+            });
+        }
+
+        let page = self.pages.get_page(id);
+
+        if let Some(page) = page {
+            {
+                let page = page.get_mut();
+                self.ownership.borrow_mut().insert(id, page);
+            }
+            self.get_page(id)
+        } else {
+            None
+        }
+    }
+}
+
+/// staging area for batched insertions, it will keep track of pages already shadowed and reuse them,
+/// it can be used to create a new `Version` at the end with all the insertions done atomically
+pub(crate) struct InsertTransaction<'locks> {
+    pub current_root: PageId,
+    pub extra: HashMap<PageId, Page>,
+    pub old_ids: Vec<PageId>,
+    pub current: Option<usize>,
+    pub page_manager: MutexGuard<'locks, PageManager>,
+    pub versions: MutexGuard<'locks, VecDeque<Arc<Version>>>,
+    pub current_version: Arc<RwLock<Arc<Version>>>,
+    pub version: Arc<Version>,
+    pub pages: Pages,
+    borrowed: HashMap<PageId, Arc<()>>,
+}
+
+impl<'locks> traits::ReadTransaction for InsertTransaction<'locks> {
+    fn root(&self) -> PageId {
+        self.current_root
+    }
+
+    fn get_page(&self, id: PageId) -> Option<PageHandle<borrow::Immutable>> {
+        if let Some(page) = self.extra.get_mut(&id) {
+            let id = page.id();
+            let raw_ptr = page.mem_page.as_mut().as_mut_ptr();
+            return Some(PageHandle {
+                id,
+                raw_ptr,
+                _lifetime_marker: PhantomData,
+                borrow: Immutable,
+            });
+        }
+
+        let page = self.pages.get_page(id);
+
+        if let Some(page) = page {
+            {
+                let page = page.get_mut();
+                self.extra.insert(id, page);
+            }
+            self.get_page(id)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'locks> traits::WriteTransaction for InsertTransaction<'locks> {
+    fn add_new_node(&mut self, mem_page: crate::mem_page::MemPage, key_buffer_size: u32) -> PageId {
+        let id = self.page_manager.new_id();
+        let page = Page {
+            page_id: id,
+            mem_page,
+            key_buffer_size,
+        };
+
+        // TODO: handle this error
+        self.extra.insert(page.page_id, page);
+        id
+    }
+
+    fn mut_page(&mut self, id: PageId) -> Option<MutPage> {
+        if self.borrowed.contains(&id) {
+            panic!("tried to borrow page mutably twice");
+        }
+
+        let already_fetched = self.extra.contains_key(&id);
+
+        let handle = self
+            .get_page(id)
+            .map(|inmutable_handle| inmutable_handle.make_mut());
+
+        handle.map(|handle| {
+            if already_fetched {
+                MutPage::AlreadyInTransaction(handle)
+            } else {
+                let old_id = handle.id;
+                self.old_ids.push(old_id);
+                handle.id = self.page_manager.new_id();
+                MutPage::NeedsShadow {
+                    old_id,
+                    page: handle,
+                }
+            }
+        })
+    }
+
+    fn delete_node(&mut self, id: PageId) {
+        self.old_ids.push(id);
+    }
+
+    /// commit creates a new version of the tree, it doesn't sync the file, but it makes the version
+    /// available to new readers
+    fn commit<K>(mut self)
+    where
+        K: Key,
+    {
+        let pages = self.pages;
+
+        for (_id, page) in self.extra.drain() {
+            pages.write_page(page).unwrap();
+        }
+
+        let transaction = super::WriteTransaction {
+            new_root: self.current_root,
+            shadowed_pages: self.old_ids,
+            // Pages allocated at the end, basically
+            next_page_id: self.page_manager.next_page(),
+        };
+
+        let mut current_version = self.current_version.write().unwrap();
+
+        self.versions.push_back(current_version.clone());
+
+        *current_version = Arc::new(Version {
+            root: self.current_root,
+            transaction,
+        });
+    }
+}
+
+impl<'txmanager> InsertTransaction<'txmanager> {
+    /// create a staging area for a single insert
+    pub(crate) fn backtrack<'me, K>(&'me mut self) -> super::InsertBacktrack<'me, 'txmanager, K>
+    where
+        K: Key,
+    {
+        super::InsertBacktrack {
+            builder: self,
+            backtrack: vec![],
+            new_root: None,
+            phantom_key: PhantomData,
+        }
+    }
+
+    pub(crate) fn current_root(&self) -> PageId {
+        self.current_root
+    }
+}

--- a/btree/src/mem_page.rs
+++ b/btree/src/mem_page.rs
@@ -26,11 +26,6 @@ impl MemPage {
         }
         MemPage { data, layout }
     }
-
-    pub(crate) fn len(&self) -> usize {
-        // TODO: Research more, I don't know if this is valid because the docs say 'minimum' size
-        self.layout.size()
-    }
 }
 
 impl AsMut<[u8]> for MemPage {

--- a/btree/src/mem_page.rs
+++ b/btree/src/mem_page.rs
@@ -5,7 +5,7 @@ const MEM_ALIGNMENT: usize = 8;
 /// Box-like structure but with custom alignment
 /// all nodes are allocated on this structure, but ideally at some point we could just use pointers into the mmap
 #[derive(Debug)]
-pub(crate) struct MemPage {
+pub struct MemPage {
     data: *mut u8,
     layout: alloc::Layout,
 }

--- a/btree/src/storage.rs
+++ b/btree/src/storage.rs
@@ -65,7 +65,7 @@ impl MmapStorage {
             .unwrap())
     }
 
-    pub fn resize(&mut self, minimum_required_size: u64) -> Result<(), io::Error> {
+    pub fn extend(&mut self, minimum_required_size: u64) -> Result<(), io::Error> {
         if minimum_required_size > self.allocated_size {
             self.allocated_size = Self::next_power_of_two(minimum_required_size);
 
@@ -122,7 +122,7 @@ mod tests {
 
         match unsafe { storage.get_mut(30, 10) } {
             Ok(_) => panic!("Should need resize"),
-            Err(pos) => storage.resize(pos).unwrap(),
+            Err(pos) => storage.extend(pos).unwrap(),
         }
 
         unsafe { storage.get_mut(30, 10) }


### PR DESCRIPTION
# Use mmaped region instead of heap allocations

## Motivation

Before this PR, the storage is using mmap just for reading and writing from/to heap allocated pages. This means almost the only benefit of using a memory mapped file is the os cache.

## Summary

The actual important changes are the ones in *storage.rs* and *pages.rs*, but changing the location of the ownership of the data required more changes in the higher level transaction module. 

- Avoid copying from the mmap and just use indexes to take slices of page size.
- Separate the *write* from the *extend* operation so we can synchronize in order to avoid dangling pointers when unmapping and remapping.
- Make the the insert transaction algorithm track id's instead of box allocations.

The previous `Page` abstraction (that was basically a `Box`) is replaced for a `PageHandle`, that contains a slice to the memory mapped region. The main issue with this approach, is that extending the mmaped region requires an `unmap` operation first, so we must take care of not allowing reads nor writes to proceed when this happens. At this point, a writer may need to extend the storage, but won't be able to proceed as long as a reader is holding a read lock, this should anyway be rare as we always allocate more space than we need (and there is only one writer at a time, so that part is not problematic).

### Disclaimer
There is a bit of noise in the diffs because I split the the version module into two, in general, there are no changes for the tree algorithms, but I couldn't keep everything localized to the storage (particularly the copy on write part needed to be changed, some error propagation, first page initialization)