### PR TITLE
Make consistency checks less intrusive

### DIFF
--- a/btree/src/arrayview.rs
+++ b/btree/src/arrayview.rs
@@ -114,7 +114,11 @@ where
         self.len
     }
 
-    pub(crate) fn get<'me>(&'me self, pos: usize) -> Option<<E as Storeable<'_>>::Output> {
+    pub(crate) fn get<'me>(&'me self, pos: usize) -> <E as Storeable<'_>>::Output {
+        self.try_get(pos).unwrap()
+    }
+
+    pub(crate) fn try_get<'me>(&'me self, pos: usize) -> Option<<E as Storeable<'_>>::Output> {
         if pos < self.len() {
             Some(
                 E::read(
@@ -277,7 +281,7 @@ where
     type Item = <E as Storeable<'elements>>::Output;
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos < self.view.len() {
-            let e = self.view.get(self.pos);
+            let e = self.view.try_get(self.pos);
             self.pos += 1;
             e
         } else {

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -255,9 +255,7 @@ where
                 page_size.try_into().unwrap(),
                 key_size,
                 move |mut node: Node<K, &mut [u8]>| {
-                    node.as_leaf_mut()
-                        .unwrap()
-                        .insert(key, value, &mut allocate)
+                    node.as_leaf_mut().insert(key, value, &mut allocate)
                 },
             );
 
@@ -295,7 +293,6 @@ where
 
                 match node.as_node_mut(page_size.try_into().unwrap(), key_size, |mut node| {
                     node.as_internal_mut()
-                        .unwrap()
                         .insert(split_key, right_id, &mut allocate)
                 }) {
                     InternalInsertStatus::Ok => return Ok(()),
@@ -338,7 +335,6 @@ where
         );
 
         node.as_internal_mut()
-            .unwrap()
             .insert_first(key, left_child, right_child);
 
         node
@@ -355,13 +351,8 @@ where
         page_ref.as_node(
             page_size,
             key_buffer_size,
-            |node: Node<K, &[u8]>| match node.as_leaf().unwrap().keys().binary_search(key) {
-                Ok(pos) => node
-                    .as_leaf()
-                    .unwrap()
-                    .values()
-                    .get(pos)
-                    .map(|n| *n.borrow()),
+            |node: Node<K, &[u8]>| match node.as_leaf().keys().binary_search(key) {
+                Ok(pos) => node.as_leaf().values().get(pos).map(|n| *n.borrow()),
                 Err(_) => None,
             },
         )
@@ -376,7 +367,7 @@ where
         loop {
             let new_current =
                 current.as_node(page_size, key_buffer_size, |node: Node<K, &[u8]>| {
-                    node.as_internal().map(|inode| {
+                    node.try_as_internal().map(|inode| {
                         let upper_pivot = match inode.keys().binary_search(key) {
                             Ok(pos) => Some(pos + 1),
                             Err(pos) => Some(pos),
@@ -467,22 +458,22 @@ mod tests {
                         node::NodeTag::Internal => {
                             println!("Internal Node");
                             println!("keys: ");
-                            for k in node.as_internal().unwrap().keys().into_iter() {
+                            for k in node.as_internal().keys().into_iter() {
                                 println!("{:?}", k.borrow());
                             }
                             println!("children: ");
-                            for c in node.as_internal().unwrap().children().into_iter() {
+                            for c in node.as_internal().children().into_iter() {
                                 println!("{:?}", c.borrow());
                             }
                         }
                         node::NodeTag::Leaf => {
                             println!("Leaf Node");
                             println!("keys: ");
-                            for k in node.as_leaf().unwrap().keys().into_iter() {
+                            for k in node.as_leaf().keys().into_iter() {
                                 println!("{:?}", k.borrow());
                             }
                             println!("values: ");
-                            for v in node.as_leaf().unwrap().values().into_iter() {
+                            for v in node.as_leaf().values().into_iter() {
                                 println!("{:?}", v.borrow());
                             }
                         }

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -352,7 +352,7 @@ where
             page_size,
             key_buffer_size,
             |node: Node<K, &[u8]>| match node.as_leaf().keys().binary_search(key) {
-                Ok(pos) => node.as_leaf().values().get(pos).map(|n| *n.borrow()),
+                Ok(pos) => Some(*node.as_leaf().values().get(pos).borrow()),
                 Err(_) => None,
             },
         )
@@ -375,10 +375,10 @@ where
                         .filter(|pos| pos < &inode.children().len());
 
                         let new_current_id = if let Some(upper_pivot) = upper_pivot {
-                            inode.children().get(upper_pivot).unwrap().clone()
+                            inode.children().get(upper_pivot)
                         } else {
                             let last = inode.children().len().checked_sub(1).unwrap();
-                            inode.children().get(last).unwrap().clone()
+                            inode.children().get(last)
                         };
 
                         tx.get_page(new_current_id).unwrap()

--- a/btree/src/btreeindex/node/internal_node.rs
+++ b/btree/src/btreeindex/node/internal_node.rs
@@ -159,7 +159,7 @@ where
                 // the key would be inserted in the first half
                 if pos < m.try_into().unwrap() {
                     let mut right_node_internal = right_node.as_internal_mut();
-                    let split_key = self.keys().get(m - 1 as usize).unwrap().borrow().clone();
+                    let split_key = self.keys().get(m - 1 as usize).borrow().clone();
 
                     let mut keys_mut = right_node_internal.keys_mut();
                     for k in self.keys().sub(m..self.keys().len()).into_iter() {
@@ -193,7 +193,7 @@ where
                 // the key would be inserted in the last half
                 else if pos > m.try_into().unwrap() {
                     let mut right_internal_node = right_node.as_internal_mut();
-                    let split_key = self.keys().get(m as usize).unwrap().borrow().clone();
+                    let split_key = self.keys().get(m as usize).borrow().clone();
 
                     let mut keys_mut = right_internal_node.keys_mut();
                     for k in self.keys().sub(m + 1..pos as usize).into_iter() {

--- a/btree/src/btreeindex/node/internal_node.rs
+++ b/btree/src/btreeindex/node/internal_node.rs
@@ -158,7 +158,7 @@ where
 
                 // the key would be inserted in the first half
                 if pos < m.try_into().unwrap() {
-                    let mut right_node_internal = right_node.as_internal_mut().unwrap();
+                    let mut right_node_internal = right_node.as_internal_mut();
                     let split_key = self.keys().get(m - 1 as usize).unwrap().borrow().clone();
 
                     let mut keys_mut = right_node_internal.keys_mut();
@@ -192,7 +192,7 @@ where
                 }
                 // the key would be inserted in the last half
                 else if pos > m.try_into().unwrap() {
-                    let mut right_internal_node = right_node.as_internal_mut().unwrap();
+                    let mut right_internal_node = right_node.as_internal_mut();
                     let split_key = self.keys().get(m as usize).unwrap().borrow().clone();
 
                     let mut keys_mut = right_internal_node.keys_mut();
@@ -230,7 +230,7 @@ where
                     InternalInsertStatus::Split(split_key.clone(), right_node)
                 } else {
                     // pos == m
-                    let mut right_internal_node = right_node.as_internal_mut().unwrap();
+                    let mut right_internal_node = right_node.as_internal_mut();
 
                     let split_key = key;
 

--- a/btree/src/btreeindex/node/leaf_node.rs
+++ b/btree/src/btreeindex/node/leaf_node.rs
@@ -115,7 +115,7 @@ where
                         .zip(self.values().sub(m - 1..self.values().len()).into_iter())
                         .enumerate()
                     {
-                        match right_node.as_leaf_mut().unwrap().insert_key_value::<F>(
+                        match right_node.as_leaf_mut().insert_key_value::<F>(
                             i,
                             k.borrow().clone(),
                             v,
@@ -144,7 +144,7 @@ where
                         .into_iter()
                         .zip(self.values().sub(m..pos).into_iter())
                     {
-                        right_node.as_leaf_mut().unwrap().insert_key_value::<F>(
+                        right_node.as_leaf_mut().insert_key_value::<F>(
                             position,
                             k.borrow().clone(),
                             v,
@@ -153,7 +153,7 @@ where
                         position += 1;
                     }
 
-                    right_node.as_leaf_mut().unwrap().insert_key_value::<F>(
+                    right_node.as_leaf_mut().insert_key_value::<F>(
                         position,
                         key.clone(),
                         value.clone(),
@@ -167,7 +167,7 @@ where
                         .into_iter()
                         .zip(self.values().sub(pos..self.values().len()).into_iter())
                     {
-                        right_node.as_leaf_mut().unwrap().insert_key_value::<F>(
+                        right_node.as_leaf_mut().insert_key_value::<F>(
                             position,
                             k.borrow().clone(),
                             v,
@@ -184,12 +184,9 @@ where
 
                     let split_key = key.clone();
 
-                    right_node.as_leaf_mut().unwrap().insert_key_value::<F>(
-                        0,
-                        key.clone(),
-                        value,
-                        None,
-                    );
+                    right_node
+                        .as_leaf_mut()
+                        .insert_key_value::<F>(0, key.clone(), value, None);
 
                     let mut position = 1;
 
@@ -199,7 +196,7 @@ where
                         .into_iter()
                         .zip(self.values().sub(m..self.values().len()).into_iter())
                     {
-                        right_node.as_leaf_mut().unwrap().insert_key_value::<F>(
+                        right_node.as_leaf_mut().insert_key_value::<F>(
                             position,
                             k.borrow().clone(),
                             v,

--- a/btree/src/btreeindex/node/leaf_node.rs
+++ b/btree/src/btreeindex/node/leaf_node.rs
@@ -106,7 +106,7 @@ where
                 let mut right_node = allocate.unwrap()();
 
                 if pos < m.try_into().unwrap() {
-                    let split_key = self.keys().get(m - 1 as usize).unwrap().borrow().clone();
+                    let split_key = self.keys().get(m - 1 as usize).borrow().clone();
 
                     for (i, (k, v)) in self
                         .keys()
@@ -135,7 +135,7 @@ where
 
                     LeafInsertStatus::Split(split_key.clone(), right_node)
                 } else if pos > m.try_into().unwrap() {
-                    let split_key = self.keys().get(m as usize).unwrap().borrow().clone();
+                    let split_key = self.keys().get(m as usize).borrow().clone();
 
                     let mut position = 0;
                     for (k, v) in self

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -48,7 +48,9 @@ where
         }
     }
 
-    pub(crate) fn as_internal_mut<'i: 'b>(&'i mut self) -> Option<InternalNode<'b, K, &mut [u8]>> {
+    pub(crate) fn try_as_internal_mut<'i: 'b>(
+        &'i mut self,
+    ) -> Option<InternalNode<'b, K, &mut [u8]>> {
         match self.get_tag() {
             NodeTag::Internal => Some(InternalNode::from_raw(
                 self.key_buffer_size,
@@ -58,7 +60,7 @@ where
         }
     }
 
-    pub(crate) fn as_leaf_mut<'i: 'b>(&'i mut self) -> Option<LeafNode<'b, K, &mut [u8]>> {
+    pub(crate) fn try_as_leaf_mut<'i: 'b>(&'i mut self) -> Option<LeafNode<'b, K, &mut [u8]>> {
         match self.get_tag() {
             NodeTag::Leaf => Some(LeafNode::from_raw(
                 self.key_buffer_size,
@@ -66,6 +68,14 @@ where
             )),
             NodeTag::Internal => None,
         }
+    }
+
+    pub(crate) fn as_internal_mut(&mut self) -> InternalNode<K, &mut [u8]> {
+        self.try_as_internal_mut().unwrap()
+    }
+
+    pub(crate) fn as_leaf_mut(&mut self) -> LeafNode<K, &mut [u8]> {
+        self.try_as_leaf_mut().unwrap()
     }
 }
 
@@ -92,7 +102,7 @@ where
         }
     }
 
-    pub(crate) fn as_internal<'i: 'b>(&'i self) -> Option<InternalNode<'b, K, &[u8]>> {
+    pub(crate) fn try_as_internal<'i: 'b>(&'i self) -> Option<InternalNode<'b, K, &[u8]>> {
         match self.get_tag() {
             NodeTag::Internal => Some(InternalNode::view(
                 self.key_buffer_size,
@@ -102,7 +112,7 @@ where
         }
     }
 
-    pub(crate) fn as_leaf<'i: 'b>(&'i self) -> Option<LeafNode<'b, K, &[u8]>> {
+    pub(crate) fn try_as_leaf<'i: 'b>(&'i self) -> Option<LeafNode<'b, K, &[u8]>> {
         match self.get_tag() {
             NodeTag::Leaf => Some(LeafNode::view(
                 self.key_buffer_size,
@@ -110,6 +120,10 @@ where
             )),
             NodeTag::Internal => None,
         }
+    }
+
+    pub(crate) fn as_leaf(&self) -> LeafNode<K, &[u8]> {
+        self.try_as_leaf().unwrap()
     }
 }
 
@@ -129,6 +143,16 @@ mod tests {
     use crate::mem_page::MemPage;
     use crate::tests::U64Key;
     use std::mem::size_of;
+
+    impl<'b, K, T> Node<K, T>
+    where
+        K: Key,
+        T: AsRef<[u8]> + 'b,
+    {
+        pub(crate) fn as_internal(&self) -> InternalNode<K, &[u8]> {
+            self.try_as_internal().unwrap()
+        }
+    }
 
     #[test]
     fn insert_internal_with_split_at_first() {
@@ -167,11 +191,9 @@ mod tests {
         };
 
         node.as_internal_mut()
-            .unwrap()
             .insert_first(U64Key(i1 as u64), 0u32, i1);
         match node
             .as_internal_mut()
-            .unwrap()
             .insert(U64Key(i2 as u64), i2, &mut allocate)
         {
             InternalInsertStatus::Ok => (),
@@ -180,25 +202,22 @@ mod tests {
 
         match node
             .as_internal_mut()
-            .unwrap()
             .insert(U64Key(i3 as u64), i3, &mut allocate)
         {
             InternalInsertStatus::Split(U64Key(2), new_node) => {
-                assert_eq!(new_node.as_internal().unwrap().keys().len(), 1);
+                assert_eq!(new_node.as_internal().keys().len(), 1);
                 assert_eq!(
                     new_node
                         .as_internal()
-                        .unwrap()
                         .keys()
                         .get(0)
                         .expect("Couldn't get first key"),
                     U64Key(3)
                 );
-                assert_eq!(new_node.as_internal().unwrap().children().len(), 2);
+                assert_eq!(new_node.as_internal().children().len(), 2);
                 assert_eq!(
                     new_node
                         .as_internal()
-                        .unwrap()
                         .children()
                         .get(0)
                         .expect("Couldn't get first key"),
@@ -207,7 +226,6 @@ mod tests {
                 assert_eq!(
                     new_node
                         .as_internal()
-                        .unwrap()
                         .children()
                         .get(1)
                         .expect("Couldn't get second key"),
@@ -219,14 +237,11 @@ mod tests {
             }
         };
 
-        assert_eq!(node.as_internal().unwrap().keys().len(), 1);
-        assert_eq!(
-            node.as_internal().unwrap().keys().get(0).unwrap(),
-            U64Key(1)
-        );
-        assert_eq!(node.as_internal().unwrap().children().len(), 2);
-        assert_eq!(node.as_internal().unwrap().children().get(0).unwrap(), 0u32);
-        assert_eq!(node.as_internal().unwrap().children().get(1).unwrap(), 1u32);
+        assert_eq!(node.as_internal().keys().len(), 1);
+        assert_eq!(node.as_internal().keys().get(0).unwrap(), U64Key(1));
+        assert_eq!(node.as_internal().children().len(), 2);
+        assert_eq!(node.as_internal().children().get(0).unwrap(), 0u32);
+        assert_eq!(node.as_internal().children().get(1).unwrap(), 1u32);
     }
 
     #[test]
@@ -263,29 +278,17 @@ mod tests {
             Node::new_leaf(std::mem::size_of::<U64Key>(), page)
         };
 
-        match node
-            .as_leaf_mut()
-            .unwrap()
-            .insert(U64Key(i1), i1, &mut allocate)
-        {
+        match node.as_leaf_mut().insert(U64Key(i1), i1, &mut allocate) {
             LeafInsertStatus::Ok => (),
             _ => panic!("second insertion shouldn't split"),
         };
-        match node
-            .as_leaf_mut()
-            .unwrap()
-            .insert(U64Key(i2), i2, &mut allocate)
-        {
+        match node.as_leaf_mut().insert(U64Key(i2), i2, &mut allocate) {
             LeafInsertStatus::Ok => (),
             _ => panic!("second insertion shouldn't split"),
         };
-        match node
-            .as_leaf_mut()
-            .unwrap()
-            .insert(U64Key(i3), i3, &mut allocate)
-        {
+        match node.as_leaf_mut().insert(U64Key(i3), i3, &mut allocate) {
             LeafInsertStatus::Split(U64Key(2), new_node) => {
-                let new_leaf = new_node.as_leaf().unwrap();
+                let new_leaf = new_node.as_leaf();
                 assert_eq!(new_leaf.keys().len(), 2);
                 assert_eq!(new_leaf.keys().get(0).unwrap(), U64Key(2));
                 assert_eq!(new_leaf.keys().get(1).unwrap(), U64Key(3));
@@ -298,9 +301,9 @@ mod tests {
             }
         };
 
-        assert_eq!(node.as_leaf().unwrap().keys().len(), 1);
-        assert_eq!(node.as_leaf().unwrap().keys().get(0).unwrap(), U64Key(1));
-        assert_eq!(node.as_leaf().unwrap().values().len(), 1);
-        assert_eq!(node.as_leaf().unwrap().values().get(0).unwrap(), 1);
+        assert_eq!(node.as_leaf().keys().len(), 1);
+        assert_eq!(node.as_leaf().keys().get(0).unwrap(), U64Key(1));
+        assert_eq!(node.as_leaf().values().len(), 1);
+        assert_eq!(node.as_leaf().values().get(0).unwrap(), 1);
     }
 }

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -206,31 +206,10 @@ mod tests {
         {
             InternalInsertStatus::Split(U64Key(2), new_node) => {
                 assert_eq!(new_node.as_internal().keys().len(), 1);
-                assert_eq!(
-                    new_node
-                        .as_internal()
-                        .keys()
-                        .get(0)
-                        .expect("Couldn't get first key"),
-                    U64Key(3)
-                );
+                assert_eq!(new_node.as_internal().keys().get(0), U64Key(3));
                 assert_eq!(new_node.as_internal().children().len(), 2);
-                assert_eq!(
-                    new_node
-                        .as_internal()
-                        .children()
-                        .get(0)
-                        .expect("Couldn't get first key"),
-                    2
-                );
-                assert_eq!(
-                    new_node
-                        .as_internal()
-                        .children()
-                        .get(1)
-                        .expect("Couldn't get second key"),
-                    3
-                );
+                assert_eq!(new_node.as_internal().children().get(0), 2);
+                assert_eq!(new_node.as_internal().children().get(1), 3);
             }
             _ => {
                 panic!("third insertion should split");
@@ -238,10 +217,10 @@ mod tests {
         };
 
         assert_eq!(node.as_internal().keys().len(), 1);
-        assert_eq!(node.as_internal().keys().get(0).unwrap(), U64Key(1));
+        assert_eq!(node.as_internal().keys().get(0), U64Key(1));
         assert_eq!(node.as_internal().children().len(), 2);
-        assert_eq!(node.as_internal().children().get(0).unwrap(), 0u32);
-        assert_eq!(node.as_internal().children().get(1).unwrap(), 1u32);
+        assert_eq!(node.as_internal().children().get(0), 0u32);
+        assert_eq!(node.as_internal().children().get(1), 1u32);
     }
 
     #[test]
@@ -290,11 +269,11 @@ mod tests {
             LeafInsertStatus::Split(U64Key(2), new_node) => {
                 let new_leaf = new_node.as_leaf();
                 assert_eq!(new_leaf.keys().len(), 2);
-                assert_eq!(new_leaf.keys().get(0).unwrap(), U64Key(2));
-                assert_eq!(new_leaf.keys().get(1).unwrap(), U64Key(3));
+                assert_eq!(new_leaf.keys().get(0), U64Key(2));
+                assert_eq!(new_leaf.keys().get(1), U64Key(3));
                 assert_eq!(new_leaf.values().len(), 2);
-                assert_eq!(new_leaf.values().get(0).unwrap(), 2);
-                assert_eq!(new_leaf.values().get(1).unwrap(), 3);
+                assert_eq!(new_leaf.values().get(0), 2);
+                assert_eq!(new_leaf.values().get(1), 3);
             }
             _ => {
                 panic!("third insertion should split");
@@ -302,8 +281,8 @@ mod tests {
         };
 
         assert_eq!(node.as_leaf().keys().len(), 1);
-        assert_eq!(node.as_leaf().keys().get(0).unwrap(), U64Key(1));
+        assert_eq!(node.as_leaf().keys().get(0), U64Key(1));
         assert_eq!(node.as_leaf().values().len(), 1);
-        assert_eq!(node.as_leaf().values().get(0).unwrap(), 1);
+        assert_eq!(node.as_leaf().values().get(0), 1);
     }
 }

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -190,10 +190,10 @@ where
                         .filter(|pos| pos < &inode.children().len());
 
                         if let Some(upper_pivot) = upper_pivot {
-                            current = inode.children().get(upper_pivot).unwrap().clone();
+                            current = inode.children().get(upper_pivot);
                         } else {
                             let last = inode.children().len().checked_sub(1).unwrap();
-                            current = inode.children().get(last).unwrap().clone();
+                            current = inode.children().get(last);
                         }
                         false
                     } else {

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -182,7 +182,7 @@ where
                 self.page_size,
                 self.key_buffer_size.try_into().unwrap(),
                 |node: Node<K, &[u8]>| {
-                    if let Some(inode) = node.as_internal() {
+                    if let Some(inode) = node.try_as_internal() {
                         let upper_pivot = match inode.keys().binary_search(key) {
                             Ok(pos) => Some(pos + 1),
                             Err(pos) => Some(pos),

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -259,7 +259,7 @@ impl<'a, 'b: 'a, 'c: 'b> RedirectPointers<'a, 'b, 'c> {
             page_size,
             key_buffer_size,
             |mut node: Node<K, &mut [u8]>| {
-                let mut node = node.as_internal_mut().unwrap();
+                let mut node = node.as_internal_mut();
                 let pos_to_update = match node.children().linear_search(old_id) {
                     Some(pos) => pos,
                     None => unreachable!(),


### PR DESCRIPTION
# Summary

- Rename `Node::as_leaf` and `Node::as_internal` to `Node::try_as_leaf` and `Node::try_as_internal`.
- Add new `Node::as_leaf` and `Node::as_internal` that panic if the tag doesn't match. In almost all cases we actually know what kind of node we are expecting, this way we don't need to `unwrap` all the time for things that are integrity bugs, and make the code less clear.

Also do the same for `ArrayView::get` with `ArrayView::try_get`. This is a bit less idiomatic when compared with the slice and vector api, but the way the things are currently defined I can't implement `Index` for `ArrayView` because I can't specify the lifetime of the associated (return) type.