### PR TITLE
Mmaped flatfile

### DIFF
--- a/btree/benches/benchmark.rs
+++ b/btree/benches/benchmark.rs
@@ -9,6 +9,8 @@ use std::convert::TryInto;
 
 static SEED: u64 = 11;
 
+const BLOB_SIZE: usize = 1024 * 10; // 10 kb?
+
 #[derive(Debug, Clone, Ord, Eq, PartialEq, PartialOrd)]
 pub struct U64Key(pub u64);
 
@@ -24,6 +26,12 @@ impl<'a> Storeable<'a> for U64Key {
     }
 }
 
+fn random_blob(rng: &mut impl rand::Rng) -> Box<[u8]> {
+    let mut buf = vec![0u8; BLOB_SIZE];
+    rng.fill(&mut buf[..]);
+    buf.into_boxed_slice()
+}
+
 fn single_key_insertion(c: &mut Criterion) {
     // TODO: Maybe create a temp file somehow?
     let dir_path = "benchmark_single_key_insertion";
@@ -33,32 +41,31 @@ fn single_key_insertion(c: &mut Criterion) {
     let mut tree: BTreeStore<U64Key> =
         BTreeStore::new(dir_path, key_size.try_into().unwrap(), page_size).unwrap();
 
-    let n: u64 = 2000000;
+    let n: u64 = 200000;
+
+    let mut rng = StdRng::seed_from_u64(SEED);
 
     tree.insert_many(
         (0..n)
             .step_by(2)
-            .map(|i| (U64Key(i.clone()), i.to_le_bytes())),
+            .map(|i| (U64Key(i.clone()), random_blob(&mut rng))),
     )
     .expect("Couldn't insert setup values");
-
-    let mut rng = StdRng::seed_from_u64(SEED);
 
     c.bench_function("insertion", |b| {
         b.iter(|| {
             let r: u64 = rng.gen();
             let key = if r % 2 == 0 { r + 1 } else { r };
 
-            tree.insert(U64Key(key), &key.to_le_bytes()).unwrap_or(());
+            let blob_to_insert = random_blob(&mut rng);
+            tree.insert(U64Key(key), &blob_to_insert[..]).unwrap_or(());
 
             assert_eq!(
-                LittleEndian::read_u64(
-                    tree.get(&U64Key(key))
-                        .unwrap()
-                        .expect("Key not found")
-                        .as_ref()
-                ),
-                key
+                tree.get(&U64Key(key))
+                    .unwrap()
+                    .expect("Key not found")
+                    .as_ref(),
+                &blob_to_insert[..]
             );
         })
     });
@@ -74,25 +81,30 @@ fn single_key_search(c: &mut Criterion) {
     let tree: BTreeStore<U64Key> =
         BTreeStore::new(dir_path, key_size.try_into().unwrap(), page_size).unwrap();
 
-    let n: u64 = 2000000;
-
-    tree.insert_many((0..n).map(|i| (U64Key(i.clone()), i.to_le_bytes())))
-        .expect("Couldn't insert setup values");
+    let n: u64 = 200000;
 
     let mut rng = StdRng::seed_from_u64(SEED);
+
+    use std::collections::HashMap;
+    let mut data = HashMap::new();
+
+    for i in 0u64..n {
+        data.insert(i, random_blob(&mut rng));
+    }
+
+    tree.insert_many(data.iter().map(|(key, value)| (U64Key(*key), value)))
+        .expect("Couldn't insert setup values");
 
     c.bench_function("search", |b| {
         b.iter(|| {
             let key: u64 = rng.gen_range(0, n);
             assert_eq!(
-                LittleEndian::read_u64(
-                    tree.get(&U64Key(key))
-                        .unwrap()
-                        .expect("Key not found")
-                        .as_ref()
-                ),
-                key
-            );
+                tree.get(&U64Key(key))
+                    .unwrap()
+                    .expect("Key not found")
+                    .as_ref(),
+                &data.get(&key).unwrap()[..]
+            )
         })
     });
 
@@ -107,7 +119,7 @@ criterion_group!(
 
 criterion_group!(
     name = search;
-    config = Criterion::default().sample_size(1000);
+    config = Criterion::default().sample_size(500);
     targets = single_key_search
 );
 

--- a/btree/examples/blockindex.rs
+++ b/btree/examples/blockindex.rs
@@ -7,7 +7,7 @@ use std::io::BufRead;
 struct Key([u8; 32]);
 
 fn main() -> io::Result<()> {
-    let mut db: BTreeStore<Key> = BTreeStore::open("blocksdb")
+    let db: BTreeStore<Key> = BTreeStore::open("blocksdb")
         .or_else(|_| BTreeStore::new("blocksdb", 32, 4096))
         .unwrap();
 

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -1,4 +1,7 @@
+use crate::storage::MmapStorage;
+use byteorder::{ByteOrder, LittleEndian};
 use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{fs, path};
 
 pub const SZ_BITS: usize = 24;
@@ -112,5 +115,126 @@ impl From<Pos> for u64 {
 impl From<u64> for Pos {
     fn from(n: u64) -> Pos {
         Pos(n)
+    }
+}
+
+pub struct MmapedAppendOnlyFile {
+    storage: MmapStorage,
+    next_pos: AtomicU64,
+}
+
+unsafe impl Send for MmapedAppendOnlyFile {}
+unsafe impl Sync for MmapedAppendOnlyFile {}
+
+impl MmapedAppendOnlyFile {
+    /// Reopen or create a new appender with the appending file
+    pub fn new<P: AsRef<path::Path>>(filename: P) -> Result<Self, io::Error> {
+        let filename = filename.as_ref();
+
+        if !filename.exists() {
+            let mut f = fs::File::create(&filename)?;
+            f.write_all(&MAGIC)?;
+            f.set_len(DATA_START)?;
+        }
+
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&filename)?;
+
+        let storage = MmapStorage::new(file)?;
+        let next_pos = storage.len();
+
+        unsafe {
+            if storage.get(0, MAGIC_SIZE as u64) != MAGIC {
+                return Err(Error::new(ErrorKind::Other, "magic mismatch"));
+            }
+        }
+
+        Ok(Self {
+            storage,
+            next_pos: AtomicU64::new(next_pos),
+        })
+    }
+
+    /// Check if this appender can still be appended to.
+    pub fn can_append(&mut self) -> Result<bool, io::Error> {
+        // let pos = self.ahandle.seek(SeekFrom::Current(0))?;
+        // Ok(pos <= MAX_POS_OFFSET)
+        unimplemented!()
+    }
+
+    /// Append a blob of data and return the file offset
+    ///
+    /// Can only append data of MAX_BLOB_SIZE
+    pub fn append(&mut self, buf: &[u8]) -> Result<Pos, io::Error> {
+        if buf.len() > MAX_BLOB_SIZE {
+            return Err(Error::new(ErrorKind::Other, "blob size too big"));
+        }
+        // if (buf.len() & 0b11) != 0 {
+        //     return Err(Error::new(
+        //         ErrorKind::Other,
+        //         "blob size is not a multiple of 4",
+        //     ));
+        // }
+
+        let next_pos = self.next_pos.load(Ordering::Acquire);
+
+        if next_pos > MAX_POS_OFFSET {
+            return Err(Error::new(ErrorKind::Other, "offset position too big"));
+        }
+
+        let blen = buf.len() as u32;
+        let szbuf = blen.to_le_bytes();
+
+        let region_len = szbuf.len() as u64 + buf.len() as u64;
+
+        self.next_pos
+            .store(next_pos + region_len, Ordering::Release);
+
+        let mmaped_region = unsafe {
+            match self.storage.get_mut(next_pos, region_len) {
+                Ok(slice) => slice,
+                Err(including) => {
+                    self.storage.extend(including)?;
+                    self.storage.get_mut(next_pos, region_len).unwrap()
+                }
+            }
+        };
+
+        mmaped_region[0..szbuf.len()].copy_from_slice(&szbuf[..]);
+        mmaped_region[szbuf.len()..].copy_from_slice(&buf[..]);
+
+        // self.ahandle.sync_data()?;
+        Ok(Pos(next_pos))
+    }
+
+    /// Get the blob stored at position @pos
+    pub fn get_at(&self, pos: Pos) -> Result<Box<[u8]>, io::Error> {
+        // TODO: this will panic if position if out of range, we may want to handle that?
+        let szbuf = unsafe { self.storage.get(pos.into(), 4) };
+
+        let len = LittleEndian::read_u32(&szbuf);
+
+        let mut v = vec![0u8; len as usize];
+
+        unsafe {
+            v.copy_from_slice(self.storage.get(pos.0 + 4, len as u64));
+        }
+
+        Ok(v.into())
+    }
+
+    pub fn sync(&mut self) -> Result<(), io::Error> {
+        self.storage.sync()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn it_works() {
+        assert!(true)
     }
 }

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -1,6 +1,6 @@
 use crate::storage::MmapStorage;
-use byteorder::{ByteOrder, LittleEndian};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
+use std::convert::TryInto;
 use std::io::{self, Error, ErrorKind, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{fs, path};
@@ -131,7 +131,7 @@ impl MmapedAppendOnlyFile {
         let storage = self.storage.read();
         let szbuf = unsafe { storage.get(pos.into(), 4) };
 
-        let len = LittleEndian::read_u32(&szbuf);
+        let len = u32::from_le_bytes(szbuf.try_into().unwrap());
 
         let mut v = vec![0u8; len as usize];
 

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -1,8 +1,7 @@
 use crate::storage::MmapStorage;
 use byteorder::{ByteOrder, LittleEndian};
-use parking_lot::lock_api;
-use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
-use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom, Write};
+use parking_lot::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
+use std::io::{self, Error, ErrorKind, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{fs, path};
 
@@ -17,109 +16,12 @@ pub const MAX_POS_OFFSET: u64 = 2 << POS_BITS - 1; // last possible position 1by
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Pos(u64);
 
-/// Appender store blob of data (each of maximum size of 16 Mb) offering
-/// also a direct access to known index whilst it is appended
-pub struct Appender {
-    rhandle: fs::File,
-    ahandle: fs::File,
-}
-
 const MAGIC_SIZE: usize = 8;
 const MAGIC: [u8; MAGIC_SIZE] = [0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88];
 const DATA_START: u64 = 4096;
 
-impl Appender {
-    /// Reopen or create a new appender with the appending file
-    pub fn new<P: AsRef<path::Path>>(filename: P) -> Result<Self, io::Error> {
-        let filename = filename.as_ref();
-
-        if !filename.exists() {
-            let mut f = fs::File::create(&filename)?;
-            f.write_all(&MAGIC)?;
-            f.set_len(DATA_START)?;
-        }
-
-        let mut rhandle = fs::OpenOptions::new().read(true).open(&filename)?;
-
-        let ahandle = {
-            let mut ahandle = fs::OpenOptions::new().append(true).open(&filename)?;
-            ahandle.seek(SeekFrom::End(0))?;
-            ahandle
-        };
-
-        let mut buf = [0u8; MAGIC_SIZE];
-        rhandle.read_exact(&mut buf)?;
-        rhandle.seek(SeekFrom::Start(DATA_START))?;
-
-        if buf != MAGIC {
-            return Err(Error::new(ErrorKind::Other, "magic mismatch"));
-        }
-
-        Ok(Self { rhandle, ahandle })
-    }
-
-    /// Check if this appender can still be appended to.
-    pub fn can_append(&mut self) -> Result<bool, io::Error> {
-        let pos = self.ahandle.seek(SeekFrom::Current(0))?;
-        Ok(pos <= MAX_POS_OFFSET)
-    }
-
-    /// Append a blob of data and return the file offset
-    ///
-    /// Can only append data of MAX_BLOB_SIZE
-    pub fn append(&mut self, buf: &[u8]) -> Result<Pos, io::Error> {
-        if buf.len() > MAX_BLOB_SIZE {
-            return Err(Error::new(ErrorKind::Other, "blob size too big"));
-        }
-        // if (buf.len() & 0b11) != 0 {
-        //     return Err(Error::new(
-        //         ErrorKind::Other,
-        //         "blob size is not a multiple of 4",
-        //     ));
-        // }
-        let pos = self.ahandle.seek(SeekFrom::Current(0))?;
-        if pos > MAX_POS_OFFSET {
-            return Err(Error::new(ErrorKind::Other, "offset position too big"));
-        }
-        let blen = buf.len() as u32;
-        let szbuf = blen.to_le_bytes();
-        self.ahandle.write_all(&szbuf[..])?;
-        self.ahandle.write_all(buf)?;
-
-        // self.ahandle.sync_data()?;
-        Ok(Pos(pos))
-    }
-
-    /// Get the blob stored at position @pos
-    pub fn get_at(&mut self, pos: Pos) -> Result<Box<[u8]>, io::Error> {
-        self.rhandle.seek(SeekFrom::Start(pos.0))?;
-
-        let mut szbuf = [0u8; 4];
-        self.rhandle.read_exact(&mut szbuf)?;
-        let len = u32::from_le_bytes(szbuf);
-        let mut v = vec![0u8; len as usize];
-        self.rhandle.read_exact(&mut v)?;
-        Ok(v.into())
-    }
-
-    pub fn sync(&mut self) -> Result<(), io::Error> {
-        self.ahandle.sync_data()?;
-        Ok(())
-    }
-}
-
-impl From<Pos> for u64 {
-    fn from(pos: Pos) -> u64 {
-        pos.0
-    }
-}
-
-impl From<u64> for Pos {
-    fn from(n: u64) -> Pos {
-        Pos(n)
-    }
-}
-
+/// Appender store blob of data (each of maximum size of 16 Mb) offering
+/// also a direct access to known index whilst it is appended
 pub struct MmapedAppendOnlyFile {
     storage: RwLock<MmapStorage>,
     next_pos: AtomicU64,
@@ -237,6 +139,18 @@ impl MmapedAppendOnlyFile {
     pub fn sync(&self) -> Result<(), io::Error> {
         self.storage.read().sync()?;
         Ok(())
+    }
+}
+
+impl From<Pos> for u64 {
+    fn from(pos: Pos) -> u64 {
+        pos.0
+    }
+}
+
+impl From<u64> for Pos {
+    fn from(n: u64) -> Pos {
+        Pos(n)
     }
 }
 

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -7,8 +7,7 @@ pub mod btreeindex;
 pub mod flatfile;
 mod mem_page;
 pub mod storage;
-use flatfile::{Appender, MmapedAppendOnlyFile};
-use std::sync::{Mutex, RwLock};
+use flatfile::MmapedAppendOnlyFile;
 
 const METADATA_FILE: &'static str = "metadata";
 const TREE_FILE: &'static str = "pages";

--- a/btree/src/storage.rs
+++ b/btree/src/storage.rs
@@ -85,6 +85,10 @@ impl MmapStorage {
         // there is nothing really unsafe here, we need the block only because of unsafe cell (at least nothing that is not already present in the memmap api)
         unsafe { &*self.mmap.get() }.flush()
     }
+
+    pub fn len(&self) -> u64 {
+        self.file_len.load(Ordering::SeqCst)
+    }
 }
 
 impl Drop for MmapStorage {


### PR DESCRIPTION
Replace the seek and write/read approach used for storing the contents of the store for a similar abstraction based on a memory mapped file (before it was only used for the index/tree pages). This also moves the synchronization of the file to the appender, which means that now `BTreeStore` can be shared without external synchronization (because `insert` takes `&self` and not `&mut self`). Although maybe this is not a good thing?.

* Note *: This still needs a few more tests, particularly because most tree tests only test the index, so this kind of gets left out.