### PR TITLE
Add delete algorithm

### DIFF
--- a/btree/benches/benchmark.rs
+++ b/btree/benches/benchmark.rs
@@ -24,6 +24,9 @@ impl<'a> Storeable<'a> for U64Key {
     fn read(buf: &'a [u8]) -> Result<Self::Output, Self::Error> {
         Ok(U64Key(LittleEndian::read_u64(buf)))
     }
+    fn as_output(self) -> Self {
+        self
+    }
 }
 
 fn random_blob(rng: &mut impl rand::Rng) -> Box<[u8]> {

--- a/btree/src/btreeindex/backtrack.rs
+++ b/btree/src/btreeindex/backtrack.rs
@@ -1,5 +1,4 @@
 /// Helpers to keep track of parent pointers and siblings when traversing the tree.
-
 use super::transaction;
 use super::transaction::{MutablePage, PageRef, PageRefMut, WriteTransaction};
 use crate::btreeindex::{node::NodeRef, Node, PageId};

--- a/btree/src/btreeindex/backtrack.rs
+++ b/btree/src/btreeindex/backtrack.rs
@@ -1,3 +1,5 @@
+/// Helpers to keep track of parent pointers and siblings when traversing the tree.
+
 use super::transaction;
 use super::transaction::{MutablePage, PageRef, PageRefMut, WriteTransaction};
 use crate::btreeindex::{node::NodeRef, Node, PageId};

--- a/btree/src/btreeindex/backtrack.rs
+++ b/btree/src/btreeindex/backtrack.rs
@@ -1,0 +1,403 @@
+use super::transaction::{MutablePage, PageRef, PageRefMut, WriteTransaction};
+use super::{transaction};
+use crate::btreeindex::{
+    borrow::{Immutable, Mutable},
+    node::{NodeRef, NodeRefMut},
+    page_manager::PageManager,
+    Node, PageHandle, PageId, Pages,
+};
+use crate::mem_page::MemPage;
+use crate::Key;
+
+
+
+
+use std::convert::{TryFrom, TryInto};
+use std::marker::PhantomData;
+
+
+
+/// this is basically a stack, but it will rename pointers and interact with the builder in order to reuse
+/// already cloned pages
+pub struct InsertBacktrack<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K>
+where
+    K: Key,
+{
+    tx: &'txbuilder mut transaction::WriteTransaction<'txmanager, 'storage>,
+    backtrack: Vec<PageId>,
+    new_root: Option<PageId>,
+    phantom_key: PhantomData<[K]>,
+    key_buffer_size: u32,
+}
+
+/// this is basically a stack, but it will rename pointers and interact with the builder in order to reuse
+/// already cloned pages
+pub struct DeleteBacktrack<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K>
+where
+    K: Key,
+{
+    tx: &'txbuilder transaction::WriteTransaction<'txmanager, 'storage>,
+    backtrack: Vec<PageId>,
+    parent_info: Vec<(Option<usize>, Option<PageId>, Option<PageId>)>,
+    new_root: Option<PageId>,
+    phantom_key: PhantomData<[K]>,
+    key_buffer_size: u32,
+}
+
+pub struct DeleteNextElement<'a, 'b: 'a, 'c: 'b, 'd: 'c, K>
+where
+    K: Key,
+{
+    pub next: PageRefMut<'a, 'd>,
+    pub parent: Option<PageRefMut<'a, 'd>>,
+    pub anchor: Option<usize>,
+    pub left: Option<PageRef<'a, 'd>>,
+    pub right: Option<PageRef<'a, 'd>>,
+    backtrack: &'a mut DeleteBacktrack<'b, 'c, 'd, K>,
+}
+
+impl<'a, 'b: 'a, 'c: 'b, 'd: 'c, K> DeleteNextElement<'a, 'b, 'c, 'd, K>
+where
+    K: Key,
+{
+    pub fn mut_left_sibling(&self, key_size: usize) -> PageRefMut<'a, 'd> {
+        let left_id = self.left.as_ref().unwrap().id();
+        match self.backtrack.tx.mut_page(dbg!(left_id)).unwrap() {
+            MutablePage::InTransaction(handle) => handle,
+            MutablePage::NeedsParentRedirect(redirect_pointers) => {
+                redirect_pointers.redirect_parent_in_tx::<K>(key_size, self.parent.clone().unwrap())
+            }
+        }
+    }
+
+    pub fn mut_right_sibling(&self, key_size: usize) -> PageRefMut<'a, 'd> {
+        let right_id = self.right.as_ref().unwrap().id();
+        match self.backtrack.tx.mut_page(dbg!(right_id)).unwrap() {
+            MutablePage::InTransaction(handle) => handle,
+            MutablePage::NeedsParentRedirect(redirect_pointers) => {
+                redirect_pointers.redirect_parent_in_tx::<K>(key_size, self.parent.clone().unwrap())
+            }
+        }
+    }
+
+    /// delete current node, this just adds the id to the list of free pages *after* the transaction is confirmed
+    pub fn delete_node(&self) {
+        let id = self.next.id();
+        self.backtrack.delete_node(id)
+    }
+
+    /// delete right sibling of current node, this just adds the id to the list of free pages *after* the transaction is confirmed
+    pub fn delete_right_sibling(&self) {
+        let id = self.right.as_ref().map(|handle| handle.id()).unwrap();
+        self.backtrack.delete_node(dbg!(id))
+    }
+
+    pub fn set_root(&self, id: PageId) {
+        self.backtrack.tx.current_root.set(id)
+    }
+}
+
+impl<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K>
+    DeleteBacktrack<'txbuilder, 'txmanager, 'storage, K>
+where
+    K: Key,
+{
+    pub(crate) fn new_search_for(
+        tx: &'txbuilder mut WriteTransaction<'txmanager, 'storage>,
+        key: &K,
+    ) -> Self {
+        let key_buffer_size = tx.key_buffer_size.clone();
+        let mut backtrack = DeleteBacktrack {
+            tx,
+            backtrack: vec![],
+            parent_info: vec![],
+            new_root: None,
+            phantom_key: PhantomData,
+            key_buffer_size,
+        };
+        backtrack.search_for(key);
+        backtrack
+    }
+    /// traverse the tree while storing the path, so we can then backtrack while splitting
+    pub fn search_for(&mut self, key: &K) {
+        enum Step {
+            Internal(Option<usize>, Option<PageId>, Option<PageId>),
+            Leaf,
+        }
+
+        let mut current = self.tx.root();
+
+        loop {
+            let page = self.tx.get_page(current).unwrap();
+
+            let found_leaf = page.as_node(
+                self.key_buffer_size.try_into().unwrap(),
+                |node: Node<K, &[u8]>| {
+                    if let Some(inode) = node.try_as_internal() {
+                        let upper_pivot = match inode.keys().binary_search(key) {
+                            Ok(pos) => Some(pos + 1),
+                            Err(pos) => Some(pos),
+                        }
+                        .filter(|pos| pos < &inode.children().len());
+
+                        let anchor = upper_pivot
+                            .or_else(|| inode.keys().len().checked_sub(1))
+                            .and_then(|up| up.checked_sub(1));
+
+                        let left_sibling_id = anchor.and_then(|pos| inode.children().try_get(pos));
+
+                        let right_sibling_id = anchor
+                            .map(|pos| pos + 2)
+                            .or(Some(1))
+                            .and_then(|pos| inode.children().try_get(pos));
+
+                        if let Some(upper_pivot) = upper_pivot {
+                            current = inode.children().get(upper_pivot);
+                        } else {
+                            let last = inode.children().len().checked_sub(1).unwrap();
+                            current = inode.children().get(last);
+                        }
+
+                        Step::Internal(anchor, left_sibling_id, right_sibling_id)
+                    } else {
+                        Step::Leaf
+                    }
+                },
+            );
+
+            self.backtrack.push(page.id());
+
+            match found_leaf {
+                Step::Internal(anchor, left, right) => self.parent_info.push((anchor, left, right)),
+                Step::Leaf => break,
+            }
+        }
+    }
+
+    pub fn get_next<'this>(
+        &'this mut self,
+    ) -> Result<Option<DeleteNextElement<'this, 'txbuilder, 'txmanager, 'storage, K>>, std::io::Error>
+    {
+        let id = match dbg!(&mut self.backtrack).pop() {
+            Some(id) => id,
+            None => return Ok(None),
+        };
+
+        if self.backtrack.is_empty() {
+            assert!(self.new_root.is_none());
+            self.new_root = Some(id);
+        }
+
+        let key_buffer_size = usize::try_from(self.key_buffer_size).unwrap();
+
+        let (parent, anchor, left, right) = if self.backtrack.is_empty() {
+            (None, None, None, None)
+        } else {
+            let parent = self.backtrack.last().unwrap();
+
+            let (anchor, left, right) = self.parent_info.pop().unwrap();
+            (Some(parent), anchor, left, right)
+        };
+
+        let next = match self.tx.mut_page(id)? {
+            transaction::MutablePage::NeedsParentRedirect(rename_in_parents) => {
+                // this part may be tricky, we need to recursively clone and redirect all the path
+                // from the root to the node we are writing to. We need the backtrack stack, because
+                // that's the only way to get the parent of a node (because there are no parent pointers)
+                // so we iterate it in reverse but without consuming the stack (as we still need it for the
+                // rest of the insertion algorithm)
+                let mut rename_in_parents = Some(rename_in_parents);
+                let mut finished = None;
+                for id in self.backtrack.iter().rev() {
+                    let result = rename_in_parents
+                        .take()
+                        .unwrap()
+                        .redirect_parent_pointer::<K>(key_buffer_size, *id)?;
+
+                    match result {
+                        MutablePage::NeedsParentRedirect(rename) => {
+                            rename_in_parents = Some(rename)
+                        }
+                        MutablePage::InTransaction(handle) => {
+                            finished = Some(handle);
+                            break;
+                        }
+                    }
+                }
+                match finished {
+                    Some(handle) => handle,
+                    None => rename_in_parents.unwrap().finish(),
+                }
+            }
+            transaction::MutablePage::InTransaction(handle) => handle,
+        };
+
+        let left = left.and_then(|id| self.tx.get_page(id));
+        let right = right.and_then(|id| self.tx.get_page(id));
+        let parent = parent.map(|id| match self.tx.mut_page(*id).unwrap() {
+            MutablePage::InTransaction(handle) => handle,
+            _ => unreachable!(),
+        });
+
+        Ok(Some(DeleteNextElement {
+            next,
+            parent,
+            anchor,
+            left,
+            right,
+            backtrack: self,
+        }))
+    }
+
+    pub fn delete_node(&self, page_id: PageId) {
+        self.tx.delete_node(page_id)
+    }
+}
+
+impl<'txbuilder, 'txmanager: 'txbuilder, 'index: 'txmanager, K>
+    InsertBacktrack<'txbuilder, 'txmanager, 'index, K>
+where
+    K: Key,
+{
+    pub(crate) fn new_search_for(
+        tx: &'txbuilder mut WriteTransaction<'txmanager, 'index>,
+        key: &K,
+    ) -> Self {
+        let key_buffer_size = tx.key_buffer_size.clone();
+        let mut backtrack = InsertBacktrack {
+            tx,
+            backtrack: vec![],
+            new_root: None,
+            phantom_key: PhantomData,
+            key_buffer_size,
+        };
+
+        backtrack.search_for(key);
+        backtrack
+    }
+    /// traverse the tree while storing the path, so we can then backtrack while splitting
+    fn search_for<'a>(&'a mut self, key: &K) {
+        let mut current = self.tx.root();
+
+        loop {
+            let page = self.tx.get_page(current).unwrap();
+
+            let found_leaf = page.as_node(
+                self.key_buffer_size.try_into().unwrap(),
+                |node: Node<K, &[u8]>| {
+                    if let Some(inode) = node.try_as_internal() {
+                        let upper_pivot = match inode.keys().binary_search(key) {
+                            Ok(pos) => Some(pos + 1),
+                            Err(pos) => Some(pos),
+                        }
+                        .filter(|pos| pos < &inode.children().len());
+
+                        if let Some(upper_pivot) = upper_pivot {
+                            current = inode.children().get(upper_pivot);
+                        } else {
+                            let last = inode.children().len().checked_sub(1).unwrap();
+                            current = inode.children().get(last);
+                        }
+                        false
+                    } else {
+                        true
+                    }
+                },
+            );
+
+            self.backtrack.push(page.id());
+
+            if found_leaf {
+                break;
+            }
+        }
+    }
+
+    pub fn get_next<'a>(&'a mut self) -> Result<Option<PageRefMut<'a, 'index>>, std::io::Error> {
+        let id = match self.backtrack.pop() {
+            Some(id) => id,
+            None => return Ok(None),
+        };
+
+        if self.backtrack.is_empty() {
+            assert!(self.new_root.is_none());
+            self.new_root = Some(id);
+        }
+
+        let key_buffer_size = usize::try_from(self.key_buffer_size).unwrap();
+
+        match self.tx.mut_page(id)? {
+            transaction::MutablePage::NeedsParentRedirect(rename_in_parents) => {
+                // this part may be tricky, we need to recursively clone and redirect all the path
+                // from the root to the node we are writing to. We need the backtrack stack, because
+                // that's the only way to get the parent of a node (because there are no parent pointers)
+                // so we iterate it in reverse but without consuming the stack (as we still need it for the
+                // rest of the insertion algorithm)
+                let mut rename_in_parents = rename_in_parents;
+                for id in self.backtrack.iter().rev() {
+                    let result =
+                        rename_in_parents.redirect_parent_pointer::<K>(key_buffer_size, *id)?;
+
+                    match result {
+                        MutablePage::NeedsParentRedirect(rename) => rename_in_parents = rename,
+                        MutablePage::InTransaction(handle) => return Ok(Some(handle)),
+                    }
+                }
+                let page = rename_in_parents.finish();
+                Ok(Some(page))
+            }
+            transaction::MutablePage::InTransaction(handle) => Ok(Some(handle)),
+        }
+    }
+
+    pub fn has_next(&self) -> bool {
+        self.backtrack.last().is_some()
+    }
+
+    pub fn add_new_node(
+        &mut self,
+        mem_page: MemPage,
+        key_buffer_size: u32,
+    ) -> Result<PageId, std::io::Error> {
+        self.tx.add_new_node(mem_page, key_buffer_size)
+    }
+
+    pub fn new_root(
+        &mut self,
+        mem_page: MemPage,
+        key_buffer_size: u32,
+    ) -> Result<(), std::io::Error> {
+        let id = self.tx.add_new_node(mem_page, key_buffer_size)?;
+        self.new_root = Some(id);
+
+        Ok(())
+    }
+}
+
+impl<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K> Drop
+    for InsertBacktrack<'txbuilder, 'txmanager, 'storage, K>
+where
+    K: Key,
+{
+    fn drop(&mut self) {
+        if let Some(new_root) = self.new_root {
+            self.tx.current_root.set(new_root);
+        } else {
+            self.tx.current_root.set(*self.backtrack.first().unwrap());
+        }
+    }
+}
+
+impl<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K> Drop
+    for DeleteBacktrack<'txbuilder, 'txmanager, 'storage, K>
+where
+    K: Key,
+{
+    fn drop(&mut self) {
+        if let Some(new_root) = self.new_root {
+            self.tx.current_root.set(new_root);
+        } else {
+            self.tx.current_root.set(*self.backtrack.first().unwrap());
+        }
+    }
+}

--- a/btree/src/btreeindex/backtrack.rs
+++ b/btree/src/btreeindex/backtrack.rs
@@ -1,21 +1,11 @@
+use super::transaction;
 use super::transaction::{MutablePage, PageRef, PageRefMut, WriteTransaction};
-use super::{transaction};
-use crate::btreeindex::{
-    borrow::{Immutable, Mutable},
-    node::{NodeRef, NodeRefMut},
-    page_manager::PageManager,
-    Node, PageHandle, PageId, Pages,
-};
+use crate::btreeindex::{node::NodeRef, Node, PageId};
 use crate::mem_page::MemPage;
 use crate::Key;
 
-
-
-
 use std::convert::{TryFrom, TryInto};
 use std::marker::PhantomData;
-
-
 
 /// this is basically a stack, but it will rename pointers and interact with the builder in order to reuse
 /// already cloned pages
@@ -44,12 +34,15 @@ where
     key_buffer_size: u32,
 }
 
+/// type to operate on the current element in the stack (branch) of nodes. This borrows the backtrack and acts as a proxy, in order to make borrowing simpler, because
 pub struct DeleteNextElement<'a, 'b: 'a, 'c: 'b, 'd: 'c, K>
 where
     K: Key,
 {
     pub next: PageRefMut<'a, 'd>,
     pub parent: Option<PageRefMut<'a, 'd>>,
+    // anchor is an index into the keys array of a node used to find the current node in the parent without searching. The leftmost(lowest) child has None as anchor
+    // this means it's inmediate right sibling would have anchor of 0, and so on.
     pub anchor: Option<usize>,
     pub left: Option<PageRef<'a, 'd>>,
     pub right: Option<PageRef<'a, 'd>>,

--- a/btree/src/btreeindex/metadata.rs
+++ b/btree/src/btreeindex/metadata.rs
@@ -110,7 +110,7 @@ mod tests {
 
         let page_manager = metadata.page_manager;
         assert_eq!(page_manager.next_page(), FIRST_PAGE_ID);
-        assert_eq!(page_manager.free_pages(), &vec![]);
+        // assert_eq!(page_manager.free_pages(), &vec![]);
 
         std::fs::remove_file("metadata_test").unwrap();
     }

--- a/btree/src/btreeindex/metadata.rs
+++ b/btree/src/btreeindex/metadata.rs
@@ -110,7 +110,7 @@ mod tests {
 
         let page_manager = metadata.page_manager;
         assert_eq!(page_manager.next_page(), FIRST_PAGE_ID);
-        // assert_eq!(page_manager.free_pages(), &vec![]);
+        assert_eq!(page_manager.free_pages(), &vec![]);
 
         std::fs::remove_file("metadata_test").unwrap();
     }

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -394,6 +394,7 @@ where
             .transaction_manager
             .insert_transaction(&self.pages, key_buffer_size);
 
+<<<<<<< HEAD
         {
             let mut backtrack = tx.delete_backtrack();
 
@@ -413,6 +414,27 @@ where
             let mut leaf = next;
             let leaf_id = leaf.id();
 
+=======
+        let backtrack = tx.delete_backtrack();
+
+        backtrack.search_for(key);
+
+        // path loaded (cloned) in transaction
+
+        // let (leaf, parent, anchor, left, right) = backtrack.get_next()?.unwrap();
+        let DeleteNextElement {
+            next,
+            parent,
+            anchor,
+            left,
+            right,
+        } = backtrack.get_next()?.unwrap();
+
+        let leaf = next;
+        let leaf_id = leaf.page_id;
+
+        let rebalance_result = {
+>>>>>>> d11a15a... start adding leaf delete
             let delete_status = leaf.as_node_mut(key_buffer_size as usize, |mut node| {
                 node.as_leaf_mut().delete(key)
             })?;
@@ -434,46 +456,45 @@ where
             };
 
             let parent = parent.unwrap();
-            let parent_id = parent.id();
+            let parent_id = parent.page_id;
 
             let rebalance_result =
                 leaf.as_node_mut(key_buffer_size as usize, |mut node: Node<K, &mut [u8]>| {
-                    let siblings = SiblingsArg::new_from_options(left, right);
+                    let left_sibling = left.and_then(|id| backtrack.mut_sibling(id));
+
+                    let right_sibling = right.and_then(|id| backtrack.mut_sibling(id));
+
+                    let siblings = SiblingsArg::new_from_options(left_sibling, right_sibling);
 
                     node.as_leaf_mut()
-                        .rebalance(siblings)
+                        .rebalance(RebalanceArgs {
+                            parent,
+                            parent_anchor: anchor,
+                            siblings,
+                        })
                         .expect("couldn't rebalance leaf")
                 });
 
-            match rebalance_result {
-                RebalanceResult::TookKeyFromLeft => {
-                    let siblings = unimplemented!();
-                    leaf.as_node_mut(key_buffer_size as usize, |mut node: Node<K, &mut [u8]>| {
-                        node.as_leaf_mut()
-                            .take_key_from_left(parent, anchor, siblings)
-                    });
-                }
-                RebalanceResult::TookKeyFromRight => {
-                    let siblings = unimplemented!();
-                    leaf.as_node_mut(key_buffer_size as usize, |mut node: Node<K, &mut [u8]>| {
-                        node.as_leaf_mut()
-                            .take_key_from_right(parent, anchor, siblings)
-                    });
-                }
-                RebalanceResult::MergeIntoLeft => {
-                    backtrack.delete_node(leaf_id);
+            rebalance_result
+        };
 
-                    self.delete_internal(
-                        anchor.expect("merged into left sibling, but anchor is None"),
-                        &mut backtrack,
-                    );
-                }
-                RebalanceResult::MergeIntoSelf => {
-                    self.delete_internal(anchor.map_or(0, |a| a + 1), &mut backtrack);
-                    backtrack.delete_node(right.unwrap());
-                }
-            };
-        }
+        match rebalance_result {
+            RebalanceResult::TookKeyFromLeft => {}
+            RebalanceResult::TookKeyFromRight => {}
+            RebalanceResult::MergeIntoLeft => {
+                tx.delete_node(leaf_id);
+
+                self.delete_internal(
+                    anchor.expect("merged into left sibling, but anchor is None"),
+                    &mut backtrack,
+                );
+            }
+            RebalanceResult::MergeIntoSelf => {
+                self.delete_internal(anchor.map_or(0, |a| a + 1), &mut backtrack);
+                tx.delete_node(right.unwrap());
+            }
+        };
+
         tx.commit::<K>();
 
         Ok(())

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -239,7 +239,7 @@ where
 
     pub(crate) fn insert_in_leaf<'a, 'b: 'a>(
         &self,
-        mut leaf: PageRefMut<'a, 'b>,
+        leaf: PageRefMut<'a, 'b>,
         key: K,
         value: Value,
     ) -> Result<Option<(K, Node<K, MemPage>)>, BTreeStoreError> {
@@ -278,7 +278,7 @@ where
         let mut right_id = to_insert;
         loop {
             let (current_id, new_split_key, new_node) = {
-                let mut node = backtrack.get_next()?.unwrap();
+                let node = backtrack.get_next()?.unwrap();
                 let node_id = node.id();
                 let key_size = usize::try_from(self.static_settings.key_buffer_size).unwrap();
                 let page_size = self.static_settings.page_size.try_into().unwrap();

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -244,7 +244,7 @@ where
 
     pub(crate) fn insert_in_leaf<'a, 'b: 'a>(
         &self,
-        leaf: PageRefMut<'a, 'b>,
+        mut leaf: PageRefMut<'a, 'b>,
         key: K,
         value: Value,
     ) -> Result<Option<(K, Node<K, MemPage>)>, BTreeStoreError> {
@@ -283,7 +283,7 @@ where
         let mut right_id = to_insert;
         loop {
             let (current_id, new_split_key, new_node) = {
-                let node = backtrack.get_next()?.unwrap();
+                let mut node = backtrack.get_next()?.unwrap();
                 let node_id = node.id();
                 let key_size = usize::try_from(self.static_settings.key_buffer_size).unwrap();
                 let page_size = self.static_settings.page_size.try_into().unwrap();

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -164,7 +164,7 @@ pub mod borrow {
             });
 
             match *arc {
-                BorrowGuard::Exclusive => panic!("can't borrow mutably borrowed page"),
+                BorrowGuard::Exclusive => panic!("can't borrow mutably borrowed page {}", id),
                 _ => (),
             }
 

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -1,4 +1,5 @@
 pub mod transaction;
+use super::node::SiblingHandle;
 use super::pages::*;
 use super::{transaction::PageRefMut, Metadata, Node, PageId};
 use crate::btreeindex::page_manager::PageManager;
@@ -55,6 +56,20 @@ where
 {
     tx: &'txbuilder mut transaction::InsertTransaction<'txmanager, 'storage>,
     backtrack: Vec<PageId>,
+    new_root: Option<PageId>,
+    phantom_key: PhantomData<[K]>,
+    key_buffer_size: u32,
+}
+
+/// this is basically a stack, but it will rename pointers and interact with the builder in order to reuse
+/// already cloned pages
+pub struct DeleteBacktrack<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K>
+where
+    K: Key,
+{
+    tx: &'txbuilder mut transaction::InsertTransaction<'txmanager, 'storage>,
+    backtrack: Vec<PageId>,
+    parent_info: Vec<(Option<usize>, Option<PageId>, Option<PageId>)>,
     new_root: Option<PageId>,
     phantom_key: PhantomData<[K]>,
     key_buffer_size: u32,
@@ -217,7 +232,7 @@ where
 
         let key_buffer_size = usize::try_from(self.key_buffer_size).unwrap();
 
-        match self.tx.mut_page(id)? {
+        match self.tx.mut_page(id, None)? {
             transaction::MutablePage::NeedsParentRedirect(rename_in_parents) => {
                 // this part may be tricky, we need to recursively clone and redirect all the path
                 // from the root to the node we are writing to. We need the backtrack stack, because
@@ -230,12 +245,13 @@ where
 
                     match result {
                         MutablePage::NeedsParentRedirect(rename) => rename_in_parents = rename,
-                        MutablePage::InTransaction(handle) => return Ok(Some(handle)),
+                        MutablePage::InTransaction(handle, _) => return Ok(Some(handle)),
                     }
                 }
-                Ok(Some(rename_in_parents.finish()))
+                let (page, _) = rename_in_parents.finish();
+                Ok(Some(page))
             }
-            transaction::MutablePage::InTransaction(handle) => Ok(Some(handle)),
+            transaction::MutablePage::InTransaction(handle, _) => Ok(Some(handle)),
         }
     }
 
@@ -265,6 +281,199 @@ where
 
 impl<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K> Drop
     for InsertBacktrack<'txbuilder, 'txmanager, 'storage, K>
+where
+    K: Key,
+{
+    fn drop(&mut self) {
+        if let Some(new_root) = self.new_root {
+            self.tx.current_root = new_root;
+        } else {
+            self.tx.current_root = *self.backtrack.first().unwrap();
+        }
+    }
+}
+
+pub struct DeleteNextElement<'a> {
+    next: PageHandle<'a, Mutable<'a>>,
+    parent: Option<PageHandle<'a, Mutable<'a>>>,
+    anchor: Option<usize>,
+    left: Option<PageId>,
+    right: Option<PageId>,
+}
+
+impl<'txbuilder, 'txmanager: 'txbuilder, 'index: 'txmanager, K>
+    DeleteBacktrack<'txbuilder, 'txmanager, 'index, K>
+where
+    K: Key,
+{
+    /// traverse the tree while storing the path, so we can then backtrack while splitting
+    pub fn search_for(&mut self, key: &K) {
+        enum Step {
+            Internal(Option<usize>, Option<PageId>, Option<PageId>),
+            Leaf,
+        }
+
+        let mut current = self.tx.root();
+
+        loop {
+            let page = self.tx.get_page(current).unwrap();
+
+            let found_leaf = page.as_node(
+                self.key_buffer_size.try_into().unwrap(),
+                |node: Node<K, &[u8]>| {
+                    if let Some(inode) = node.try_as_internal() {
+                        let upper_pivot = match inode.keys().binary_search(key) {
+                            Ok(pos) => Some(pos + 1),
+                            Err(pos) => Some(pos),
+                        }
+                        .filter(|pos| pos < &inode.children().len());
+
+                        let anchor = upper_pivot
+                            .or_else(|| inode.keys().len().checked_sub(1))
+                            .and_then(|up| up.checked_sub(1));
+
+                        let left_sibling_id = anchor.and_then(|pos| inode.children().try_get(pos));
+
+                        let right_sibling_id = anchor
+                            .map(|pos| pos + 2)
+                            .or(Some(1))
+                            .and_then(|pos| inode.children().try_get(pos));
+
+                        // (anchor, left_sibling_id, right_sibling_id)
+                        // self.parent_info
+                        //     .push((anchor, left_sibling_id, right_sibling_id));
+
+                        if let Some(upper_pivot) = upper_pivot {
+                            current = inode.children().get(upper_pivot);
+                        } else {
+                            let last = inode.children().len().checked_sub(1).unwrap();
+                            current = inode.children().get(last);
+                        }
+                        // false
+                        Step::Internal(anchor, left_sibling_id, right_sibling_id)
+                    } else {
+                        // true
+                        Step::Leaf
+                    }
+                },
+            );
+
+            self.backtrack.push(page.id());
+
+            match found_leaf {
+                Step::Internal(anchor, left, right) => self.parent_info.push((anchor, left, right)),
+                Step::Leaf => break,
+            }
+
+            // if found_leaf {
+            //     break;
+            // }
+        }
+    }
+
+    pub fn get_next(&mut self) -> Result<Option<DeleteNextElement>, std::io::Error> {
+        let id = match self.backtrack.pop() {
+            Some(id) => id,
+            None => return Ok(None),
+        };
+
+        if self.backtrack.is_empty() {
+            assert!(self.new_root.is_none());
+            self.new_root = Some(id);
+        }
+
+        let key_buffer_size = usize::try_from(self.key_buffer_size).unwrap();
+
+        let (parent, anchor, left, right) = if self.backtrack.is_empty() {
+            (None, None, None, None)
+        } else {
+            let parent = self.backtrack.last().unwrap();
+
+            let (anchor, left, right) = self.parent_info.pop().unwrap();
+            (Some(parent), anchor, left, right)
+        };
+
+        let (next, parent) = match self.tx.mut_page(id, parent.map(|n| *n))? {
+            transaction::MutablePage::NeedsParentRedirect(rename_in_parents) => {
+                // this part may be tricky, we need to recursively clone and redirect all the path
+                // from the root to the node we are writing to. We need the backtrack stack, because
+                // that's the only way to get the parent of a node (because there are no parent pointers)
+                // so we iterate it in reverse but without consuming the stack (as we still need it for the
+                // rest of the insertion algorithm)
+                let mut rename_in_parents = Some(rename_in_parents);
+                let mut finished = None;
+                for id in self.backtrack.iter().rev() {
+                    let result = rename_in_parents
+                        .take()
+                        .unwrap()
+                        .rename_parent::<K>(key_buffer_size, *id)?;
+
+                    match result {
+                        MutablePage::NeedsParentRedirect(rename) => {
+                            rename_in_parents = Some(rename)
+                        }
+                        MutablePage::InTransaction(handle, parent) => {
+                            finished = Some((handle, parent));
+                            break;
+                        }
+                    }
+                }
+                match finished {
+                    Some(handle) => handle,
+                    None => rename_in_parents.unwrap().finish(),
+                }
+            }
+            transaction::MutablePage::InTransaction(handle, parent) => (handle, parent),
+        };
+
+        Ok(Some(DeleteNextElement {
+            next,
+            parent,
+            anchor,
+            left,
+            right,
+        }))
+    }
+
+    pub fn has_next(&self) -> bool {
+        self.backtrack.last().is_some()
+    }
+
+    pub fn add_new_node(
+        &mut self,
+        mem_page: MemPage,
+        key_buffer_size: u32,
+    ) -> Result<PageId, std::io::Error> {
+        self.tx.add_new_node(mem_page, key_buffer_size)
+    }
+
+    pub fn mut_sibling<'a>(
+        &'a mut self,
+        page_id: PageId,
+    ) -> impl FnMut() -> PageHandle<'a, Mutable<'a>> + 'a {
+        move || {
+            match self.tx.mut_page(page_id, None).unwrap() {
+                // todo: remove this unwrap by changing the SiblingHandle to process errors?
+                transaction::MutablePage::NeedsParentRedirect(redirect) => unimplemented!(),
+                transaction::MutablePage::InTransaction(handle, _) => handle,
+            }
+        }
+    }
+
+    pub fn new_root(
+        &mut self,
+        mem_page: MemPage,
+        key_buffer_size: u32,
+    ) -> Result<(), std::io::Error> {
+        let id = self.tx.add_new_node(mem_page, key_buffer_size)?;
+        self.new_root = Some(id);
+
+        Ok(())
+    }
+}
+
+impl<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K> Drop
+    for DeleteBacktrack<'txbuilder, 'txmanager, 'storage, K>
 where
     K: Key,
 {

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -4,7 +4,7 @@ use super::{
     transaction::{PageRef, PageRefMut},
     Metadata, Node, PageId,
 };
-use crate::btreeindex::node::NodePageRef;
+use crate::btreeindex::node::NodeRef;
 use crate::btreeindex::page_manager::PageManager;
 
 use crate::mem_page::MemPage;
@@ -338,11 +338,13 @@ where
         }
     }
 
-    pub fn delete_left_sibling(&self) {
-        let id = self.left.as_ref().map(|handle| handle.id()).unwrap();
+    /// delete current node, this just adds the id to the list of free pages *after* the transaction is confirmed
+    pub fn delete_node(&self) {
+        let id = self.next.id();
         self.backtrack.delete_node(id)
     }
 
+    /// delete right sibling of current node, this just adds the id to the list of free pages *after* the transaction is confirmed
     pub fn delete_right_sibling(&self) {
         let id = self.right.as_ref().map(|handle| handle.id()).unwrap();
         self.backtrack.delete_node(dbg!(id))

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -4,9 +4,7 @@ use super::{
     transaction::{PageRef, PageRefMut},
     Metadata, Node, PageId,
 };
-use crate::btreeindex::page_manager::PageManager;
-
-use crate::btreeindex::node::NodeRef;
+use crate::btreeindex::node::NodePageRef;
 use crate::btreeindex::page_manager::PageManager;
 use crate::btreeindex::pages::{
     borrow::{Immutable, Mutable},

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -3,7 +3,6 @@ use super::pages::*;
 use super::{transaction::PageRefMut, Metadata, Node, PageId};
 use crate::btreeindex::page_manager::PageManager;
 
-use crate::btreeindex::node::NodeRef;
 use crate::mem_page::MemPage;
 use crate::Key;
 use std::collections::VecDeque;

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -1,13 +1,9 @@
 pub mod transaction;
 use super::pages::*;
-use super::{
-    transaction::{PageRef, PageRefMut},
-    Metadata, Node, PageId,
-};
-use crate::btreeindex::node::NodeRef;
-use super::{Metadata, PageId};
+use super::Metadata;
 use crate::btreeindex::page_manager::PageManager;
-use crate::btreeindex::node::NodeRef;
+
+use super::PageId;
 
 use std::collections::VecDeque;
 

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -6,13 +6,14 @@ use super::{
 };
 use crate::btreeindex::node::NodeRef;
 use crate::btreeindex::page_manager::PageManager;
+use crate::btreeindex::node::NodeRef;
 
-use crate::mem_page::MemPage;
-use crate::Key;
+
+
 use std::collections::VecDeque;
-use std::convert::{TryFrom, TryInto};
-use std::marker::PhantomData;
-use transaction::{InsertTransaction, MutablePage, ReadTransaction};
+
+
+use transaction::{ReadTransaction, WriteTransaction};
 
 use parking_lot::RwLock;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -26,12 +27,12 @@ pub(crate) struct TransactionManager {
 #[derive(Debug)]
 pub(crate) struct Version {
     root: PageId,
-    transaction: WriteTransaction,
+    transaction: WriteTransactionDelta,
 }
 
 #[derive(Debug)]
 /// delta-like structure, it has the list of pages that can be collected after no readers are using them
-pub(crate) struct WriteTransaction {
+pub(crate) struct WriteTransactionDelta {
     new_root: PageId,
     shadowed_pages: Vec<PageId>,
     deleted_pages: Vec<PageId>,
@@ -52,38 +53,11 @@ impl Version {
     }
 }
 
-/// this is basically a stack, but it will rename pointers and interact with the builder in order to reuse
-/// already cloned pages
-pub struct InsertBacktrack<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K>
-where
-    K: Key,
-{
-    tx: &'txbuilder mut transaction::InsertTransaction<'txmanager, 'storage>,
-    backtrack: Vec<PageId>,
-    new_root: Option<PageId>,
-    phantom_key: PhantomData<[K]>,
-    key_buffer_size: u32,
-}
-
-/// this is basically a stack, but it will rename pointers and interact with the builder in order to reuse
-/// already cloned pages
-pub struct DeleteBacktrack<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K>
-where
-    K: Key,
-{
-    tx: &'txbuilder transaction::InsertTransaction<'txmanager, 'storage>,
-    backtrack: Vec<PageId>,
-    parent_info: Vec<(Option<usize>, Option<PageId>, Option<PageId>)>,
-    new_root: Option<PageId>,
-    phantom_key: PhantomData<[K]>,
-    key_buffer_size: u32,
-}
-
 impl TransactionManager {
     pub fn new(metadata: &Metadata) -> TransactionManager {
         let latest_version = Arc::new(RwLock::new(Arc::new(Version {
             root: metadata.root,
-            transaction: WriteTransaction {
+            transaction: WriteTransactionDelta {
                 new_root: metadata.root,
                 shadowed_pages: vec![],
                 next_page_id: metadata.page_manager.next_page(),
@@ -114,11 +88,11 @@ impl TransactionManager {
         &'me self,
         pages: &'index RwLock<Pages>,
         key_buffer_size: u32,
-    ) -> InsertTransaction<'me, 'index> {
+    ) -> WriteTransaction<'me, 'index> {
         let page_manager = self.page_manager.lock().unwrap();
         let versions = self.versions.lock().unwrap();
 
-        InsertTransaction::new(
+        WriteTransaction::new(
             self.latest_version().root(),
             pages,
             page_manager,
@@ -182,340 +156,6 @@ impl TransactionManager {
             _page_manager: page_manager,
             _versions: versions,
         })
-    }
-}
-
-impl<'txbuilder, 'txmanager: 'txbuilder, 'index: 'txmanager, K>
-    InsertBacktrack<'txbuilder, 'txmanager, 'index, K>
-where
-    K: Key,
-{
-    /// traverse the tree while storing the path, so we can then backtrack while splitting
-    pub fn search_for<'a>(&'a mut self, key: &K) {
-        let mut current = self.tx.root();
-
-        loop {
-            let page = self.tx.get_page(current).unwrap();
-
-            let found_leaf = page.as_node(
-                self.key_buffer_size.try_into().unwrap(),
-                |node: Node<K, &[u8]>| {
-                    if let Some(inode) = node.try_as_internal() {
-                        let upper_pivot = match inode.keys().binary_search(key) {
-                            Ok(pos) => Some(pos + 1),
-                            Err(pos) => Some(pos),
-                        }
-                        .filter(|pos| pos < &inode.children().len());
-
-                        if let Some(upper_pivot) = upper_pivot {
-                            current = inode.children().get(upper_pivot);
-                        } else {
-                            let last = inode.children().len().checked_sub(1).unwrap();
-                            current = inode.children().get(last);
-                        }
-                        false
-                    } else {
-                        true
-                    }
-                },
-            );
-
-            self.backtrack.push(page.id());
-
-            if found_leaf {
-                break;
-            }
-        }
-    }
-
-    pub fn get_next<'a>(&'a mut self) -> Result<Option<PageRefMut<'a, 'index>>, std::io::Error> {
-        let id = match self.backtrack.pop() {
-            Some(id) => id,
-            None => return Ok(None),
-        };
-
-        if self.backtrack.is_empty() {
-            assert!(self.new_root.is_none());
-            self.new_root = Some(id);
-        }
-
-        let key_buffer_size = usize::try_from(self.key_buffer_size).unwrap();
-
-        match self.tx.mut_page(id)? {
-            transaction::MutablePage::NeedsParentRedirect(rename_in_parents) => {
-                // this part may be tricky, we need to recursively clone and redirect all the path
-                // from the root to the node we are writing to. We need the backtrack stack, because
-                // that's the only way to get the parent of a node (because there are no parent pointers)
-                // so we iterate it in reverse but without consuming the stack (as we still need it for the
-                // rest of the insertion algorithm)
-                let mut rename_in_parents = rename_in_parents;
-                for id in self.backtrack.iter().rev() {
-                    let result = rename_in_parents.rename_parent::<K>(key_buffer_size, *id)?;
-
-                    match result {
-                        MutablePage::NeedsParentRedirect(rename) => rename_in_parents = rename,
-                        MutablePage::InTransaction(handle) => return Ok(Some(handle)),
-                    }
-                }
-                let page = rename_in_parents.finish();
-                Ok(Some(page))
-            }
-            transaction::MutablePage::InTransaction(handle) => Ok(Some(handle)),
-        }
-    }
-
-    pub fn has_next(&self) -> bool {
-        self.backtrack.last().is_some()
-    }
-
-    pub fn add_new_node(
-        &mut self,
-        mem_page: MemPage,
-        key_buffer_size: u32,
-    ) -> Result<PageId, std::io::Error> {
-        self.tx.add_new_node(mem_page, key_buffer_size)
-    }
-
-    pub fn new_root(
-        &mut self,
-        mem_page: MemPage,
-        key_buffer_size: u32,
-    ) -> Result<(), std::io::Error> {
-        let id = self.tx.add_new_node(mem_page, key_buffer_size)?;
-        self.new_root = Some(id);
-
-        Ok(())
-    }
-}
-
-impl<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K> Drop
-    for InsertBacktrack<'txbuilder, 'txmanager, 'storage, K>
-where
-    K: Key,
-{
-    fn drop(&mut self) {
-        if let Some(new_root) = self.new_root {
-            self.tx.current_root.set(new_root);
-        } else {
-            self.tx.current_root.set(*self.backtrack.first().unwrap());
-        }
-    }
-}
-
-pub struct DeleteNextElement<'a, 'b: 'a, 'c: 'b, 'd: 'c, K>
-where
-    K: Key,
-{
-    pub next: PageRefMut<'a, 'd>,
-    pub parent: Option<PageRefMut<'a, 'd>>,
-    pub anchor: Option<usize>,
-    pub left: Option<PageRef<'a, 'd>>,
-    pub right: Option<PageRef<'a, 'd>>,
-    backtrack: &'a mut DeleteBacktrack<'b, 'c, 'd, K>,
-}
-
-impl<'a, 'b: 'a, 'c: 'b, 'd: 'c, K> DeleteNextElement<'a, 'b, 'c, 'd, K>
-where
-    K: Key,
-{
-    pub fn mut_left_sibling(&self, key_size: usize) -> PageRefMut<'a, 'd> {
-        let left_id = self.left.as_ref().unwrap().id();
-        match self.backtrack.tx.mut_page(dbg!(left_id)).unwrap() {
-            MutablePage::InTransaction(handle) => handle,
-            MutablePage::NeedsParentRedirect(redirect_pointers) => {
-                redirect_pointers.redirect_parent_in_tx::<K>(key_size, self.parent.clone().unwrap())
-            }
-        }
-    }
-
-    pub fn mut_right_sibling(&self, key_size: usize) -> PageRefMut<'a, 'd> {
-        let right_id = self.right.as_ref().unwrap().id();
-        match self.backtrack.tx.mut_page(dbg!(right_id)).unwrap() {
-            MutablePage::InTransaction(handle) => handle,
-            MutablePage::NeedsParentRedirect(redirect_pointers) => {
-                redirect_pointers.redirect_parent_in_tx::<K>(key_size, self.parent.clone().unwrap())
-            }
-        }
-    }
-
-    /// delete current node, this just adds the id to the list of free pages *after* the transaction is confirmed
-    pub fn delete_node(&self) {
-        let id = self.next.id();
-        self.backtrack.delete_node(id)
-    }
-
-    /// delete right sibling of current node, this just adds the id to the list of free pages *after* the transaction is confirmed
-    pub fn delete_right_sibling(&self) {
-        let id = self.right.as_ref().map(|handle| handle.id()).unwrap();
-        self.backtrack.delete_node(dbg!(id))
-    }
-
-    pub fn set_root(&self, id: PageId) {
-        self.backtrack.tx.current_root.set(id)
-    }
-}
-
-impl<'txbuilder, 'txmanager: 'txbuilder, 'index: 'txmanager, K>
-    DeleteBacktrack<'txbuilder, 'txmanager, 'index, K>
-where
-    K: Key,
-{
-    /// traverse the tree while storing the path, so we can then backtrack while splitting
-    pub fn search_for(&mut self, key: &K) {
-        enum Step {
-            Internal(Option<usize>, Option<PageId>, Option<PageId>),
-            Leaf,
-        }
-
-        let mut current = self.tx.root();
-
-        loop {
-            let page = self.tx.get_page(current).unwrap();
-
-            let found_leaf = page.as_node(
-                self.key_buffer_size.try_into().unwrap(),
-                |node: Node<K, &[u8]>| {
-                    if let Some(inode) = node.try_as_internal() {
-                        let upper_pivot = match inode.keys().binary_search(key) {
-                            Ok(pos) => Some(pos + 1),
-                            Err(pos) => Some(pos),
-                        }
-                        .filter(|pos| pos < &inode.children().len());
-
-                        let anchor = upper_pivot
-                            .or_else(|| inode.keys().len().checked_sub(1))
-                            .and_then(|up| up.checked_sub(1));
-
-                        let left_sibling_id = anchor.and_then(|pos| inode.children().try_get(pos));
-
-                        let right_sibling_id = anchor
-                            .map(|pos| pos + 2)
-                            .or(Some(1))
-                            .and_then(|pos| inode.children().try_get(pos));
-
-                        // (anchor, left_sibling_id, right_sibling_id)
-                        // self.parent_info
-                        //     .push((anchor, left_sibling_id, right_sibling_id));
-
-                        if let Some(upper_pivot) = upper_pivot {
-                            current = inode.children().get(upper_pivot);
-                        } else {
-                            let last = inode.children().len().checked_sub(1).unwrap();
-                            current = inode.children().get(last);
-                        }
-                        // false
-                        Step::Internal(anchor, left_sibling_id, right_sibling_id)
-                    } else {
-                        // true
-                        Step::Leaf
-                    }
-                },
-            );
-
-            self.backtrack.push(dbg!(page.id()));
-
-            match found_leaf {
-                Step::Internal(anchor, left, right) => self.parent_info.push((anchor, left, right)),
-                Step::Leaf => break,
-            }
-
-            // if found_leaf {
-            //     break;
-            // }
-        }
-    }
-
-    pub fn get_next<'this>(
-        &'this mut self,
-    ) -> Result<Option<DeleteNextElement<'this, 'txbuilder, 'txmanager, 'index, K>>, std::io::Error>
-    {
-        let id = match dbg!(&mut self.backtrack).pop() {
-            Some(id) => id,
-            None => return Ok(None),
-        };
-
-        if self.backtrack.is_empty() {
-            assert!(self.new_root.is_none());
-            self.new_root = Some(id);
-        }
-
-        let key_buffer_size = usize::try_from(self.key_buffer_size).unwrap();
-
-        let (parent, anchor, left, right) = if self.backtrack.is_empty() {
-            (None, None, None, None)
-        } else {
-            let parent = self.backtrack.last().unwrap();
-
-            let (anchor, left, right) = self.parent_info.pop().unwrap();
-            (Some(parent), anchor, left, right)
-        };
-
-        let next = match self.tx.mut_page(id)? {
-            transaction::MutablePage::NeedsParentRedirect(rename_in_parents) => {
-                // this part may be tricky, we need to recursively clone and redirect all the path
-                // from the root to the node we are writing to. We need the backtrack stack, because
-                // that's the only way to get the parent of a node (because there are no parent pointers)
-                // so we iterate it in reverse but without consuming the stack (as we still need it for the
-                // rest of the insertion algorithm)
-                let mut rename_in_parents = Some(rename_in_parents);
-                let mut finished = None;
-                for id in self.backtrack.iter().rev() {
-                    let result = rename_in_parents
-                        .take()
-                        .unwrap()
-                        .rename_parent::<K>(key_buffer_size, *id)?;
-
-                    match result {
-                        MutablePage::NeedsParentRedirect(rename) => {
-                            rename_in_parents = Some(rename)
-                        }
-                        MutablePage::InTransaction(handle) => {
-                            finished = Some(handle);
-                            break;
-                        }
-                    }
-                }
-                match finished {
-                    Some(handle) => handle,
-                    None => rename_in_parents.unwrap().finish(),
-                }
-            }
-            transaction::MutablePage::InTransaction(handle) => handle,
-        };
-
-        let left = left.and_then(|id| self.tx.get_page(id));
-        let right = right.and_then(|id| self.tx.get_page(id));
-        let parent = parent.map(|id| match self.tx.mut_page(*id).unwrap() {
-            MutablePage::InTransaction(handle) => handle,
-            _ => unreachable!(),
-        });
-
-        Ok(Some(DeleteNextElement {
-            next,
-            parent,
-            anchor,
-            left,
-            right,
-            backtrack: self,
-        }))
-    }
-
-    pub fn delete_node(&self, page_id: PageId) {
-        self.tx.delete_node(page_id)
-    }
-}
-
-impl<'txbuilder, 'txmanager: 'txbuilder, 'storage: 'txmanager, K> Drop
-    for DeleteBacktrack<'txbuilder, 'txmanager, 'storage, K>
-where
-    K: Key,
-{
-    fn drop(&mut self) {
-        if let Some(new_root) = self.new_root {
-            self.tx.current_root.set(new_root);
-        } else {
-            self.tx.current_root.set(*self.backtrack.first().unwrap());
-        }
     }
 }
 

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -5,13 +5,11 @@ use super::{
     Metadata, Node, PageId,
 };
 use crate::btreeindex::node::NodeRef;
+use super::{Metadata, PageId};
 use crate::btreeindex::page_manager::PageManager;
 use crate::btreeindex::node::NodeRef;
 
-
-
 use std::collections::VecDeque;
-
 
 use transaction::{ReadTransaction, WriteTransaction};
 

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -222,7 +222,7 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
                     .pages
                     .borrow()
                     .mut_page(*id)
-                    .expect("already fetched transaction was not allocated");
+                    .expect("already fetched page was not allocated");
 
                 let handle = PageRefMut {
                     pages: &self.pages,
@@ -360,9 +360,11 @@ impl<'a, 'b: 'a, 'c: 'b> RedirectPointers<'a, 'b, 'c> {
                 last_old_id: parent_id,
                 last_new_id: parent_new_id,
                 shadowed_page: self.shadowed_page,
+                // this is the parent id of shadowed_page, not of the current node in the iteration
             }))
         } else {
-            Ok(MutablePage::InTransaction(self.finish()))
+            let page = self.finish();
+            Ok(MutablePage::InTransaction(page))
         }
     }
 
@@ -408,6 +410,14 @@ impl<'txmanager, 'storage> InsertTransaction<'txmanager, 'storage> {
             phantom_key: PhantomData,
             key_buffer_size,
         }
+    }
+}
+
+impl<'storage> Deref for ExtendablePages<'storage> {
+    type Target = Pages;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().unwrap()
     }
 }
 

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -1,9 +1,6 @@
 use super::Version;
 use crate::btreeindex::{
-    borrow::Immutable,
-    node::{NodeRef, NodeRefMut},
-    page_manager::PageManager,
-    Node, PageHandle, PageId, Pages,
+    borrow::Immutable, page_manager::PageManager, Node, PageHandle, PageId, Pages,
 };
 use crate::Key;
 use parking_lot::lock_api;

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -111,12 +111,6 @@ impl<'a, 'b: 'a> NodeRefMut for PageRefMut<'a, 'b> {
 // -> drop write guard -> take read guard ourselves
 struct ExtendablePages<'storage>(Option<RwLockUpgradableReadGuard<'storage, Pages>>);
 
-pub(super) struct Neighbourhood {
-    parent: PageId,
-    left: Option<PageId>,
-    right: Option<PageId>,
-}
-
 impl<'a> ReadTransaction<'a> {
     pub(super) fn new(version: Arc<Version>, pages: RwLockReadGuard<Pages>) -> ReadTransaction {
         ReadTransaction { version, pages }
@@ -312,7 +306,7 @@ impl<'locks, 'storage: 'locks> InsertTransaction<'locks, 'storage> {
         K: Key,
     {
         // let state = self.state.borrow();
-        let new_root = self.root();
+        let new_root = dbg!(self.root());
         let state = self.state.into_inner();
         let transaction = super::WriteTransaction {
             new_root,

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -391,13 +391,23 @@ impl<'txmanager, 'storage> InsertTransaction<'txmanager, 'storage> {
             key_buffer_size,
         }
     }
-}
 
-impl<'storage> Deref for ExtendablePages<'storage> {
-    type Target = Pages;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref().unwrap()
+    /// create a staging area for a single insert
+    pub(crate) fn delete_backtrack<'me, K>(
+        &'me mut self,
+    ) -> super::DeleteBacktrack<'me, 'txmanager, 'storage, K>
+    where
+        K: Key,
+    {
+        let key_buffer_size = self.key_buffer_size.clone();
+        super::DeleteBacktrack {
+            tx: self,
+            backtrack: vec![],
+            parent_info: vec![],
+            new_root: None,
+            phantom_key: PhantomData,
+            key_buffer_size,
+        }
     }
 }
 

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -129,6 +129,16 @@ where
         result
     }
 
+    pub fn delete(&self, key: K) -> Result<(), BTreeStoreError> {
+        let flatfile = self.flatfile.lock().unwrap();
+        self.index.delete(&key)?;
+
+        flatfile.sync()?;
+        self.index.checkpoint()?;
+
+        Ok(())
+    }
+
     /// insert many values in one transaction (with only one fsync)
     pub fn insert_many<B: AsRef<[u8]>>(
         &self,

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -130,10 +130,9 @@ where
     }
 
     pub fn delete(&self, key: K) -> Result<(), BTreeStoreError> {
-        let mut flatfile = self.flatfile.lock().unwrap();
         self.index.delete(&key)?;
 
-        flatfile.sync()?;
+        self.flatfile.sync()?;
         self.index.checkpoint()?;
 
         Ok(())

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -130,7 +130,7 @@ where
     }
 
     pub fn delete(&self, key: K) -> Result<(), BTreeStoreError> {
-        let flatfile = self.flatfile.lock().unwrap();
+        let mut flatfile = self.flatfile.lock().unwrap();
         self.index.delete(&key)?;
 
         flatfile.sync()?;


### PR DESCRIPTION
As #301 adds the delete and rebalance algorithms for the node types, this adds the actual functions to do the delete. This includes traversing the tree to find the leaf where the key to delete is found, clone the whole path, and traverse back (by using a stack/backtrack) calling rebalance (and cloning/shadowing siblings) as necessary. 

Caveats:
- There is still a bit of code duplication between the newly added `DeleteBacktrack` and the previous `InsertBacktrack`, as they act similarly but not quite.
- The chaining of borrows in `TransactionManager` -> `WriteTransaction` -> `DeleteBacktrack` -> `DeleteNextElement` made lifetime annotations a bit verbose, it's not really complex, but there may be some way to write that better (each one borrows from the previous one and exposes the necessary methods at each stage, this simplifies borrowing, but I'm not sure how idiomatic it is)