### PR TITLE
Add leaf and internal delete

### DIFF
--- a/btree/benches/benchmark.rs
+++ b/btree/benches/benchmark.rs
@@ -30,7 +30,7 @@ fn single_key_insertion(c: &mut Criterion) {
     let key_size = std::mem::size_of::<U64Key>();
     let page_size = 4096;
 
-    let mut tree: BTreeStore<U64Key> =
+    let tree: BTreeStore<U64Key> =
         BTreeStore::new(dir_path, key_size.try_into().unwrap(), page_size).unwrap();
 
     let n: u64 = 2000000;

--- a/btree/examples/blockindex.rs
+++ b/btree/examples/blockindex.rs
@@ -58,4 +58,8 @@ impl<'a> Storeable<'a> for Key {
         buf.read_exact(&mut bytes).expect("deserialize failed");
         Ok(Key(bytes))
     }
+
+    fn as_output(self) -> Self::Output {
+        self
+    }
 }

--- a/btree/src/arrayview.rs
+++ b/btree/src/arrayview.rs
@@ -306,8 +306,13 @@ impl<'a> Storeable<'a> for u32 {
     fn write(&self, buf: &mut [u8]) -> Result<(), Self::Error> {
         Ok(LittleEndian::write_u32(buf, *self))
     }
+
     fn read(buf: &'a [u8]) -> Result<Self::Output, Self::Error> {
         Ok(LittleEndian::read_u32(buf))
+    }
+
+    fn as_output(self) -> Self::Output {
+        self
     }
 }
 
@@ -318,8 +323,13 @@ impl<'a> Storeable<'a> for u64 {
     fn write(&self, buf: &mut [u8]) -> Result<(), Self::Error> {
         Ok(LittleEndian::write_u64(buf, *self))
     }
+
     fn read(buf: &'a [u8]) -> Result<Self::Output, Self::Error> {
         Ok(LittleEndian::read_u64(buf))
+    }
+
+    fn as_output(self) -> Self::Output {
+        self
     }
 }
 

--- a/btree/src/arrayview.rs
+++ b/btree/src/arrayview.rs
@@ -203,7 +203,6 @@ where
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn delete(&mut self, pos: usize) -> Result<(), ()> {
         if pos < self.len() {
             unsafe {

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -1,4 +1,6 @@
 mod metadata;
+// FIXME: allow dead code momentarily, because all of the delete algorithms are unused, and placing the directive with more granularity would be too troublesome
+#[allow(dead_code)]
 mod node;
 mod page_manager;
 mod pages;

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -10,7 +10,7 @@ use version_management::*;
 use crate::mem_page::MemPage;
 use crate::BTreeStoreError;
 use metadata::{Metadata, StaticSettings};
-use node::{InternalInsertStatus, LeafInsertStatus, Node, NodeRefMut};
+use node::{InternalInsertStatus, LeafInsertStatus, Node, NodeRef, NodeRefMut};
 use pages::{borrow, PageHandle, Pages, PagesInitializationParams};
 use std::borrow::Borrow;
 

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -10,7 +10,7 @@ use version_management::*;
 use crate::mem_page::MemPage;
 use crate::BTreeStoreError;
 use metadata::{Metadata, StaticSettings};
-use node::{InternalInsertStatus, LeafInsertStatus, Node, NodePageRefMut};
+use node::{InternalInsertStatus, LeafInsertStatus, Node, NodeRefMut};
 use pages::{borrow, PageHandle, Pages, PagesInitializationParams};
 use std::borrow::Borrow;
 

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -10,7 +10,7 @@ use version_management::*;
 use crate::mem_page::MemPage;
 use crate::BTreeStoreError;
 use metadata::{Metadata, StaticSettings};
-use node::{InternalInsertStatus, LeafInsertStatus, Node};
+use node::{InternalInsertStatus, LeafInsertStatus, Node, NodePageRefMut};
 use pages::{borrow, PageHandle, Pages, PagesInitializationParams};
 use std::borrow::Borrow;
 
@@ -237,7 +237,7 @@ where
 
     pub(crate) fn insert_in_leaf<'a, 'b: 'a>(
         &self,
-        leaf: PageRefMut<'a, 'b>,
+        mut leaf: PageRefMut<'a, 'b>,
         key: K,
         value: Value,
     ) -> Result<Option<(K, Node<K, MemPage>)>, BTreeStoreError> {
@@ -276,7 +276,7 @@ where
         let mut right_id = to_insert;
         loop {
             let (current_id, new_split_key, new_node) = {
-                let node = backtrack.get_next()?.unwrap();
+                let mut node = backtrack.get_next()?.unwrap();
                 let node_id = node.id();
                 let key_size = usize::try_from(self.static_settings.key_buffer_size).unwrap();
                 let page_size = self.static_settings.page_size.try_into().unwrap();

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -4,7 +4,7 @@ mod page_manager;
 mod pages;
 mod version_management;
 
-use version_management::transaction::{InsertTransaction, ReadTransaction};
+use version_management::transaction::{InsertTransaction, PageRefMut, ReadTransaction};
 use version_management::*;
 
 use crate::mem_page::MemPage;
@@ -235,9 +235,9 @@ where
         Ok(())
     }
 
-    pub(crate) fn insert_in_leaf<'a>(
+    pub(crate) fn insert_in_leaf<'a, 'b: 'a>(
         &self,
-        mut leaf: PageHandle<'a, borrow::Mutable<'a>>,
+        mut leaf: PageRefMut<'a, 'b>,
         key: K,
         value: Value,
     ) -> Result<Option<(K, Node<K, MemPage>)>, BTreeStoreError> {

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -237,7 +237,7 @@ where
 
     pub(crate) fn insert_in_leaf<'a, 'b: 'a>(
         &self,
-        mut leaf: PageRefMut<'a, 'b>,
+        leaf: PageRefMut<'a, 'b>,
         key: K,
         value: Value,
     ) -> Result<Option<(K, Node<K, MemPage>)>, BTreeStoreError> {
@@ -276,7 +276,7 @@ where
         let mut right_id = to_insert;
         loop {
             let (current_id, new_split_key, new_node) = {
-                let mut node = backtrack.get_next()?.unwrap();
+                let node = backtrack.get_next()?.unwrap();
                 let node_id = node.id();
                 let key_size = usize::try_from(self.static_settings.key_buffer_size).unwrap();
                 let page_size = self.static_settings.page_size.try_into().unwrap();

--- a/btree/src/btreeindex/node/internal_node.rs
+++ b/btree/src/btreeindex/node/internal_node.rs
@@ -1,7 +1,9 @@
-use super::Node;
-use crate::btreeindex::{Children, ChildrenMut, Keys, KeysMut, PageId};
-use crate::Key;
-use crate::MemPage;
+use super::{Node, RebalanceArgs, RebalanceResult, SiblingsArg};
+use crate::btreeindex::{
+    pages::{borrow::Mutable, PageHandle},
+    Children, ChildrenMut, Keys, KeysMut, PageId,
+};
+use crate::{BTreeStoreError, Key, MemPage};
 use byteorder::{ByteOrder as _, LittleEndian};
 use std::borrow::Borrow;
 use std::convert::{TryFrom, TryInto};
@@ -29,6 +31,12 @@ pub(crate) enum InternalInsertStatus<K> {
     Ok,
     Split(K, Node<K, MemPage>),
     DuplicatedKey(K),
+}
+
+#[derive(Debug)]
+pub(crate) enum InternalDeleteStatus {
+    Ok,
+    NeedsRebalance,
 }
 
 impl<'b, K, T> InternalNode<'b, K, T>
@@ -261,6 +269,273 @@ where
         }
     }
 
+    #[allow(dead_code)]
+    pub fn delete_key_children(&mut self, pos: usize) -> InternalDeleteStatus {
+        let current_len = self.keys().len();
+        self.keys_mut()
+            .delete(pos)
+            .expect("Couldn't delete last key");
+        self.children_mut()
+            .delete(pos + 1)
+            .expect("Couldn't delete last child");
+        self.set_len(current_len - 1);
+
+        if self.children().len() < self.lower_bound() {
+            InternalDeleteStatus::NeedsRebalance
+        } else {
+            InternalDeleteStatus::Ok
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn rebalance<'siblings: 'b, F: FnMut() -> PageHandle<'siblings, Mutable<'siblings>>>(
+        &'b mut self,
+        args: RebalanceArgs<'siblings, F>,
+    ) -> Result<RebalanceResult, BTreeStoreError> {
+        let current_len = self.keys().len();
+        let mut parent_ref = args.parent;
+        let anchor = args.parent_anchor;
+
+        let result = {
+            let left_sibling_handle = match &args.siblings {
+                SiblingsArg::Left((handle, _)) | SiblingsArg::Both((handle, _), _) => Some(handle),
+                _ => None,
+            };
+
+            let right_sibling_handle = match &args.siblings {
+                SiblingsArg::Right((handle, _)) | SiblingsArg::Both(_, (handle, _)) => Some(handle),
+                _ => None,
+            };
+
+            if self.children().len() < self.lower_bound() {
+                // underflow
+                if left_sibling_handle
+                    .filter(|handle| {
+                        handle.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| -> bool {
+                            node.as_internal().has_extra()
+                        })
+                    })
+                    .is_some()
+                {
+                    RebalanceResult::TookKeyFromLeft
+                } else if right_sibling_handle
+                    .clone()
+                    .filter(|handle| {
+                        handle.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                            node.as_internal().has_extra()
+                        })
+                    })
+                    .is_some()
+                {
+                    RebalanceResult::TookKeyFromRight
+                } else if left_sibling_handle.is_some() {
+                    RebalanceResult::MergeIntoLeft
+                } else if right_sibling_handle.is_some() {
+                    RebalanceResult::MergeIntoSelf
+                } else {
+                    unreachable!();
+                }
+            } else {
+                // TODO: add error? vs don't do anything
+                panic!("node doesn't need rebalance")
+            }
+        };
+
+        match result {
+            RebalanceResult::TookKeyFromLeft => {
+                let mut sibling_clone = match args.siblings {
+                    SiblingsArg::Left((_, clone)) | SiblingsArg::Both((_, clone), _) => clone,
+                    _ => unreachable!(),
+                };
+
+                let mut sibling = sibling_clone();
+
+                // steal a key from the left sibling through parent
+                let (new_anchor_key, new_first_child) =
+                    sibling.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                        let node = node.as_internal();
+                        let keys = node.keys();
+                        let last = keys.len().checked_sub(1).unwrap();
+                        let stolen_key = keys.get(last);
+                        let stolen_child = node.children().get(last + 1);
+                        (stolen_key.borrow().clone(), stolen_child.borrow().clone())
+                    });
+
+                let new_first_key =
+                    parent_ref.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                        let node = node.as_internal();
+                        let keys = node.keys();
+                        let stolen_key = keys.get(anchor.unwrap());
+                        stolen_key.borrow().clone()
+                    });
+
+                self.keys_mut()
+                    .insert(0, &new_first_key)
+                    .expect("Couldn't insert key at pos 0");
+                self.children_mut()
+                    .insert(0, &new_first_child)
+                    .expect("Couldn't insert child at pos 0");
+                self.set_len(current_len + 1);
+
+                parent_ref.as_node_mut(self.key_buffer_size, |mut node| {
+                    node.as_internal_mut()
+                        .update_key(anchor.unwrap(), new_anchor_key.borrow().clone())
+                        .unwrap();
+                });
+
+                sibling.as_node_mut(self.key_buffer_size, |mut node: Node<K, &mut [u8]>| {
+                    let mut sibling = node.as_internal_mut();
+                    let last = sibling.keys().len().checked_sub(1).unwrap();
+                    sibling.keys_mut().delete(last).unwrap();
+                    sibling.children_mut().delete(last + 1).unwrap();
+                    sibling.set_len(last);
+                });
+            }
+            RebalanceResult::TookKeyFromRight => {
+                let mut sibling_mut = match args.siblings {
+                    SiblingsArg::Right((_, clone)) | SiblingsArg::Both(_, (_, clone)) => clone,
+                    _ => unreachable!(),
+                };
+
+                let mut sibling = sibling_mut();
+
+                // steal a key from the right sibling though parent
+                let (new_right_anchor_key, new_last_child) =
+                    sibling.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                        let node = node.as_internal();
+                        let keys = node.keys();
+                        let stolen_key = keys.get(0);
+                        let stolen_child = node.children().get(0);
+                        (stolen_key.borrow().clone(), stolen_child.borrow().clone())
+                    });
+
+                let right_anchor_pos = anchor.map(|a| a + 1).unwrap_or(0);
+
+                let new_last_key =
+                    parent_ref.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                        node.as_internal()
+                            .keys()
+                            .get(right_anchor_pos)
+                            .borrow()
+                            .clone()
+                    });
+
+                parent_ref.as_node_mut(self.key_buffer_size, |mut node| {
+                    node.as_internal_mut()
+                        .update_key(right_anchor_pos, new_right_anchor_key.borrow().clone())
+                        .unwrap()
+                });
+
+                let insert_pos = self.keys().len();
+                self.keys_mut()
+                    .append(new_last_key.borrow())
+                    .expect("Couldn't append key");
+                self.children_mut()
+                    .insert(insert_pos + 1, &new_last_child)
+                    .expect("Couldn't append child");
+                self.set_len(current_len + 1);
+
+                sibling.as_node_mut(self.key_buffer_size, |mut node: Node<K, &mut [u8]>| {
+                    let mut sibling = node.as_internal_mut();
+                    let current_len = sibling.keys().len();
+                    sibling
+                        .keys_mut()
+                        .delete(0)
+                        .expect("Couldn't delete key at pos 0");
+                    sibling
+                        .children_mut()
+                        .delete(0)
+                        .expect("Couldn't delete child at pos 0");
+                    sibling.set_len(current_len.checked_sub(1).unwrap());
+                });
+            }
+            RebalanceResult::MergeIntoLeft => {
+                let mut sibling_clone = match args.siblings {
+                    SiblingsArg::Left((_, clone)) | SiblingsArg::Both((_, clone), _) => clone,
+                    _ => unreachable!(),
+                };
+
+                let mut sibling = sibling_clone();
+
+                //merge this into left
+                let anchor_key =
+                    parent_ref.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                        node.as_internal()
+                            .keys()
+                            .get(anchor.unwrap())
+                            .borrow()
+                            .clone()
+                    });
+
+                sibling.as_node_mut(self.key_buffer_size, |mut node| {
+                    for (k, v) in Some(anchor_key.as_output())
+                        .into_iter()
+                        .chain(self.keys().into_iter())
+                        .zip(self.children().into_iter())
+                    {
+                        let mut merge_target = node.as_internal_mut();
+                        let insert_pos = merge_target.keys().len();
+                        merge_target
+                            .keys_mut()
+                            .append(k.borrow())
+                            .expect("Couldn't append key");
+                        merge_target
+                            .children_mut()
+                            .insert(insert_pos + 1, &v)
+                            .expect("Couldn't append child");
+                        merge_target.set_len(insert_pos + 1);
+                    }
+                });
+
+                self.set_len(0);
+            }
+            RebalanceResult::MergeIntoSelf => {
+                //merge right into this
+                let mut sibling_mut = match args.siblings {
+                    SiblingsArg::Right((_, clone)) | SiblingsArg::Both(_, (_, clone)) => clone,
+                    _ => unreachable!(),
+                };
+
+                let sibling = sibling_mut();
+
+                let anchor_key =
+                    parent_ref.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                        node.as_internal()
+                            .keys()
+                            .get(anchor.map(|a| a + 1).unwrap_or(0))
+                            .borrow()
+                            .clone()
+                    });
+
+                sibling.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                    for (k, v) in Some(anchor_key.as_output())
+                        .into_iter()
+                        .chain(node.as_internal().keys().into_iter())
+                        .zip(node.as_internal().children().into_iter())
+                    {
+                        let insert_pos = self.keys().len();
+                        self.keys_mut()
+                            .append(k.borrow())
+                            .expect("Couldn't append key");
+                        self.children_mut()
+                            .insert(insert_pos + 1, &v)
+                            .expect("Couldn't append child");
+                        self.set_len(insert_pos + 1);
+                    }
+
+                    // node.as_internal_mut().unwrap().set_len(0);
+                    // not really necessary, because this node will get deleted anyway
+                });
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub fn update_key(&mut self, pos: usize, key: K) -> Result<(), ()> {
+        self.keys_mut().update(pos, &key)
+    }
+
     fn set_len(&mut self, new_len: usize) {
         let new_len = u64::try_from(new_len).unwrap();
         LittleEndian::write_u64(&mut self.data.as_mut()[0..LEN_SIZE], new_len);
@@ -323,5 +598,420 @@ where
         let data = &self.data.as_ref()[LEN_SIZE..LEN_SIZE + self.max_keys * self.key_buffer_size];
 
         Keys::new_dynamic_size(data, len.try_into().unwrap(), self.key_buffer_size)
+    }
+
+    fn has_extra(&self) -> bool {
+        self.children().len() > self.lower_bound()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::btreeindex::node::tests::{
+        allocate_internal as allocate, internal_page, internal_page_mut, pages,
+    };
+    use crate::tests::U64Key;
+
+    impl<T: AsRef<[u8]> + AsMut<[u8]>> InternalNode<'_, U64Key, T> {
+        fn delete(&mut self, key: &U64Key) -> Result<InternalDeleteStatus, BTreeStoreError> {
+            match self.keys().binary_search(key) {
+                Ok(pos) => Ok(self.delete_key_children(pos)),
+                Err(_pos) => return Err(BTreeStoreError::KeyNotFound),
+            }
+        }
+    }
+    // TEMPORAL
+    use std::fmt::Debug;
+    impl<'a, K: Key, T> Debug for InternalNode<'a, K, T>
+    where
+        T: AsRef<[u8]>,
+    {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "Internal Node {{ max_keys: {}, keys: {} }}",
+                self.max_keys,
+                self.keys().len()
+            )
+        }
+    }
+
+    impl<'a, T: 'a> PartialEq for InternalNode<'a, U64Key, T>
+    where
+        T: AsRef<[u8]>,
+    {
+        fn eq(&self, other: &Self) -> bool {
+            let same_keys = self.keys().into_iter().collect::<Vec<U64Key>>()
+                == other.keys().into_iter().collect::<Vec<U64Key>>();
+
+            let same_children = self.children().into_iter().collect::<Vec<u32>>()
+                == other.children().into_iter().collect::<Vec<u32>>();
+
+            same_keys && same_children
+        }
+    }
+
+    impl<T> Eq for InternalNode<'_, U64Key, T> where T: AsRef<[u8]> {}
+
+    #[test]
+    fn delete_without_underflow() {
+        let input = [2, 3];
+        let page_size = 8 + 8 + 3 * size_of::<U64Key>() + 4 * size_of::<PageId>();
+
+        let buffer = MemPage::new(page_size);
+        let mut node: Node<U64Key, MemPage> =
+            Node::new_internal(std::mem::size_of::<U64Key>(), buffer);
+
+        node.as_internal_mut().insert_first(U64Key(1), 0, 1);
+
+        for i in input.iter() {
+            match node
+                .as_internal_mut()
+                .insert(U64Key(*i as u64), *i, &mut allocate)
+            {
+                InternalInsertStatus::Ok => (),
+                _ => panic!("insertion shouldn't split"),
+            };
+        }
+
+        match node.as_internal_mut().delete(&U64Key(1)).unwrap() {
+            InternalDeleteStatus::Ok => (),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn delete_with_take_from_left() {
+        let before_pages = pages();
+        let mut node = internal_page_mut(
+            &before_pages,
+            22,
+            vec![U64Key(15), U64Key(17)],
+            vec![1u32, 2, 3],
+        );
+        let parent = internal_page_mut(
+            &before_pages,
+            1,
+            vec![U64Key(10), U64Key(20), U64Key(30)],
+            vec![21, 22, 23, 24],
+        );
+        let left_sibling = internal_page(
+            &before_pages,
+            21,
+            vec![U64Key(1), U64Key(3), U64Key(5)],
+            vec![31, 32, 33, 34],
+        );
+
+        node.as_node_mut(size_of::<U64Key>(), |mut node| {
+            let mut node = node.as_internal_mut();
+            assert!(node.keys().len() == 2);
+            match node.delete(&U64Key(15)).unwrap() {
+                InternalDeleteStatus::NeedsRebalance => (),
+                _ => panic!(),
+            }
+
+            match node
+                .rebalance(RebalanceArgs {
+                    parent,
+                    parent_anchor: Some(0),
+                    siblings: SiblingsArg::Left((left_sibling, || {
+                        before_pages.make_shadow(21, 31).unwrap();
+                        before_pages.mut_page(31).unwrap()
+                    })),
+                })
+                .unwrap()
+            {
+                RebalanceResult::TookKeyFromLeft => (),
+                _ => panic!(),
+            }
+        });
+
+        let auxiliar_pages = pages();
+        let node_expected = internal_page(
+            &auxiliar_pages,
+            22,
+            vec![U64Key(10), U64Key(17)],
+            vec![34, 1, 3],
+        );
+
+        node.as_node(size_of::<U64Key>(), |before| {
+            node_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                assert_eq!(before.as_internal(), node_expected.as_internal())
+            })
+        });
+
+        assert_eq!(
+            before_pages.get_page(31).unwrap().as_node(
+                size_of::<U64Key>(),
+                |node: Node<U64Key, &[u8]>| node.as_internal().keys().len()
+            ),
+            2
+        );
+
+        assert_eq!(
+            before_pages.get_page(1).unwrap().as_node(
+                size_of::<U64Key>(),
+                |node: Node<U64Key, &[u8]>| node.as_internal().keys().get(0)
+            ),
+            U64Key(5)
+        )
+    }
+
+    #[test]
+    fn delete_with_take_from_right() {
+        let before_pages = pages();
+        let parent = internal_page_mut(
+            &before_pages,
+            1,
+            vec![U64Key(10), U64Key(20), U64Key(30)],
+            vec![1, 2, 3, 4],
+        );
+        let mut node = internal_page_mut(
+            &before_pages,
+            12,
+            vec![U64Key(15), U64Key(17)],
+            vec![11, 12, 13],
+        );
+        let right_sibling = internal_page(
+            &before_pages,
+            13,
+            vec![U64Key(22), U64Key(24), U64Key(26)],
+            vec![21, 22, 23, 24],
+        );
+
+        node.as_node_mut(size_of::<U64Key>(), |mut node| {
+            let mut node = node.as_internal_mut();
+            match node.delete(&U64Key(15)).unwrap() {
+                InternalDeleteStatus::NeedsRebalance => (),
+                _ => panic!(),
+            };
+
+            match node
+                .rebalance(RebalanceArgs {
+                    parent,
+                    parent_anchor: Some(0),
+                    siblings: SiblingsArg::Right((right_sibling, || {
+                        before_pages.make_shadow(13, 31).unwrap();
+                        before_pages.mut_page(31).unwrap()
+                    })),
+                })
+                .unwrap()
+            {
+                RebalanceResult::TookKeyFromRight => (),
+                _ => panic!(),
+            }
+        });
+
+        let aux_pages = pages();
+        let node_expected = internal_page(
+            &aux_pages,
+            12,
+            vec![U64Key(17), U64Key(20)],
+            vec![11, 13, 21],
+        );
+        node.as_node(size_of::<U64Key>(), |before| {
+            node_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                assert_eq!(before.as_internal(), node_expected.as_internal())
+            })
+        });
+
+        let right_sibling_expected = internal_page(
+            &aux_pages,
+            13,
+            vec![U64Key(24), U64Key(26)],
+            vec![22, 23, 24],
+        );
+
+        before_pages
+            .get_page(31)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                right_sibling_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_internal(), node_expected.as_internal())
+                })
+            });
+
+        let parent_expected = internal_page(
+            &aux_pages,
+            1,
+            vec![U64Key(10), U64Key(22), U64Key(30)],
+            vec![1, 2, 3, 4],
+        );
+
+        before_pages
+            .get_page(1)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                parent_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_internal(), node_expected.as_internal())
+                })
+            });
+    }
+
+    #[test]
+    fn delete_with_left_merge() {
+        let before_pages = pages();
+        let parent = internal_page_mut(
+            &before_pages,
+            1,
+            vec![U64Key(10), U64Key(20), U64Key(30)],
+            vec![1, 2, 3, 4],
+        );
+        let mut node = internal_page_mut(
+            &before_pages,
+            12,
+            vec![U64Key(15), U64Key(17)],
+            vec![11, 12, 13],
+        );
+        let left_sibling = internal_page(
+            &before_pages,
+            11,
+            vec![U64Key(5), U64Key(7)],
+            vec![21, 22, 23],
+        );
+
+        node.as_node_mut(size_of::<U64Key>(), |mut node| {
+            let mut node = node.as_internal_mut();
+            match node.delete(&U64Key(15)).unwrap() {
+                InternalDeleteStatus::NeedsRebalance => (),
+                _ => panic!(),
+            };
+
+            match node
+                .rebalance(RebalanceArgs {
+                    parent,
+                    parent_anchor: Some(0),
+                    siblings: SiblingsArg::Left((left_sibling, || {
+                        before_pages.make_shadow(11, 31).unwrap();
+                        before_pages.mut_page(31).unwrap()
+                    })),
+                })
+                .unwrap()
+            {
+                RebalanceResult::MergeIntoLeft => (),
+                _ => panic!(),
+            }
+        });
+
+        assert_eq!(
+            node.as_node(size_of::<U64Key>(), |n: Node<U64Key, &[u8]>| n
+                .as_internal()
+                .keys()
+                .len()),
+            0
+        );
+
+        let aux_pages = pages();
+        let left_sibling_expected = internal_page(
+            &aux_pages,
+            11,
+            vec![U64Key(5), U64Key(7), U64Key(10), U64Key(17)],
+            vec![21, 22, 23, 11, 13],
+        );
+
+        before_pages
+            .get_page(31)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                left_sibling_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_internal(), node_expected.as_internal())
+                })
+            });
+
+        let parent_expected = internal_page_mut(
+            &aux_pages,
+            1,
+            vec![U64Key(10), U64Key(20), U64Key(30)],
+            vec![1, 2, 3, 4],
+        );
+
+        before_pages
+            .get_page(1)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                parent_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_internal(), node_expected.as_internal())
+                })
+            });
+    }
+
+    #[test]
+    fn delete_with_right_merge() {
+        let before_pages = pages();
+
+        let parent = internal_page_mut(
+            &before_pages,
+            1,
+            vec![U64Key(10), U64Key(20), U64Key(30)],
+            vec![1, 2, 3, 4],
+        );
+
+        let mut node = internal_page_mut(
+            &before_pages,
+            12,
+            vec![U64Key(15), U64Key(17)],
+            vec![11, 12, 13],
+        );
+
+        let right_sibling = internal_page(
+            &before_pages,
+            13,
+            vec![U64Key(25), U64Key(27)],
+            vec![21, 22, 23],
+        );
+
+        node.as_node_mut(size_of::<U64Key>(), |mut node| {
+            let mut node = node.as_internal_mut();
+            match node.delete(&U64Key(15)).unwrap() {
+                InternalDeleteStatus::NeedsRebalance => (),
+                _ => panic!(),
+            };
+
+            match node
+                .rebalance(RebalanceArgs {
+                    parent,
+                    parent_anchor: Some(0),
+                    siblings: SiblingsArg::Right((right_sibling, || {
+                        before_pages.make_shadow(13, 33).unwrap();
+                        before_pages.mut_page(33).unwrap()
+                    })),
+                })
+                .unwrap()
+            {
+                RebalanceResult::MergeIntoSelf => (),
+                _ => panic!(),
+            };
+        });
+
+        let aux_pages = pages();
+        let node_expected = internal_page(
+            &aux_pages,
+            12,
+            vec![U64Key(17), U64Key(20), U64Key(25), U64Key(27)],
+            vec![11, 13, 21, 22, 23],
+        );
+
+        node.as_node(size_of::<U64Key>(), |before| {
+            node_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                assert_eq!(before.as_internal(), node_expected.as_internal())
+            })
+        });
+
+        let parent_expected = internal_page(
+            &aux_pages,
+            1,
+            vec![U64Key(10), U64Key(20), U64Key(30)],
+            vec![1, 2, 3, 4],
+        );
+
+        before_pages
+            .get_page(1)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                parent_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_internal(), node_expected.as_internal())
+                })
+            });
     }
 }

--- a/btree/src/btreeindex/node/internal_node.rs
+++ b/btree/src/btreeindex/node/internal_node.rs
@@ -288,9 +288,9 @@ where
     }
 
     #[allow(dead_code)]
-    pub fn rebalance<'siblings>(
+    pub fn rebalance<N: super::NodePageRef>(
         &'b mut self,
-        args: SiblingsArg<'siblings>,
+        args: SiblingsArg<N>,
     ) -> Result<RebalanceResult, BTreeStoreError> {
         let current_len = self.keys().len();
 

--- a/btree/src/btreeindex/node/leaf_node.rs
+++ b/btree/src/btreeindex/node/leaf_node.rs
@@ -226,9 +226,9 @@ where
         }
     }
 
-    pub fn rebalance(
+    pub fn rebalance<N: super::NodePageRef>(
         &'b mut self,
-        mut args: SiblingsArg,
+        mut args: SiblingsArg<N>,
     ) -> Result<RebalanceResult, BTreeStoreError> {
         let current_len = self.keys().len();
 

--- a/btree/src/btreeindex/node/leaf_node.rs
+++ b/btree/src/btreeindex/node/leaf_node.rs
@@ -1,7 +1,11 @@
 use std::marker::PhantomData;
 
-use super::Node;
-use crate::btreeindex::{Keys, KeysMut, PageId, Values, ValuesMut};
+use super::{Node, RebalanceArgs, RebalanceResult, SiblingsArg};
+use crate::btreeindex::{
+    pages::{borrow::Mutable, PageHandle},
+    Keys, KeysMut, PageId, Values, ValuesMut,
+};
+use crate::BTreeStoreError;
 use crate::Key;
 use crate::MemPage;
 use crate::Value as V;
@@ -16,6 +20,11 @@ pub(crate) enum LeafInsertStatus<K> {
     Ok,
     Split(K, Node<K, MemPage>),
     DuplicatedKey(K),
+}
+
+pub enum LeafDeleteStatus {
+    Ok,
+    NeedsRebalance,
 }
 
 /// LeafNode is a wrapper over a slice of bytes (T). The layout is the following
@@ -217,6 +226,394 @@ where
         }
     }
 
+    pub fn rebalance<'siblings: 'b, F: FnMut() -> PageHandle<'siblings, Mutable<'siblings>>>(
+        &'b mut self,
+        mut args: RebalanceArgs<'siblings, F>,
+    ) -> Result<RebalanceResult, BTreeStoreError> {
+        let current_len = self.keys().len();
+
+        let result = {
+            let left_sibling_handle = match &args.siblings {
+                SiblingsArg::Left((handle, _)) | SiblingsArg::Both((handle, _), _) => Some(handle),
+                _ => None,
+            };
+
+            let right_sibling_handle = match &args.siblings {
+                SiblingsArg::Right((handle, _)) | SiblingsArg::Both(_, (handle, _)) => Some(handle),
+                _ => None,
+            };
+
+            if current_len < self.lower_bound() {
+                // underflow
+                if left_sibling_handle
+                    .filter(|handle| {
+                        handle.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| -> bool {
+                            node.as_leaf().has_extra()
+                        })
+                    })
+                    .is_some()
+                {
+                    RebalanceResult::TookKeyFromLeft
+                } else if right_sibling_handle
+                    .clone()
+                    .filter(|handle| {
+                        handle.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                            node.as_leaf().has_extra()
+                        })
+                    })
+                    .is_some()
+                {
+                    RebalanceResult::TookKeyFromRight
+                } else if left_sibling_handle.is_some() {
+                    RebalanceResult::MergeIntoLeft
+                } else if right_sibling_handle.is_some() {
+                    RebalanceResult::MergeIntoSelf
+                } else {
+                    unreachable!();
+                }
+            } else {
+                // TODO: add error? vs don't do anything
+                panic!("node doesn't need rebalance")
+            }
+        };
+
+        match result {
+            RebalanceResult::TookKeyFromLeft => {
+                let mut sibling_clone = match args.siblings {
+                    SiblingsArg::Left((_, clone)) | SiblingsArg::Both((_, clone), _) => clone,
+                    _ => unreachable!(),
+                };
+
+                let mut sibling = sibling_clone();
+
+                // steal a key from the left sibling
+                let (stolen_key, stolen_value) =
+                    sibling.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                        let node = node.as_leaf();
+                        let keys = node.keys();
+                        let last = keys.len().checked_sub(1).unwrap();
+                        let stolen_key = keys.get(last);
+                        let stolen_value = node.values().get(last);
+                        (stolen_key.borrow().clone(), stolen_value.borrow().clone())
+                    });
+
+                self.keys_mut()
+                    .insert(0, &stolen_key)
+                    .expect("Couldn't insert key at pos 0");
+                self.values_mut()
+                    .insert(0, &stolen_value)
+                    .expect("Couldn't insert value at pos 0");
+                self.set_len(current_len + 1);
+
+                sibling.as_node_mut(self.key_buffer_size, |mut node: Node<K, &mut [u8]>| {
+                    let mut sibling = node.as_leaf_mut();
+                    let last = sibling.keys().len().checked_sub(1).unwrap();
+                    sibling.keys_mut().delete(last).unwrap();
+                    sibling.values_mut().delete(last).unwrap();
+                    sibling.set_len(last);
+                });
+
+                let pos_to_update_in_parent = args.parent_anchor.unwrap();
+
+                args.parent
+                    .as_node_mut(self.key_buffer_size, |mut node: Node<K, &mut [u8]>| {
+                        node.as_internal_mut()
+                            .update_key(
+                                pos_to_update_in_parent,
+                                self.keys().get(0).borrow().clone(),
+                            )
+                            .expect("update key failed: tried to update a key not in range");
+                    });
+            }
+            RebalanceResult::TookKeyFromRight => {
+                // steal a key from the right sibling
+                let mut sibling_mut = match args.siblings {
+                    SiblingsArg::Right((_, clone)) | SiblingsArg::Both(_, (_, clone)) => clone,
+                    _ => unreachable!(),
+                };
+
+                let mut sibling = sibling_mut();
+
+                let (stolen_key, stolen_value) =
+                    sibling.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                        let node = node.as_leaf();
+                        let keys = node.keys();
+                        let stolen_key = keys.get(0);
+                        let stolen_value = node.values().get(0);
+                        (stolen_key.borrow().clone(), stolen_value.clone())
+                    });
+
+                // in leaf, keys.len() == values.len()
+                let insert_pos = self.keys().len();
+                self.keys_mut()
+                    .append(&stolen_key)
+                    .expect("Couldn't insert at the end");
+
+                self.values_mut()
+                    .insert(insert_pos, &stolen_value)
+                    .expect("Couldn't insert at the end");
+
+                self.set_len(current_len + 1);
+
+                sibling.as_node_mut(self.key_buffer_size, |mut node: Node<K, &mut [u8]>| {
+                    let mut sibling = node.as_leaf_mut();
+                    let current_len = sibling.keys().len();
+                    sibling.keys_mut().delete(0).unwrap();
+                    sibling.values_mut().delete(0).unwrap();
+                    sibling.set_len(current_len.checked_sub(1).unwrap());
+                });
+
+                let pos_to_update_in_parent = args.parent_anchor.map_or(0, |anchor| anchor + 1);
+
+                args.parent
+                    .as_node_mut(self.key_buffer_size, |mut node: Node<K, &mut [u8]>| {
+                        node.as_internal_mut()
+                            .update_key(
+                                pos_to_update_in_parent,
+                                sibling.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                                    node.as_leaf().keys().get(0).borrow().clone()
+                                }),
+                            )
+                            .expect("Couldn't update parent key");
+                    });
+            }
+            RebalanceResult::MergeIntoLeft => {
+                //merge this into left
+
+                let mut sibling_clone = match args.siblings {
+                    SiblingsArg::Left((_, clone)) | SiblingsArg::Both((_, clone), _) => clone,
+                    _ => unreachable!(),
+                };
+
+                let mut sibling = sibling_clone();
+
+                sibling.as_node_mut(self.key_buffer_size, |mut node| {
+                    let mut merge_target = node.as_leaf_mut();
+                    for (k, v) in self.keys().into_iter().zip(self.values().into_iter()) {
+                        // TODO: Create an Append?
+                        let insert_pos = merge_target.keys().len();
+                        merge_target
+                            .keys_mut()
+                            .insert(insert_pos, &k.borrow().clone())
+                            .expect("Couldn't insert at the end");
+                        merge_target
+                            .values_mut()
+                            .insert(insert_pos, &v.borrow().clone())
+                            .expect("Couldn't insert at the end");
+                        merge_target.set_len(insert_pos + 1);
+                    }
+                });
+            }
+            RebalanceResult::MergeIntoSelf => {
+                //merge right into this
+
+                // steal a key from the right sibling
+                let mut sibling_mut = match args.siblings {
+                    SiblingsArg::Right((_, clone)) | SiblingsArg::Both(_, (_, clone)) => clone,
+                    _ => unreachable!(),
+                };
+
+                let sibling = sibling_mut();
+
+                sibling.as_node(self.key_buffer_size, |node: Node<K, &[u8]>| {
+                    for (k, v) in node
+                        .as_leaf()
+                        .keys()
+                        .into_iter()
+                        .zip(node.as_leaf().values().into_iter())
+                    {
+                        let insert_pos = self.keys().len();
+                        self.keys_mut()
+                            .insert(insert_pos, &k.borrow().clone())
+                            .expect("Couldn't insert at the end");
+                        self.values_mut()
+                            .insert(insert_pos, &v.borrow().clone())
+                            .expect("Couldn't insert at the end");
+                        self.set_len(insert_pos + 1);
+                    }
+                });
+            }
+        };
+
+        /*
+        if current_len < self.lower_bound() {
+            // underflow
+            let left_sibling_handle = match &args.siblings {
+                SiblingsArg::Left(node) | SiblingsArg::Both(node, _) => Some(node),
+                _ => None,
+            };
+
+            let right_sibling_handle = match &args.siblings {
+                SiblingsArg::Right(node) | SiblingsArg::Both(_, node) => Some(node),
+                _ => None,
+            };
+
+            if let Some(left) = left_sibling_handle.clone().filter(|handle| {
+                handle
+                    .as_node(|node: Node<K, &[u8]>| -> bool { node.as_leaf().unwrap().has_extra() })
+            }) {
+                let mut left_sibling = left.get_mut();
+                // steal a key from the left sibling
+                let (stolen_key, stolen_value) = left_sibling.as_node(|node| {
+                    let node = node.as_leaf().unwrap();
+                    let last = node.keys().len().checked_sub(1).unwrap();
+                    let stolen_key = node.keys().get(last).unwrap();
+                    let stolen_value = node.values().get(last).unwrap();
+                    (stolen_key, stolen_value)
+                });
+
+                self.keys_mut()
+                    .insert(0, &stolen_key)
+                    .expect("Couldn't insert key at pos 0");
+                self.values_mut()
+                    .insert(0, &stolen_value)
+                    .expect("Couldn't insert value at pos 0");
+                self.set_len(current_len + 1);
+
+                left_sibling.as_node_mut(|mut node: Node<K, &mut [u8]>| {
+                    let mut sibling = node.as_leaf_mut().unwrap();
+                    let last = sibling.keys().len().checked_sub(1).unwrap();
+                    sibling.keys_mut().delete(last).unwrap();
+                    sibling.values_mut().delete(last).unwrap();
+                    sibling.set_len(last);
+                });
+
+                let pos_to_update_in_parent = args.parent_anchor.unwrap();
+
+                args.parent.as_node_mut(|mut node: Node<K, &mut [u8]>| {
+                    node.as_internal_mut()
+                        .unwrap()
+                        .update_key(pos_to_update_in_parent, self.keys().get(0).unwrap())
+                        .expect("update key failed: tried to update a key not in range");
+                });
+
+                Ok(RebalanceResult::TookKeyFromLeft(left_sibling))
+            } else if let Some(right_sibling) = right_sibling_handle.clone().filter(|handle| {
+                handle.as_node(|node: Node<K, &[u8]>| node.as_leaf().unwrap().has_extra())
+            }) {
+                let mut right_sibling = right_sibling.get_mut();
+                // steal a key from the right sibling
+
+                let (stolen_key, stolen_value) = right_sibling.as_node(|node| {
+                    let node = node.as_leaf().unwrap();
+                    let _last = node.keys().len();
+                    let stolen_key = node.keys().get(0).unwrap();
+                    let stolen_value = node.values().get(0).unwrap();
+                    (stolen_key, stolen_value)
+                });
+
+                // in leaf, keys.len() == values.len()
+                let insert_pos = self.keys().len();
+                self.keys_mut()
+                    .append(&stolen_key)
+                    .expect("Couldn't insert at the end");
+
+                self.values_mut()
+                    .insert(insert_pos, &stolen_value)
+                    .expect("Couldn't insert at the end");
+
+                self.set_len(current_len + 1);
+
+                right_sibling.as_node_mut(|mut node: Node<K, &mut [u8]>| {
+                    let mut sibling = node.as_leaf_mut().unwrap();
+                    let current_len = sibling.keys().len();
+                    sibling.keys_mut().delete(0).unwrap();
+                    sibling.values_mut().delete(0).unwrap();
+                    sibling.set_len(current_len.checked_sub(1).unwrap());
+                });
+
+                let pos_to_update_in_parent = args.parent_anchor.map_or(0, |anchor| anchor + 1);
+
+                args.parent.as_node_mut(|mut node: Node<K, &mut [u8]>| {
+                    node.as_internal_mut()
+                        .unwrap()
+                        .update_key(
+                            pos_to_update_in_parent,
+                            right_sibling
+                                .as_node(|node| node.as_leaf().unwrap().keys().get(0).unwrap()),
+                        )
+                        .expect("Couldn't update parent key");
+                });
+
+                Ok(RebalanceResult::TookKeyFromRight(right_sibling))
+            } else if let Some(node) = left_sibling_handle {
+                let mut left_sibling = node.get_mut();
+                //merge this into left
+                left_sibling.as_node_mut(|mut node| {
+                    let mut merge_target = node.as_leaf_mut().unwrap();
+                    for (k, v) in self.keys().into_iter().zip(self.values().into_iter()) {
+                        // TODO: Create an Append?
+                        let insert_pos = merge_target.keys().len();
+                        merge_target
+                            .keys_mut()
+                            .insert(insert_pos, &k)
+                            .expect("Couldn't insert at the end");
+                        merge_target
+                            .values_mut()
+                            .insert(insert_pos, &v)
+                            .expect("Couldn't insert at the end");
+                        merge_target.set_len(insert_pos + 1);
+                    }
+                });
+                Ok(RebalanceResult::MergeIntoLeft(left_sibling))
+            } else if let Some(node) = right_sibling_handle {
+                //merge right into this
+                node.as_node(|node| {
+                    for (k, v) in node
+                        .as_leaf()
+                        .unwrap()
+                        .keys()
+                        .into_iter()
+                        .zip(node.as_leaf().unwrap().values().into_iter())
+                    {
+                        let insert_pos = self.keys().len();
+                        self.keys_mut()
+                            .insert(insert_pos, &k)
+                            .expect("Couldn't insert at the end");
+                        self.values_mut()
+                            .insert(insert_pos, &v)
+                            .expect("Couldn't insert at the end");
+                        self.set_len(insert_pos + 1);
+                    }
+                });
+                Ok(RebalanceResult::MergeIntoSelf)
+            } else {
+                unreachable!();
+            }
+        } else {
+            panic!("node shouldn't be rebalanced")
+        }*/
+        Ok(result)
+    }
+
+    pub fn delete<'siblings: 'b>(
+        &'b mut self,
+        key: &'siblings K,
+    ) -> Result<LeafDeleteStatus, BTreeStoreError> {
+        match self.keys().binary_search(key) {
+            Ok(pos) => {
+                self.delete_key_value(pos)
+                    .expect("internal error: keys search returned invalid position");
+                let current_len = self.keys().len();
+                if current_len < self.lower_bound() {
+                    Ok(LeafDeleteStatus::NeedsRebalance)
+                } else {
+                    Ok(LeafDeleteStatus::Ok)
+                }
+            }
+            Err(_) => return Err(BTreeStoreError::KeyNotFound),
+        }
+    }
+
+    fn delete_key_value(&mut self, pos: usize) -> Result<(), ()> {
+        let current_len = self.keys().len();
+        self.keys_mut().delete(pos)?;
+        self.values_mut().delete(pos)?;
+
+        self.set_len(current_len - 1);
+        Ok(())
+    }
+
     fn values_mut(&mut self) -> ValuesMut {
         let len = self.keys().len();
 
@@ -293,5 +690,386 @@ where
         let data: &[u8] = &self.data.as_ref()[base..base + self.max_keys * size_of::<V>()];
 
         Values::new_static_size(data, len)
+    }
+
+    /// can give one key-value to a neighbour without imbalancing itself
+    fn has_extra(&self) -> bool {
+        self.values().len() > self.lower_bound()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::btreeindex::node::tests::{internal_page, internal_page_mut, pages};
+    use crate::btreeindex::pages::borrow::{Immutable, Mutable};
+    use crate::btreeindex::pages::Pages;
+    use crate::btreeindex::*;
+    use crate::tests::U64Key;
+    use std::mem::size_of;
+
+    use std::fmt::Debug;
+
+    impl<'a, K: Key, T> Debug for LeafNode<'a, K, T>
+    where
+        T: AsRef<[u8]>,
+    {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "LeafNode {{ max_keys: {}, keys: {} }}",
+                self.max_keys,
+                self.keys().len()
+            )
+        }
+    }
+
+    impl<'a, T: 'a> PartialEq for LeafNode<'a, U64Key, T>
+    where
+        T: AsRef<[u8]>,
+    {
+        fn eq(&self, other: &Self) -> bool {
+            let same_keys = self.keys().into_iter().collect::<Vec<U64Key>>()
+                == other.keys().into_iter().collect::<Vec<U64Key>>();
+
+            let same_values = self.values().into_iter().collect::<Vec<u64>>()
+                == other.values().into_iter().collect::<Vec<u64>>();
+
+            same_keys && same_values
+        }
+    }
+
+    impl<T> Eq for LeafNode<'_, U64Key, T> where T: AsRef<[u8]> {}
+
+    fn allocate() -> Node<U64Key, MemPage> {
+        let page_size = 8 + 8 + size_of::<PageId>() + 3 * size_of::<U64Key>() + 4 * size_of::<V>();
+        let page = MemPage::new(page_size);
+        Node::new_leaf(std::mem::size_of::<U64Key>(), page)
+    }
+
+    fn new_page_mut(
+        pages: &Pages,
+        page_id: PageId,
+        keys: Vec<U64Key>,
+        values: Vec<u64>,
+    ) -> PageHandle<Mutable> {
+        assert_eq!(keys.len(), values.len());
+
+        const NUMBER_OF_KEYS: usize = 3;
+        let page_size = crate::btreeindex::node::TAG_SIZE
+            + LEN_SIZE
+            + NUMBER_OF_KEYS * size_of::<U64Key>()
+            + NUMBER_OF_KEYS * size_of::<V>();
+
+        let mut page = pages.mut_page(page_id).unwrap();
+
+        page.as_slice(|slice| {
+            Node::<U64Key, &mut [u8]>::new_leaf(size_of::<U64Key>(), slice);
+        });
+
+        page.as_node_mut(size_of::<U64Key>(), |mut node| {
+            for (k, c) in keys.iter().zip(values.iter()) {
+                match node.as_leaf_mut().insert((*k).clone(), *c, &mut allocate) {
+                    LeafInsertStatus::Ok => (),
+                    _ => panic!("insertion shouldn't split"),
+                };
+            }
+        });
+
+        page
+    }
+
+    fn new_page(
+        pages: &Pages,
+        page_id: PageId,
+        keys: Vec<U64Key>,
+        values: Vec<u64>,
+    ) -> PageHandle<Immutable> {
+        {
+            new_page_mut(pages, page_id, keys, values);
+        }
+        pages.get_page(page_id).unwrap()
+    }
+
+    #[test]
+    fn delete_without_underflow() {
+        let pages = pages();
+        let mut node = new_page_mut(
+            &pages,
+            1,
+            vec![U64Key(1), U64Key(2), U64Key(3)],
+            vec![1, 2, 3],
+        );
+        node.as_node_mut(size_of::<U64Key>(), |mut node| {
+            match node.as_leaf_mut().delete(&U64Key(1)).unwrap() {
+                LeafDeleteStatus::Ok => (),
+                _ => panic!(),
+            }
+        });
+    }
+
+    #[test]
+    fn delete_with_take_from_left() {
+        let storage = pages();
+        let parent = internal_page_mut(&storage, 3, vec![U64Key(4), U64Key(8)], vec![2, 1, 3]);
+        let mut node = new_page_mut(&storage, 1, vec![U64Key(5), U64Key(6)], vec![5, 6]);
+        let left_sibling = new_page(
+            &storage,
+            2,
+            vec![U64Key(1), U64Key(2), U64Key(3)],
+            vec![1, 2, 3],
+        );
+
+        node.as_node_mut(size_of::<U64Key>(), |mut node| {
+            match node.as_leaf_mut().delete(&U64Key(5)).unwrap() {
+                LeafDeleteStatus::NeedsRebalance => (),
+                _ => panic!(),
+            }
+        });
+
+        node.as_node_mut(
+            size_of::<U64Key>(),
+            |mut node: Node<U64Key, &mut [u8]>| match node
+                .as_leaf_mut()
+                .rebalance(RebalanceArgs {
+                    parent,
+                    parent_anchor: Some(0),
+                    siblings: SiblingsArg::Left((left_sibling, || {
+                        storage.make_shadow(2, 12).unwrap();
+                        storage.mut_page(12).unwrap()
+                    })),
+                })
+                .unwrap()
+            {
+                RebalanceResult::TookKeyFromLeft => (),
+                _ => panic!("need took from left"),
+            },
+        );
+
+        let aux_storage = pages();
+        let node_expected = new_page(&aux_storage, 1, vec![U64Key(3), U64Key(6)], vec![3, 6]);
+        node.as_node(size_of::<U64Key>(), |before| {
+            node_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                assert_eq!(before.as_leaf(), node_expected.as_leaf())
+            })
+        });
+
+        let parent_expected =
+            internal_page(&aux_storage, 3, vec![U64Key(3), U64Key(8)], vec![2, 1, 3]);
+
+        storage
+            .get_page(3)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                parent_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_internal(), node_expected.as_internal())
+                })
+            });
+
+        let left_sibling_expected =
+            new_page(&aux_storage, 12, vec![U64Key(1), U64Key(2)], vec![1, 2]);
+
+        storage
+            .get_page(12)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                left_sibling_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_leaf(), node_expected.as_leaf())
+                })
+            });
+    }
+
+    #[test]
+    fn delete_with_take_from_right() {
+        let storage = pages();
+        let parent = internal_page_mut(&storage, 3, vec![U64Key(3), U64Key(8)], vec![1, 2, 3]);
+        let mut node = new_page_mut(&storage, 1, vec![U64Key(1), U64Key(2)], vec![1, 2]);
+        let right_sibling = new_page(
+            &storage,
+            2,
+            vec![U64Key(4), U64Key(5), U64Key(6)],
+            vec![4, 5, 6],
+        );
+
+        node.as_node_mut(size_of::<U64Key>(), |mut node| {
+            match node.as_leaf_mut().delete(&U64Key(1)).unwrap() {
+                LeafDeleteStatus::NeedsRebalance => (),
+                _ => panic!(),
+            }
+        });
+
+        node.as_node_mut(
+            size_of::<U64Key>(),
+            |mut node: Node<U64Key, &mut [u8]>| match node
+                .as_leaf_mut()
+                .rebalance(RebalanceArgs {
+                    parent,
+                    parent_anchor: None,
+                    siblings: SiblingsArg::Right((right_sibling, || {
+                        storage.make_shadow(2, 12);
+                        storage.mut_page(12).unwrap()
+                    })),
+                })
+                .unwrap()
+            {
+                RebalanceResult::TookKeyFromRight => (),
+                _ => panic!("need took from right"),
+            },
+        );
+
+        let aux_storage = pages();
+        let node_expected = new_page(&aux_storage, 1, vec![U64Key(2), U64Key(4)], vec![2, 4]);
+        node.as_node(size_of::<U64Key>(), |before| {
+            node_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                assert_eq!(before.as_leaf(), node_expected.as_leaf())
+            })
+        });
+
+        let parent_expected =
+            internal_page(&aux_storage, 3, vec![U64Key(5), U64Key(8)], vec![1, 2, 3]);
+        storage
+            .get_page(3)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                parent_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_internal(), node_expected.as_internal())
+                })
+            });
+
+        let right_sibling_expected =
+            new_page(&aux_storage, 2, vec![U64Key(5), U64Key(6)], vec![5, 6]);
+
+        storage
+            .get_page(12)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                right_sibling_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_leaf(), node_expected.as_leaf())
+                })
+            });
+    }
+
+    #[test]
+    fn delete_with_left_merge() {
+        let storage = pages();
+        let parent = internal_page_mut(&storage, 3, vec![U64Key(3), U64Key(8)], vec![2, 1, 3]);
+        let mut node = new_page_mut(&storage, 1, vec![U64Key(4), U64Key(5)], vec![4, 5]);
+        let left_sibling = new_page(&storage, 2, vec![U64Key(1), U64Key(2)], vec![1, 2]);
+
+        node.as_node_mut(size_of::<U64Key>(), |mut node| {
+            match node.as_leaf_mut().delete(&U64Key(4)).unwrap() {
+                LeafDeleteStatus::NeedsRebalance => (),
+                _ => panic!(),
+            }
+        });
+
+        node.as_node_mut(
+            size_of::<U64Key>(),
+            |mut node: Node<U64Key, &mut [u8]>| match node
+                .as_leaf_mut()
+                .rebalance(RebalanceArgs {
+                    parent,
+                    parent_anchor: Some(0),
+                    siblings: SiblingsArg::Left((left_sibling, || {
+                        storage.make_shadow(2, 12).unwrap();
+                        storage.mut_page(12).unwrap()
+                    })),
+                })
+                .unwrap()
+            {
+                RebalanceResult::MergeIntoLeft => (),
+                _ => panic!("need merge into left"),
+            },
+        );
+
+        let aux_storage = pages();
+        let left_sibling_expected = new_page(
+            &aux_storage,
+            2,
+            vec![U64Key(1), U64Key(2), U64Key(5)],
+            vec![1, 2, 5],
+        );
+
+        storage
+            .get_page(12)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                left_sibling_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_leaf(), node_expected.as_leaf())
+                })
+            });
+
+        let parent_expected =
+            internal_page(&aux_storage, 3, vec![U64Key(3), U64Key(8)], vec![2, 1, 3]);
+
+        storage
+            .get_page(3)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                parent_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_internal(), node_expected.as_internal())
+                })
+            });
+    }
+
+    #[test]
+    fn delete_with_right_merge() {
+        let storage = pages();
+
+        let parent = internal_page_mut(&storage, 3, vec![U64Key(3), U64Key(8)], vec![1, 2, 3]);
+        let mut node = new_page_mut(&storage, 1, vec![U64Key(1), U64Key(2)], vec![1, 2]);
+        let right_sibling = new_page(&storage, 2, vec![U64Key(4), U64Key(5)], vec![4, 5]);
+
+        node.as_node_mut(
+            size_of::<U64Key>(),
+            |mut node: Node<U64Key, &mut [u8]>| match node.as_leaf_mut().delete(&U64Key(2)).unwrap()
+            {
+                LeafDeleteStatus::NeedsRebalance => (),
+                _ => panic!(),
+            },
+        );
+
+        node.as_node_mut(
+            size_of::<U64Key>(),
+            |mut node: Node<U64Key, &mut [u8]>| match node
+                .as_leaf_mut()
+                .rebalance(RebalanceArgs {
+                    parent,
+                    parent_anchor: None,
+                    siblings: SiblingsArg::Right((right_sibling, || {
+                        storage.make_shadow(2, 12).unwrap();
+                        storage.mut_page(12).unwrap()
+                    })),
+                })
+                .unwrap()
+            {
+                RebalanceResult::MergeIntoSelf => (),
+                _ => panic!("need merge into self"),
+            },
+        );
+
+        let aux_storage = pages();
+        let node_expected = new_page(
+            &aux_storage,
+            2,
+            vec![U64Key(1), U64Key(4), U64Key(5)],
+            vec![1, 4, 5],
+        );
+        node.as_node(size_of::<U64Key>(), |before| {
+            node_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                assert_eq!(before.as_leaf(), node_expected.as_leaf())
+            })
+        });
+
+        let parent_expected =
+            internal_page(&aux_storage, 3, vec![U64Key(3), U64Key(8)], vec![1, 2, 3]);
+        storage
+            .get_page(3)
+            .unwrap()
+            .as_node(size_of::<U64Key>(), |before| {
+                parent_expected.as_node(size_of::<U64Key>(), |node_expected| {
+                    assert_eq!(before.as_internal(), node_expected.as_internal())
+                })
+            });
     }
 }

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -16,6 +16,22 @@ pub struct Node<K, T> {
     phantom: PhantomData<[K]>,
 }
 
+pub trait NodePageRef {
+    fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+    where
+        K: Key;
+}
+
+pub trait NodePageRefMut: NodePageRef {
+    fn as_node_mut<K, R>(
+        &mut self,
+        key_buffer_size: usize,
+        f: impl FnOnce(Node<K, &mut [u8]>) -> R,
+    ) -> R
+    where
+        K: Key;
+}
+
 pub(crate) enum NodeTag {
     Internal = 0,
     Leaf = 1,

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -46,29 +46,29 @@ pub enum RebalanceResult {
     MergeIntoSelf,
 }
 
-pub struct RebalanceArgs<'a, F: FnMut() -> PageHandle<'a, Mutable<'a>>> {
+pub struct RebalanceArgs<'a> {
     pub parent: PageHandle<'a, Mutable<'a>>,
     pub parent_anchor: Option<usize>,
-    pub siblings: SiblingsArg<'a, F>,
+    pub siblings: SiblingsArg<'a>,
 }
 
-// pub enum SiblingsArg<'a> {
-//     Left(PageHandle<'a, Mutable<'a>>),
-//     Right(PageHandle<'a, Mutable<'a>>),
-//     Both(PageHandle<'a, Mutable<'a>>, PageHandle<'a, Mutable<'a>>),
+pub enum SiblingsArg<'a> {
+    Left(PageHandle<'a, Immutable<'a>>),
+    Right(PageHandle<'a, Immutable<'a>>),
+    Both(PageHandle<'a, Immutable<'a>>, PageHandle<'a, Immutable<'a>>),
+}
+
+// pub type SiblingHandle<'a, F> = (PageHandle<'a, Immutable<'a>>, F);
+// pub enum SiblingsArg<'a, F: FnMut() -> PageHandle<'a, Mutable<'a>>> {
+//     Left(SiblingHandle<'a, F>),
+//     Right(SiblingHandle<'a, F>),
+//     Both(SiblingHandle<'a, F>, SiblingHandle<'a, F>),
 // }
 
-pub type SiblingHandle<'a, F> = (PageHandle<'a, Immutable<'a>>, F);
-pub enum SiblingsArg<'a, F: FnMut() -> PageHandle<'a, Mutable<'a>>> {
-    Left(SiblingHandle<'a, F>),
-    Right(SiblingHandle<'a, F>),
-    Both(SiblingHandle<'a, F>, SiblingHandle<'a, F>),
-}
-
-impl<'a, F: FnMut() -> PageHandle<'a, Mutable<'a>>> SiblingsArg<'a, F> {
+impl<'a> SiblingsArg<'a> {
     pub fn new_from_options(
-        left_sibling: Option<SiblingHandle<'a, F>>,
-        right_sibling: Option<SiblingHandle<'a, F>>,
+        left_sibling: Option<PageHandle<'a, Immutable<'a>>>,
+        right_sibling: Option<PageHandle<'a, Immutable<'a>>>,
     ) -> Self {
         match (left_sibling, right_sibling) {
             (Some(left), Some(right)) => SiblingsArg::Both(left, right),

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -58,11 +58,25 @@ pub struct RebalanceArgs<'a, F: FnMut() -> PageHandle<'a, Mutable<'a>>> {
 //     Both(PageHandle<'a, Mutable<'a>>, PageHandle<'a, Mutable<'a>>),
 // }
 
-type SiblingHandle<'a, F> = (PageHandle<'a, Immutable<'a>>, F);
+pub type SiblingHandle<'a, F> = (PageHandle<'a, Immutable<'a>>, F);
 pub enum SiblingsArg<'a, F: FnMut() -> PageHandle<'a, Mutable<'a>>> {
     Left(SiblingHandle<'a, F>),
     Right(SiblingHandle<'a, F>),
     Both(SiblingHandle<'a, F>, SiblingHandle<'a, F>),
+}
+
+impl<'a, F: FnMut() -> PageHandle<'a, Mutable<'a>>> SiblingsArg<'a, F> {
+    pub fn new_from_options(
+        left_sibling: Option<SiblingHandle<'a, F>>,
+        right_sibling: Option<SiblingHandle<'a, F>>,
+    ) -> Self {
+        match (left_sibling, right_sibling) {
+            (Some(left), Some(right)) => SiblingsArg::Both(left, right),
+            (Some(left), None) => SiblingsArg::Left(left),
+            (None, Some(right)) => SiblingsArg::Right(right),
+            (None, None) => unreachable!(),
+        }
+    }
 }
 
 impl<'b, K, T> Node<K, T>

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -46,16 +46,16 @@ pub enum RebalanceResult {
     MergeIntoSelf,
 }
 
-pub struct RebalanceArgs<'a> {
+pub struct RebalanceArgs<'a, N: NodePageRef + 'a> {
     pub parent: PageHandle<'a, Mutable<'a>>,
     pub parent_anchor: Option<usize>,
-    pub siblings: SiblingsArg<'a>,
+    pub siblings: SiblingsArg<N>,
 }
 
-pub enum SiblingsArg<'a> {
-    Left(PageHandle<'a, Immutable<'a>>),
-    Right(PageHandle<'a, Immutable<'a>>),
-    Both(PageHandle<'a, Immutable<'a>>, PageHandle<'a, Immutable<'a>>),
+pub enum SiblingsArg<N: NodePageRef> {
+    Left(N),
+    Right(N),
+    Both(N, N),
 }
 
 // pub type SiblingHandle<'a, F> = (PageHandle<'a, Immutable<'a>>, F);
@@ -65,11 +65,8 @@ pub enum SiblingsArg<'a> {
 //     Both(SiblingHandle<'a, F>, SiblingHandle<'a, F>),
 // }
 
-impl<'a> SiblingsArg<'a> {
-    pub fn new_from_options(
-        left_sibling: Option<PageHandle<'a, Immutable<'a>>>,
-        right_sibling: Option<PageHandle<'a, Immutable<'a>>>,
-    ) -> Self {
+impl<N: NodePageRef> SiblingsArg<N> {
+    pub fn new_from_options(left_sibling: Option<N>, right_sibling: Option<N>) -> Self {
         match (left_sibling, right_sibling) {
             (Some(left), Some(right)) => SiblingsArg::Both(left, right),
             (Some(left), None) => SiblingsArg::Left(left),

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -228,6 +228,17 @@ impl<'a> PageHandle<'a, borrow::Mutable<'a>> {
         f(node)
     }
 
+    pub fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+    where
+        K: Key,
+    {
+        let page = self.borrow.borrow as &[u8];
+
+        let node = unsafe { Node::<K, &[u8]>::from_raw(page.as_ref(), key_buffer_size) };
+
+        f(node)
+    }
+
     pub fn as_slice(&mut self, f: impl FnOnce(&mut [u8])) {
         f(self.borrow.borrow);
     }

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -202,8 +202,14 @@ impl<'a, T> PageHandle<'a, T> {
     }
 }
 
-impl<'a> PageHandle<'a, borrow::Immutable<'a>> {
-    pub fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+impl<'a> PageHandle<'a, borrow::Mutable<'a>> {
+    pub fn as_slice(&mut self, f: impl FnOnce(&mut [u8])) {
+        f(self.borrow.borrow);
+    }
+}
+
+impl<'a> super::node::NodeRef for PageHandle<'a, borrow::Immutable<'a>> {
+    fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
     where
         K: Key,
     {
@@ -215,8 +221,20 @@ impl<'a> PageHandle<'a, borrow::Immutable<'a>> {
     }
 }
 
-impl<'a> PageHandle<'a, borrow::Mutable<'a>> {
-    pub fn as_node_mut<K, R>(
+impl<'a> super::node::NodeRef for PageHandle<'a, borrow::Mutable<'a>> {
+    fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+    where
+        K: Key,
+    {
+        let node =
+            unsafe { Node::<K, &[u8]>::from_raw(self.borrow.borrow.as_ref(), key_buffer_size) };
+
+        f(node)
+    }
+}
+
+impl<'a> super::node::NodeRefMut for PageHandle<'a, borrow::Mutable<'a>> {
+    fn as_node_mut<K, R>(
         &mut self,
         key_buffer_size: usize,
         f: impl FnOnce(Node<K, &mut [u8]>) -> R,
@@ -226,21 +244,6 @@ impl<'a> PageHandle<'a, borrow::Mutable<'a>> {
     {
         let node = unsafe { Node::<K, &mut [u8]>::from_raw(self.borrow.borrow, key_buffer_size) };
         f(node)
-    }
-
-    pub fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
-    where
-        K: Key,
-    {
-        let page = self.borrow.borrow as &[u8];
-
-        let node = unsafe { Node::<K, &[u8]>::from_raw(page.as_ref(), key_buffer_size) };
-
-        f(node)
-    }
-
-    pub fn as_slice(&mut self, f: impl FnOnce(&mut [u8])) {
-        f(self.borrow.borrow);
     }
 }
 

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -3,7 +3,7 @@ use super::pages::*;
 use super::{transaction::PageRefMut, Metadata, Node, PageId};
 use crate::btreeindex::page_manager::PageManager;
 
-use crate::btreeindex::node::NodePageRef;
+use crate::btreeindex::node::NodeRef;
 use crate::mem_page::MemPage;
 use crate::Key;
 use std::collections::VecDeque;

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -1,8 +1,6 @@
 pub mod transaction;
 use super::pages::*;
-use super::Metadata;
-use super::Node;
-use super::PageId;
+use super::{transaction::PageRefMut, Metadata, Node, PageId};
 use crate::btreeindex::page_manager::PageManager;
 use crate::btreeindex::pages::{borrow::Mutable, PageHandle};
 use crate::mem_page::MemPage;
@@ -169,7 +167,7 @@ where
     K: Key,
 {
     /// traverse the tree while storing the path, so we can then backtrack while splitting
-    pub fn search_for(&mut self, key: &K) {
+    pub fn search_for<'a>(&'a mut self, key: &K) {
         let mut current = self.tx.root();
 
         loop {
@@ -206,7 +204,7 @@ where
         }
     }
 
-    pub fn get_next(&mut self) -> Result<Option<PageHandle<Mutable>>, std::io::Error> {
+    pub fn get_next<'a>(&'a mut self) -> Result<Option<PageRefMut<'a, 'index>>, std::io::Error> {
         let id = match self.backtrack.pop() {
             Some(id) => id,
             None => return Ok(None),

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -3,6 +3,7 @@ use super::pages::*;
 use super::{transaction::PageRefMut, Metadata, Node, PageId};
 use crate::btreeindex::page_manager::PageManager;
 
+use crate::btreeindex::node::NodePageRef;
 use crate::mem_page::MemPage;
 use crate::Key;
 use std::collections::VecDeque;

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -2,7 +2,7 @@ pub mod transaction;
 use super::pages::*;
 use super::{transaction::PageRefMut, Metadata, Node, PageId};
 use crate::btreeindex::page_manager::PageManager;
-use crate::btreeindex::pages::{borrow::Mutable, PageHandle};
+
 use crate::mem_page::MemPage;
 use crate::Key;
 use std::collections::VecDeque;

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -1,13 +1,11 @@
 use super::Version;
 use crate::btreeindex::{
-    borrow::{Immutable, Mutable},
-    page_manager::PageManager,
-    Node, PageHandle, PageId, Pages,
+    borrow::Immutable, page_manager::PageManager, Node, PageHandle, PageId, Pages,
 };
 use crate::Key;
 use parking_lot::lock_api;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard};
-use std::cell::{Ref, RefCell};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::marker::PhantomData;
 use std::ops::Deref;

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -1,7 +1,7 @@
 use super::Version;
 use crate::btreeindex::{
     borrow::Immutable,
-    node::{NodePageRef, NodePageRefMut},
+    node::{NodeRef, NodeRefMut},
     page_manager::PageManager,
     Node, PageHandle, PageId, Pages,
 };
@@ -60,7 +60,7 @@ impl<'a, 'b: 'a> PageRefMut<'a, 'b> {
     }
 }
 
-impl<'a, 'b: 'a> NodePageRef for PageRef<'a, 'b> {
+impl<'a, 'b: 'a> NodeRef for PageRef<'a, 'b> {
     fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
     where
         K: Key,
@@ -73,7 +73,7 @@ impl<'a, 'b: 'a> NodePageRef for PageRef<'a, 'b> {
     }
 }
 
-impl<'a, 'b: 'a> NodePageRef for PageRefMut<'a, 'b> {
+impl<'a, 'b: 'a> NodeRef for PageRefMut<'a, 'b> {
     fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
     where
         K: Key,
@@ -86,7 +86,7 @@ impl<'a, 'b: 'a> NodePageRef for PageRefMut<'a, 'b> {
     }
 }
 
-impl<'a, 'b: 'a> NodePageRefMut for PageRefMut<'a, 'b> {
+impl<'a, 'b: 'a> NodeRefMut for PageRefMut<'a, 'b> {
     fn as_node_mut<K, R>(
         &mut self,
         key_buffer_size: usize,

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -7,6 +7,7 @@ use crate::btreeindex::{
 use crate::Key;
 use parking_lot::lock_api;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard};
+use std::cell::{Ref, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -21,15 +22,68 @@ pub struct ReadTransaction<'a> {
 /// it can be used to create a new `Version` at the end with all the insertions done atomically
 pub(crate) struct InsertTransaction<'locks, 'storage: 'locks> {
     pub current_root: PageId,
+    state: RefCell<State<'locks>>,
+    pages: RefCell<ExtendablePages<'storage>>,
+    versions: MutexGuard<'locks, VecDeque<Arc<Version>>>,
+    current_version: Arc<RwLock<Arc<Version>>>,
+    key_buffer_size: u32,
+}
+
+struct State<'a> {
     /// maps old_id -> new_id
     shadows: HashMap<PageId, PageId>,
     /// in order to find shadows by the new_id (as we already redirected pointers to this)
     shadows_image: HashSet<PageId>,
-    page_manager: MutexGuard<'locks, PageManager>,
-    versions: MutexGuard<'locks, VecDeque<Arc<Version>>>,
-    pages: ExtendablePages<'storage>,
-    current_version: Arc<RwLock<Arc<Version>>>,
-    key_buffer_size: u32,
+    page_manager: MutexGuard<'a, PageManager>,
+}
+
+pub struct PageRef<'a, 'b: 'a> {
+    pages: &'a RefCell<ExtendablePages<'b>>,
+    page_id: PageId,
+}
+
+impl<'a, 'b: 'a> PageRef<'a, 'b> {
+    pub fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+    where
+        K: Key,
+    {
+        self.pages
+            .borrow()
+            .get_page(self.page_id)
+            .expect("page should be already checked")
+            .as_node(key_buffer_size, f)
+    }
+
+    pub fn id(&self) -> PageId {
+        self.page_id
+    }
+}
+
+pub struct PageRefMut<'a, 'b: 'a> {
+    pages: &'a RefCell<ExtendablePages<'b>>,
+    page_id: PageId,
+}
+
+impl<'a, 'b: 'a> PageRefMut<'a, 'b> {
+    pub fn as_node_mut<K, R>(
+        &self,
+        key_buffer_size: usize,
+        f: impl FnOnce(Node<K, &mut [u8]>) -> R,
+    ) -> R
+    where
+        K: Key,
+    {
+        self.pages
+            .borrow()
+            .mut_page(self.page_id)
+            // FIXME: this unwrap
+            .unwrap()
+            .as_node_mut(key_buffer_size, f)
+    }
+
+    pub fn id(&self) -> PageId {
+        self.page_id
+    }
 }
 
 // in most cases, we can access the storage with read only access, but in the (rare) cases
@@ -63,89 +117,119 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
         key_buffer_size: u32,
     ) -> InsertTransaction<'locks, 'storage> {
         let current_root = root;
+        let state = State {
+            shadows: HashMap::new(),
+            shadows_image: HashSet::new(),
+            page_manager,
+        };
         InsertTransaction {
             current_root,
-            page_manager,
             versions,
             current_version,
             key_buffer_size,
-            shadows: HashMap::new(),
-            shadows_image: HashSet::new(),
-            pages: ExtendablePages::new(pages),
+            pages: RefCell::new(ExtendablePages::new(pages)),
+            state: RefCell::new(state),
         }
     }
 
     pub fn root(&self) -> PageId {
-        self.shadows
+        self.state
+            .borrow()
+            .shadows
             .get(&self.current_root)
             .map(|root| *root)
             .unwrap_or(self.current_root)
     }
 
-    pub fn get_page(&self, id: PageId) -> Option<PageHandle<Immutable>> {
-        self.shadows_image
+    pub fn get_page<'this>(&'this self, id: PageId) -> Option<PageRef<'this, 'storage>> {
+        let state = self.state.borrow();
+        let id = state
+            .shadows_image
             .get(&id)
-            .or_else(|| self.shadows.get(&id))
-            .or_else(|| Some(&id))
-            .and_then(|id| self.pages.get_page(*id))
+            .or_else(|| state.shadows.get(&id))
+            .unwrap_or_else(|| &id);
+
+        let exists = self.pages.borrow().get_page(*id).is_some();
+
+        if exists {
+            Some(PageRef {
+                pages: &self.pages,
+                page_id: *id,
+            })
+        } else {
+            None
+        }
     }
 
     pub fn add_new_node(
-        &mut self,
+        &self,
         mem_page: crate::mem_page::MemPage,
         _key_buffer_size: u32,
     ) -> Result<PageId, std::io::Error> {
-        let id = self.page_manager.new_id();
+        let id = self.state.borrow_mut().page_manager.new_id();
 
-        let result = self.pages.mut_page(id);
+        let pages = self.pages.borrow();
+        let result = pages.mut_page(id);
 
-        let mut page_handle = match result {
-            Ok(page_handle) => page_handle,
+        match result {
+            Ok(mut page_handle) => {
+                page_handle.as_slice(|page| page.copy_from_slice(mem_page.as_ref()));
+            }
             Err(()) => {
-                self.pages.extend(id)?;
+                drop(pages);
+                self.pages.borrow_mut().extend(id)?;
+
+                let pages = self.pages.borrow();
                 // infallible now, after extending the storage
-                self.pages.mut_page(id).unwrap()
+                let mut page_handle = pages.mut_page(id).unwrap();
+                page_handle.as_slice(|page| page.copy_from_slice(mem_page.as_ref()));
             }
         };
-
-        page_handle.as_slice(|page| page.copy_from_slice(mem_page.as_ref()));
 
         Ok(id)
     }
 
     // TODO: mut_page and mut_page_internal are basically the same thing, but I can't find
     // a straight forward way of reusing the code because of borrowing rules, so I will ignore it for now
-    pub fn mut_page(
-        &mut self,
+    pub fn mut_page<'this>(
+        &'this self,
         id: PageId,
-    ) -> Result<MutablePage<'_, 'locks, 'storage>, std::io::Error> {
-        match self
+    ) -> Result<MutablePage<'this, 'locks, 'storage>, std::io::Error> {
+        let mut state = self.state.borrow_mut();
+
+        match state
             .shadows_image
             .get(&id)
-            .or_else(|| self.shadows.get(&id))
+            .or_else(|| state.shadows.get(&id))
         {
             Some(id) => {
-                let handle = self
+                let _pre_check = self
                     .pages
+                    .borrow()
                     .mut_page(*id)
                     .expect("already fetched transaction was not allocated");
+
+                let handle = PageRefMut {
+                    pages: &self.pages,
+                    page_id: *id,
+                };
 
                 Ok(MutablePage::InTransaction(handle))
             }
             None => {
                 let old_id = id;
-                let new_id = self.page_manager.new_id();
+                let new_id = state.page_manager.new_id();
 
-                let result = self.pages.make_shadow(old_id, new_id);
+                let result = self.pages.borrow().make_shadow(old_id, new_id);
 
-                self.shadows.insert(old_id, new_id);
-                self.shadows_image.insert(new_id);
+                state.shadows.insert(old_id, new_id);
+                state.shadows_image.insert(new_id);
 
                 match result {
                     Ok(()) => (),
                     Err(()) => {
-                        self.pages.extend(new_id)?;
-                        self.pages.make_shadow(old_id, new_id).unwrap();
+                        self.pages.borrow_mut().extend(new_id)?;
+                        self.pages.borrow().make_shadow(old_id, new_id).unwrap();
                     }
                 }
 
@@ -159,44 +243,34 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
         }
     }
 
-    fn mut_page_internal(
-        &mut self,
-        id: PageId,
-    ) -> Result<(bool, PageHandle<Mutable>), std::io::Error> {
-        match self
+    fn mut_page_internal(&self, id: PageId) -> Result<(bool, PageId), std::io::Error> {
+        let mut state = self.state.borrow_mut();
+
+        match state
             .shadows_image
             .get(&id)
-            .or_else(|| self.shadows.get(&id))
+            .or_else(|| state.shadows.get(&id))
         {
-            Some(id) => {
-                let handle = self
-                    .pages
-                    .mut_page(*id)
-                    .expect("already fetched transaction was not allocated");
-
-                Ok((false, handle))
-            }
+            Some(id) => Ok((false, *id)),
             None => {
                 let old_id = id;
-                let new_id = self.page_manager.new_id();
+                let new_id = state.page_manager.new_id();
 
-                let result = self.pages.make_shadow(old_id, new_id);
+                let result = self.pages.borrow().make_shadow(old_id, new_id);
 
-                self.shadows.insert(old_id, new_id);
-                self.shadows_image.insert(new_id);
+                state.shadows.insert(old_id, new_id);
+                state.shadows_image.insert(new_id);
 
                 match result {
                     Ok(()) => (),
                     Err(()) => {
-                        self.pages.extend(new_id)?;
+                        self.pages.borrow_mut().extend(new_id)?;
                         // Infallible after extending
-                        self.pages.make_shadow(old_id, new_id).unwrap();
+                        self.pages.borrow_mut().make_shadow(old_id, new_id).unwrap();
                     }
                 }
 
-                let handle = self.pages.mut_page(new_id).unwrap();
-
-                Ok((true, handle))
+                Ok((true, new_id))
             }
         }
     }
@@ -207,11 +281,12 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
     where
         K: Key,
     {
+        let state = self.state.borrow();
         let transaction = super::WriteTransaction {
             new_root: self.root(),
-            shadowed_pages: self.shadows.keys().cloned().collect(),
+            shadowed_pages: state.shadows.keys().cloned().collect(),
             // Pages allocated at the end, basically
-            next_page_id: self.page_manager.next_page(),
+            next_page_id: state.page_manager.next_page(),
         };
 
         let mut current_version = self.current_version.write();
@@ -227,12 +302,12 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
 
 pub enum MutablePage<'a, 'b: 'a, 'c: 'b> {
     NeedsParentRedirect(RedirectPointers<'a, 'b, 'c>),
-    InTransaction(PageHandle<'a, Mutable<'a>>),
+    InTransaction(PageRefMut<'a, 'c>),
 }
 
 /// recursive helper for the shadowing process when we need to clone and redirect pointers
 pub struct RedirectPointers<'a, 'b: 'a, 'c: 'a> {
-    tx: &'a mut InsertTransaction<'b, 'c>,
+    tx: &'a InsertTransaction<'b, 'c>,
     /// id that we need to change in the next step, at some point, we could optimize this to be
     /// an index instead of the id (so we don't need to perform the search)
     last_old_id: PageId,
@@ -247,7 +322,9 @@ impl<'a, 'b: 'a, 'c: 'b> RedirectPointers<'a, 'b, 'c> {
         key_buffer_size: usize,
         parent_id: PageId,
     ) -> Result<MutablePage<'a, 'b, 'c>, std::io::Error> {
-        let (parent_needs_shadowing, mut parent) = self.tx.mut_page_internal(parent_id)?;
+        let (parent_needs_shadowing, parent) = self.tx.mut_page_internal(parent_id)?;
+        let pages = self.tx.pages.borrow();
+        let mut parent = pages.mut_page(parent).unwrap();
 
         let old_id = self.last_old_id;
         let new_id = self.last_new_id;
@@ -274,7 +351,7 @@ impl<'a, 'b: 'a, 'c: 'b> RedirectPointers<'a, 'b, 'c> {
         }
     }
 
-    pub fn finish(self) -> PageHandle<'a, Mutable<'a>> {
+    pub fn finish(self) -> PageRefMut<'a, 'c> {
         match self.tx.mut_page(self.shadowed_page).unwrap() {
             MutablePage::InTransaction(handle) => handle,
             _ => unreachable!(),

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -172,6 +172,7 @@ pub trait Storeable<'a>: Sized {
     type Output: Borrow<Self> + 'a;
     fn write(&self, buf: &mut [u8]) -> Result<(), Self::Error>;
     fn read(buf: &'a [u8]) -> Result<Self::Output, Self::Error>;
+    fn as_output(self) -> Self::Output;
 }
 
 pub trait Key: for<'a> Storeable<'a> + Ord + Clone + Debug {}
@@ -197,8 +198,13 @@ mod tests {
         fn write(&self, buf: &mut [u8]) -> Result<(), Self::Error> {
             Ok(LittleEndian::write_u64(buf, self.0))
         }
+
         fn read(buf: &'a [u8]) -> Result<Self::Output, Self::Error> {
             Ok(U64Key(LittleEndian::read_u64(buf)))
+        }
+
+        fn as_output(self) -> Self::Output {
+            self
         }
     }
 


### PR DESCRIPTION
# Start integrating delete algorithm

This PR primarily adds both `InternalNode` and `LeafNode` delete and rebalance algorithms. They are not usable by themselves, because this doesn't add the top level delete algorithm, but as this was quite long itself I thought it was better to split it.

There are a few things to improve still, for example, the test code is a bit verbose, there is probably some way of making it more succinct. Currently `rebalance` doesn't actually do the rebalancing, instead it determines which is the required rebalancing technique and returns a new object which takes the additional parameters. This is done in order to just clone/shadow the siblings when they are needed.

There is also an additional change in this PR, which is adding internal mutability to the transaction object (the one that keeps account of current cloned/not cloned pages). The reason for this is that the rebalancing algorithm may require mutating three nodes at a time, and this is the simplest way, I could split this if preferred.