### PR TITLE
Use the customized container image in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,10 @@ jobs:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
       - restore_cache:
           keys:
-            - cargo-advisory-db-v1
+            - cargo-advisory-db-v2-
       - run: cargo audit
       - save_cache:
-          key: cargo-advisory-db-v1
+          key: cargo-advisory-db-v2-{{ checksum "/usr/local/cargo/advisory-db/.git/refs/heads/master" }}
           paths:
             - /usr/local/cargo/advisory-db
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   cargo_fetch:
     docker:
-      - image: rust:latest
+      - image: inputoutput/rust:stable
     working_directory: /mnt/crate
     steps:
       - checkout
@@ -21,25 +21,9 @@ jobs:
             - /usr/local/cargo/registry
             - /usr/local/cargo/git
 
-  #rustfmt:
-  #  docker:
-  #    - image: rust:latest
-  #  working_directory: /mnt/crate
-  #  steps:
-  #    - checkout
-  #    - run:
-  #        name: Install rustfmt
-  #        command: rustup component add rustfmt
-  #    - run:
-  #        name: Print version information
-  #        command: cargo fmt -- --version
-  #    - run:
-  #        name: Check rustfmt
-  #        command: cargo fmt -- --check
-
   test_debug:
     docker:
-      - image: rust:latest
+      - image: inputoutput/rust:stable
     working_directory: /mnt/crate
     steps:
       - checkout
@@ -62,7 +46,7 @@ jobs:
 
   test_release:
     docker:
-      - image: rust:latest
+      - image: inputoutput/rust:stable
     working_directory: /mnt/crate
     steps:
       - checkout
@@ -83,7 +67,7 @@ jobs:
 
   test_nightly:
     docker:
-      - image: rustlang/rust:nightly
+      - image: inputoutput/rust:nightly
     working_directory: /mnt/crate
     steps:
       - checkout
@@ -109,16 +93,12 @@ workflows:
   test_all:
     jobs:
       - cargo_fetch
-      #- rustfmt
       - test_debug:
           requires:
-            #- rustfmt
             - cargo_fetch
       - test_release:
           requires:
-            #- rustfmt
             - cargo_fetch
       - test_nightly:
           requires:
-            #- rustfmt
             - cargo_fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   cargo_fetch:
     docker:
       - image: inputoutput/rust:stable
-    working_directory: /mnt/crate
+    working_directory: /home/circleci/build
     steps:
       - checkout
       - restore_cache:
@@ -12,7 +12,7 @@ jobs:
             - cargo-v3-
       - run: cargo fetch
       - persist_to_workspace:
-          root: /mnt/crate
+          root: /home/circleci/build
           paths:
             - Cargo.lock
       - save_cache:
@@ -24,11 +24,11 @@ jobs:
   test_debug:
     docker:
       - image: inputoutput/rust:stable
-    working_directory: /mnt/crate
+    working_directory: /home/circleci/build
     steps:
       - checkout
       - attach_workspace:
-          at: /mnt/crate
+          at: /home/circleci/build
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
@@ -47,11 +47,11 @@ jobs:
   test_release:
     docker:
       - image: inputoutput/rust:stable
-    working_directory: /mnt/crate
+    working_directory: /home/circleci/build
     steps:
       - checkout
       - attach_workspace:
-          at: /mnt/crate
+          at: /home/circleci/build
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
@@ -68,11 +68,11 @@ jobs:
   test_nightly:
     docker:
       - image: inputoutput/rust:nightly
-    working_directory: /mnt/crate
+    working_directory: /home/circleci/build
     steps:
       - checkout
       - attach_workspace:
-          at: /mnt/crate
+          at: /home/circleci/build
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,26 @@ jobs:
             - /usr/local/cargo/registry
             - /usr/local/cargo/git
 
+  cargo_audit:
+    docker:
+      - image: inputoutput/rust:stable
+    working_directory: /home/circleci/build
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /home/circleci/build
+      - restore_cache:
+          keys:
+            - cargo-v3-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+      - restore_cache:
+          keys:
+            - cargo-advisory-db-v1
+      - run: cargo audit
+      - save_cache:
+          key: cargo-advisory-db-v1
+          paths:
+            - /usr/local/cargo/advisory-db
+
   test_debug:
     docker:
       - image: inputoutput/rust:stable
@@ -93,6 +113,9 @@ workflows:
   test_all:
     jobs:
       - cargo_fetch
+      - cargo_audit:
+          requires:
+            - cargo_fetch
       - test_debug:
           requires:
             - cargo_fetch


### PR DESCRIPTION
Make use of our [tailored build images](https://github.com/input-output-hk/rust-ci-docker) in CircleCI builds.

Running `cargo audit` without extra setup is now possible, but temporarily disabled pending #294 that will remove the known vulnerability in `prost`.