### PR TITLE
Make raw bytes constructors unsafe

### DIFF
--- a/btree/src/btreeindex/node/internal_node.rs
+++ b/btree/src/btreeindex/node/internal_node.rs
@@ -39,7 +39,9 @@ where
     /// Init the given slice (mutating it) so it is a valid (empty) InternalNode that
     /// can be later read with `from_raw`
     pub fn init(key_buffer_size: usize, buffer: T) -> InternalNode<'b, K, T> {
-        let mut uninit = Self::from_raw(key_buffer_size, buffer);
+        // this is safe because we are not reading the data and by setting the length to 0 we are not
+        // going to
+        let mut uninit = unsafe { Self::from_raw(key_buffer_size, buffer) };
         uninit.set_len(0);
         uninit
     }
@@ -47,7 +49,7 @@ where
     /// mutable version of node interpretated over the given slice
     /// this shouldn't be called before calling `init`
     // TODO: add more rigorous type checking?
-    pub fn from_raw(key_buffer_size: usize, data: T) -> InternalNode<'b, K, T> {
+    pub unsafe fn from_raw(key_buffer_size: usize, data: T) -> InternalNode<'b, K, T> {
         assert_eq!(data.as_ref().as_ptr().align_offset(size_of::<PageId>()), 0);
         assert_eq!(data.as_ref().as_ptr().align_offset(size_of::<u64>()), 0);
         assert!(data.as_ref().len() > 0);

--- a/btree/src/btreeindex/node/leaf_node.rs
+++ b/btree/src/btreeindex/node/leaf_node.rs
@@ -41,13 +41,15 @@ where
 {
     /// mutate the slice of bytes so it is a valid leaf node
     pub(crate) fn init(key_buffer_size: usize, data: T) -> LeafNode<'b, K, T> {
-        let mut uninit = Self::from_raw(key_buffer_size, data);
+        // this is safe because we are not reading the data and by setting the length to 0 we are not
+        // going to
+        let mut uninit = unsafe { Self::from_raw(key_buffer_size, data) };
         uninit.set_len(0);
         uninit
     }
 
     /// read an already initialized slice of bytes as a leaf node
-    pub(crate) fn from_raw(key_buffer_size: usize, data: T) -> LeafNode<'b, K, T> {
+    pub(crate) unsafe fn from_raw(key_buffer_size: usize, data: T) -> LeafNode<'b, K, T> {
         assert_eq!(data.as_ref().as_ptr().align_offset(size_of::<PageId>()), 0);
         assert_eq!(data.as_ref().as_ptr().align_offset(size_of::<u64>()), 0);
         assert!(key_buffer_size % 8 == 0);

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -51,21 +51,27 @@ where
     pub(crate) fn try_as_internal_mut<'i: 'b>(
         &'i mut self,
     ) -> Option<InternalNode<'b, K, &mut [u8]>> {
+        // the unsafe part is actually in Node::from_raw, so at this point we don't care that much
         match self.get_tag() {
-            NodeTag::Internal => Some(InternalNode::from_raw(
-                self.key_buffer_size,
-                &mut self.data.as_mut()[TAG_SIZE..],
-            )),
+            NodeTag::Internal => unsafe {
+                Some(InternalNode::from_raw(
+                    self.key_buffer_size,
+                    &mut self.data.as_mut()[TAG_SIZE..],
+                ))
+            },
             NodeTag::Leaf => None,
         }
     }
 
     pub(crate) fn try_as_leaf_mut<'i: 'b>(&'i mut self) -> Option<LeafNode<'b, K, &mut [u8]>> {
+        // the unsafe part is actually in Node::from_raw, so at this point we don't care that much
         match self.get_tag() {
-            NodeTag::Leaf => Some(LeafNode::from_raw(
-                self.key_buffer_size,
-                &mut self.data.as_mut()[TAG_SIZE..],
-            )),
+            NodeTag::Leaf => unsafe {
+                Some(LeafNode::from_raw(
+                    self.key_buffer_size,
+                    &mut self.data.as_mut()[TAG_SIZE..],
+                ))
+            },
             NodeTag::Internal => None,
         }
     }
@@ -84,7 +90,7 @@ where
     K: Key,
     T: AsRef<[u8]> + 'b,
 {
-    pub(crate) fn from_raw(data: T, key_buffer_size: usize) -> Node<K, T> {
+    pub(crate) unsafe fn from_raw(data: T, key_buffer_size: usize) -> Node<K, T> {
         Node {
             data,
             key_buffer_size,

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -214,7 +214,7 @@ impl<'a> PageHandle<'a, borrow::Immutable<'a>> {
     {
         let page = self.borrow.borrow;
 
-        let node = Node::<K, &[u8]>::from_raw(page.as_ref(), key_buffer_size);
+        let node = unsafe { Node::<K, &[u8]>::from_raw(page.as_ref(), key_buffer_size) };
 
         f(node)
     }
@@ -230,7 +230,7 @@ impl<'a> PageHandle<'a, borrow::Mutable<'a>> {
     where
         K: Key,
     {
-        let node = Node::<K, &mut [u8]>::from_raw(self.borrow.borrow, key_buffer_size);
+        let node = unsafe { Node::<K, &mut [u8]>::from_raw(self.borrow.borrow, key_buffer_size) };
         f(node)
     }
 

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -203,12 +203,7 @@ impl<'a, T> PageHandle<'a, T> {
 }
 
 impl<'a> PageHandle<'a, borrow::Immutable<'a>> {
-    pub fn as_node<K, R>(
-        &self,
-        _page_size: u64,
-        key_buffer_size: usize,
-        f: impl FnOnce(Node<K, &[u8]>) -> R,
-    ) -> R
+    pub fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
     where
         K: Key,
     {
@@ -223,7 +218,6 @@ impl<'a> PageHandle<'a, borrow::Immutable<'a>> {
 impl<'a> PageHandle<'a, borrow::Mutable<'a>> {
     pub fn as_node_mut<K, R>(
         &mut self,
-        _page_size: u64,
         key_buffer_size: usize,
         f: impl FnOnce(Node<K, &mut [u8]>) -> R,
     ) -> R


### PR DESCRIPTION
# About

- Make the `Node::from_raw` constructor `unsafe`, as well as the ones for `LeafNode` and `InternalNode`. This is mostly as a lint (and to be correct), because it's an internal api and we don't read data from external sources, so we shouldn't use some bytes as a `Node` that were not a `Node`, but I think it is a good practice.
-  Remove an unused parameter.

------
  **DO NOT MERGE** before #289 (they are not related, but this is rebased on top of that)

