### PR TITLE
split contiguous mmaped file in pages

### DIFF
--- a/btree/benches/benchmark.rs
+++ b/btree/benches/benchmark.rs
@@ -60,14 +60,11 @@ fn single_key_insertion(c: &mut Criterion) {
             let r: u64 = rng.gen();
             let key = if r % 2 == 0 { r + 1 } else { r };
 
-            let blob_to_insert = random_blob(&mut rng);
+            let blob_to_insert: Box<[u8]> = random_blob(&mut rng);
             tree.insert(U64Key(key), &blob_to_insert[..]).unwrap_or(());
 
             assert_eq!(
-                tree.get(&U64Key(key))
-                    .unwrap()
-                    .expect("Key not found")
-                    .as_ref(),
+                tree.get(&U64Key(key)).unwrap().expect("Key not found"),
                 &blob_to_insert[..]
             );
         })
@@ -102,10 +99,7 @@ fn single_key_search(c: &mut Criterion) {
         b.iter(|| {
             let key: u64 = rng.gen_range(0, n);
             assert_eq!(
-                tree.get(&U64Key(key))
-                    .unwrap()
-                    .expect("Key not found")
-                    .as_ref(),
+                tree.get(&U64Key(key)).unwrap().expect("Key not found"),
                 &data.get(&key).unwrap()[..]
             )
         })

--- a/btree/src/btreeindex/backtrack.rs
+++ b/btree/src/btreeindex/backtrack.rs
@@ -35,60 +35,88 @@ where
     phantom_key: PhantomData<[K]>,
 }
 
-// lifetimes on this are a bit bothersome with four 'linear' (re) borrows, there may be some way of refactoring this things, but that would probably need to be done higher in
-// the hierarchy
-/// type to operate on the current element in the stack (branch) of nodes. This borrows the backtrack and acts as a proxy, in order to make borrowing simpler, because
-// XXX: having a left sibling means anchor is not None, and having a sibling in general means parent is not None also, maybe this invariants could be expressed in the type structure
 pub struct DeleteNextElement<'a, 'b: 'a, 'c: 'b, 'd: 'c, K>
 where
     K: Key,
 {
+    pub next_element: NextElement<'a, 'b, 'c, 'd, K>,
+    pub mut_context: Option<MutableContext<'a, 'b, 'c, 'd, K>>,
+}
+
+// lifetimes on this are a bit bothersome with four 'linear' (re) borrows, there may be some way of refactoring this things, but that would probably need to be done higher in
+// the hierarchy
+/// type to operate on the current element in the stack (branch) of nodes. This borrows the backtrack and acts as a proxy, in order to make borrowing simpler, because
+// XXX: having a left sibling means anchor is not None, and having a sibling in general means parent is not None also, maybe this invariants could be expressed in the type structure
+pub struct NextElement<'a, 'b: 'a, 'c: 'b, 'd: 'c, K>
+where
+    K: Key,
+{
     pub next: PageRefMut<'a>,
-    pub parent: Option<PageRefMut<'a>>,
     // anchor is an index into the keys array of a node used to find the current node in the parent without searching. The leftmost(lowest) child has None as anchor
     // this means it's inmediate right sibling would have anchor of 0, and so on.
     pub anchor: Option<usize>,
     pub left: Option<PageRef<'a>>,
     pub right: Option<PageRef<'a>>,
-    backtrack: &'a mut DeleteBacktrack<'b, 'c, 'd, K>,
+    backtrack: &'a DeleteBacktrack<'b, 'c, 'd, K>,
 }
 
-impl<'a, 'b: 'a, 'c: 'b, 'd: 'c, K> DeleteNextElement<'a, 'b, 'c, 'd, K>
+pub struct MutableContext<'a, 'b: 'a, 'c: 'b, 'd: 'c, K>
 where
     K: Key,
 {
-    pub fn mut_left_sibling(&self, key_size: usize) -> PageRefMut<'a> {
-        let left_id = self.left.as_ref().unwrap().id();
-        match self.backtrack.tx.mut_page(dbg!(left_id)).unwrap() {
+    parent: PageRefMut<'a>,
+    // anchor is an index into the keys array of a node used to find the current node in the parent without searching. The leftmost(lowest) child has None as anchor
+    // this means it's inmediate right sibling would have anchor of 0, and so on.
+    current_id: PageId,
+    left_id: Option<PageId>,
+    right_id: Option<PageId>,
+    backtrack: &'a DeleteBacktrack<'b, 'c, 'd, K>,
+}
+
+impl<'a, 'b: 'a, 'c: 'b, 'd: 'c, K> MutableContext<'a, 'b, 'c, 'd, K>
+where
+    K: Key,
+{
+    pub fn mut_left_sibling(&mut self, key_size: usize) -> (PageRefMut<'a>, &mut PageRefMut<'a>) {
+        let sibling = match self.backtrack.tx.mut_page(self.left_id.unwrap()).unwrap() {
             MutablePage::InTransaction(handle) => handle,
             MutablePage::NeedsParentRedirect(redirect_pointers) => {
-                redirect_pointers.redirect_parent_in_tx::<K>(key_size, self.parent.clone().unwrap())
+                redirect_pointers.redirect_parent_in_tx::<K>(key_size, &mut self.parent)
             }
-        }
+        };
+
+        (sibling, &mut self.parent)
     }
 
-    pub fn mut_right_sibling(&self, key_size: usize) -> PageRefMut<'a> {
-        let right_id = self.right.as_ref().unwrap().id();
-        match self.backtrack.tx.mut_page(dbg!(right_id)).unwrap() {
+    pub fn mut_right_sibling(&mut self, key_size: usize) -> (PageRefMut<'a>, &mut PageRefMut<'a>) {
+        let sibling = match self.backtrack.tx.mut_page(self.right_id.unwrap()).unwrap() {
             MutablePage::InTransaction(handle) => handle,
             MutablePage::NeedsParentRedirect(redirect_pointers) => {
-                redirect_pointers.redirect_parent_in_tx::<K>(key_size, self.parent.clone().unwrap())
+                redirect_pointers.redirect_parent_in_tx::<K>(key_size, &mut self.parent)
             }
+        };
+
+        (sibling, &mut self.parent)
+    }
+
+    /// delete right sibling of current node, this just adds the id to the list of free pages *after* the transaction is confirmed
+    pub fn delete_right_sibling(&self) -> Result<(), ()> {
+        match self.right_id {
+            None => Err(()),
+            Some(right_id) => Ok(self.backtrack.delete_node(right_id)),
         }
     }
 
     /// delete current node, this just adds the id to the list of free pages *after* the transaction is confirmed
     pub fn delete_node(&self) {
-        let id = self.next.id();
-        self.backtrack.delete_node(id)
+        self.backtrack.delete_node(self.current_id)
     }
+}
 
-    /// delete right sibling of current node, this just adds the id to the list of free pages *after* the transaction is confirmed
-    pub fn delete_right_sibling(&self) {
-        let id = self.right.as_ref().map(|handle| handle.id()).unwrap();
-        self.backtrack.delete_node(dbg!(id))
-    }
-
+impl<'a, 'b: 'a, 'c: 'b, 'd: 'c, K> NextElement<'a, 'b, 'c, 'd, K>
+where
+    K: Key,
+{
     pub fn set_root(&self, id: PageId) {
         self.backtrack.tx.current_root.set(id)
     }
@@ -228,28 +256,47 @@ where
             transaction::MutablePage::InTransaction(handle) => handle,
         };
 
-        let (parent, left, right) = if let Some((parent, _anchor, left, right)) = parent_info {
-            let left = left.and_then(|id| self.tx.get_page(id));
-            let right = right.and_then(|id| self.tx.get_page(id));
-            let parent = match self.tx.mut_page(*parent).unwrap() {
-                MutablePage::InTransaction(handle) => handle,
-                _ => unreachable!(),
-            };
+        let mut_context = match parent_info {
+            Some((parent, _anchor, left_id, right_id)) => {
+                let parent = match self.tx.mut_page(*parent)? {
+                    MutablePage::InTransaction(handle) => handle,
+                    _ => unreachable!(),
+                };
+                Some(MutableContext {
+                    parent,
+                    // anchor is an index into the keys array of a node used to find the current node in the parent without searching. The leftmost(lowest) child has None as anchor
+                    // this means it's inmediate right sibling would have anchor of 0, and so on.
+                    left_id,
+                    right_id,
+                    current_id: id,
+                    backtrack: self,
+                })
+            }
+            None => None,
+        };
 
-            (Some(parent), left, right)
-        } else {
-            (None, None, None)
+        let (left, right) = match parent_info {
+            Some((_parent, _anchor, left, right)) => {
+                let left = left.and_then(|id| self.tx.get_page(id));
+                let right = right.and_then(|id| self.tx.get_page(id));
+
+                (left, right)
+            }
+            None => (None, None),
         };
 
         let anchor = parent_info.and_then(|(_, anchor, _, _)| anchor);
-
-        Ok(Some(DeleteNextElement {
+        let next_element = NextElement {
             next,
-            parent,
             anchor,
             left,
             right,
             backtrack: self,
+        };
+
+        Ok(Some(DeleteNextElement {
+            next_element,
+            mut_context,
         }))
     }
 
@@ -329,7 +376,7 @@ where
 
         let key_buffer_size = usize::try_from(self.tx.key_buffer_size).unwrap();
 
-        match self.tx.mut_page(id)? {
+        match self.tx.mut_page(dbg!(id))? {
             transaction::MutablePage::NeedsParentRedirect(rename_in_parents) => {
                 // this part may be tricky, we need to recursively clone and redirect all the path
                 // from the root to the node we are writing to. We need the backtrack stack, because

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -77,14 +77,7 @@ where
 
         let first_page_id = metadata.page_manager.new_id();
 
-        let mut root_page = match pages.mut_page(first_page_id) {
-            Ok(page) => page,
-            Err(_) => {
-                pages.extend(first_page_id)?;
-                // this is infallible now
-                pages.mut_page(first_page_id).unwrap()
-            }
-        };
+        let mut root_page = pages.mut_page(first_page_id)?;
 
         root_page.as_slice(|page| {
             Node::<K, &mut [u8]>::new_leaf(key_buffer_size.try_into().unwrap(), page);
@@ -243,7 +236,7 @@ where
 
     pub(crate) fn insert_in_leaf<'a, 'b: 'a>(
         &self,
-        mut leaf: PageRefMut<'a, 'b>,
+        mut leaf: PageRefMut<'a>,
         key: K,
         value: Value,
     ) -> Result<Option<(K, Node<K, MemPage>)>, BTreeStoreError> {

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -68,7 +68,7 @@ where
     ) -> Result<BTree<K>, BTreeStoreError> {
         let mut metadata = Metadata::new();
 
-        let pages_storage = crate::storage::MmapStorage::new(tree_file)?;
+        let pages_storage = crate::storage::MmapStorage::new(tree_file, None)?;
 
         let mut pages = Pages::new(PagesInitializationParams {
             storage: pages_storage,
@@ -117,7 +117,7 @@ where
         static_settings_file: impl AsRef<Path>,
     ) -> Result<BTree<K>, BTreeStoreError> {
         let tree_file = OpenOptions::new().write(true).read(true).open(tree_file)?;
-        let pages_storage = crate::storage::MmapStorage::new(tree_file)?;
+        let pages_storage = crate::storage::MmapStorage::new(tree_file, None)?;
 
         let mut static_settings_file = OpenOptions::new()
             .write(true)

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -236,9 +236,11 @@ mod tests {
     use std::mem::size_of;
     use tempfile::tempfile;
 
+    pub const PAGE_SIZE: u64 = (1 << 20) * 128; // 128mb
+
     pub fn pages() -> Pages {
         let page_size = 8 + 8 + 3 * size_of::<U64Key>() + 5 * size_of::<PageId>() + 4 + 8;
-        let storage = MmapStorage::new(tempfile().unwrap(), None).unwrap();
+        let storage = MmapStorage::new(tempfile().unwrap(), PAGE_SIZE).unwrap();
         let params = PagesInitializationParams {
             storage,
             page_size: page_size as u16,
@@ -246,7 +248,6 @@ mod tests {
         };
 
         let pages = Pages::new(params);
-        pages.mut_page(300).unwrap();
         pages
     }
 

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -238,14 +238,14 @@ mod tests {
 
     pub fn pages() -> Pages {
         let page_size = 8 + 8 + 3 * size_of::<U64Key>() + 5 * size_of::<PageId>() + 4 + 8;
-        let storage = MmapStorage::new(tempfile().unwrap()).unwrap();
+        let storage = MmapStorage::new(tempfile().unwrap(), None).unwrap();
         let params = PagesInitializationParams {
             storage,
             page_size: page_size as u16,
             key_buffer_size: size_of::<U64Key>() as u32,
         };
 
-        let mut pages = Pages::new(params);
+        let pages = Pages::new(params);
         pages.extend(300).unwrap();
         pages
     }

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -246,7 +246,7 @@ mod tests {
         };
 
         let pages = Pages::new(params);
-        pages.extend(300).unwrap();
+        pages.mut_page(300).unwrap();
         pages
     }
 

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -100,8 +100,8 @@ impl Pages {
         Ok(())
     }
 
-    pub fn extend(&mut self, to: PageId) -> Result<(), std::io::Error> {
-        let storage = &mut self.storage;
+    pub fn extend(&self, to: PageId) -> Result<(), std::io::Error> {
+        let storage = &self.storage;
 
         let from = u64::from(to.checked_sub(1).expect("0 page is used as a null ptr"))
             * u64::from(self.page_size);

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -101,15 +101,6 @@ impl Pages {
         Ok(())
     }
 
-    // pub fn extend(&self, to: PageId) -> Result<(), std::io::Error> {
-    //     let storage = &self.storage;
-
-    //     let from = u64::from(to.checked_sub(1).expect("0 page is used as a null ptr"))
-    //         * u64::from(self.page_size);
-
-    //     storage.extend(from + u64::from(self.page_size))
-    // }
-
     pub(crate) fn sync_file(&self) -> Result<(), std::io::Error> {
         self.storage.sync()
     }

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -73,14 +73,13 @@ impl TransactionManager {
         self.latest_version.read().clone()
     }
 
-    pub fn read_transaction<'a>(&self, pages: &'a RwLock<Pages>) -> ReadTransaction<'a> {
-        let guard = pages.read();
-        ReadTransaction::new(self.latest_version(), guard)
+    pub fn read_transaction<'a>(&self, pages: &'a Pages) -> ReadTransaction<'a> {
+        ReadTransaction::new(self.latest_version(), pages)
     }
 
     pub fn insert_transaction<'me, 'index: 'me>(
         &'me self,
-        pages: &'index RwLock<Pages>,
+        pages: &'index Pages,
         key_buffer_size: u32,
     ) -> WriteTransaction<'me, 'index> {
         let page_manager = self.page_manager.lock().unwrap();

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -21,7 +21,9 @@ const MAGIC_SIZE: usize = 8;
 const MAGIC: [u8; MAGIC_SIZE] = [0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88];
 const DATA_START: u64 = 4096;
 
-const MAP_PAGE_SIZE: u64 = crate::storage::DEFAULT_PAGE_SIZE;
+/// Page size of underlying storage. If a blob can't be stored in the current page, we write it at the beginning of the next page.
+/// As this may lead to wasted space, is important to choose the page size accordingly with the expected blob sizes
+const MAP_PAGE_SIZE: u64 = (1 << 20) * 128; // 128mb, this allows 8 max size blobs
 
 /// Appender store blob of data (each of maximum size of 16 Mb) offering
 /// also a direct access to known index whilst it is appended
@@ -49,7 +51,7 @@ impl MmapedAppendOnlyFile {
             .write(true)
             .open(&filename)?;
 
-        let storage = MmapStorage::new(file, Some(MAP_PAGE_SIZE))?;
+        let storage = MmapStorage::new(file, MAP_PAGE_SIZE)?;
         let next_pos = storage.len();
 
         unsafe {

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -209,10 +209,10 @@ mod test {
 
         let appender = MmapedAppendOnlyFile::new(path).unwrap();
 
-        let mut rng = StdRng::seed_from_u64(SEED);
+        let rng = StdRng::seed_from_u64(SEED);
 
         for _ in 0..(MAP_PAGE_SIZE - 1) / MAX_BLOB_SIZE as u64 {
-            let mut buf = vec![0u8; MAX_BLOB_SIZE];
+            let buf = vec![0u8; MAX_BLOB_SIZE];
             appender.append(&buf).unwrap();
         }
 

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -209,16 +209,14 @@ mod test {
 
         let appender = MmapedAppendOnlyFile::new(path).unwrap();
 
-        let rng = StdRng::seed_from_u64(SEED);
-
         for _ in 0..(MAP_PAGE_SIZE - 1) / MAX_BLOB_SIZE as u64 {
             let buf = vec![0u8; MAX_BLOB_SIZE];
             appender.append(&buf).unwrap();
         }
 
-        let mut buf = vec![0u8; MAX_BLOB_SIZE];
+        let buf = vec![0u8; MAX_BLOB_SIZE];
         let pos = appender.append(&buf[..]).unwrap();
 
-        assert_eq!(pos.0, dbg!(MAP_PAGE_SIZE))
+        assert_eq!(pos.0, MAP_PAGE_SIZE)
     }
 }

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -1,14 +1,15 @@
 use crate::storage::MmapStorage;
-use parking_lot::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
+
 use std::convert::TryInto;
 use std::io::{self, Error, ErrorKind, Write};
+
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{fs, path};
 
 pub const SZ_BITS: usize = 24;
 pub const POS_BITS: u64 = 40;
-pub const MAX_BLOB_SIZE: usize = 2 << SZ_BITS; // 16MB blob
-pub const MAX_POS_OFFSET: u64 = 2 << POS_BITS - 1; // last possible position 1byte below 1TB
+pub const MAX_BLOB_SIZE: usize = 1 << SZ_BITS; // 16MB blob
+pub const MAX_POS_OFFSET: u64 = 1 << POS_BITS - 1; // last possible position 1byte below 1TB
 
 /// Position of a blob in an appender
 ///
@@ -20,10 +21,12 @@ const MAGIC_SIZE: usize = 8;
 const MAGIC: [u8; MAGIC_SIZE] = [0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88];
 const DATA_START: u64 = 4096;
 
+const MAP_PAGE_SIZE: u64 = crate::storage::DEFAULT_PAGE_SIZE;
+
 /// Appender store blob of data (each of maximum size of 16 Mb) offering
 /// also a direct access to known index whilst it is appended
 pub struct MmapedAppendOnlyFile {
-    storage: RwLock<MmapStorage>,
+    storage: MmapStorage,
     next_pos: AtomicU64,
 }
 
@@ -46,7 +49,7 @@ impl MmapedAppendOnlyFile {
             .write(true)
             .open(&filename)?;
 
-        let storage = MmapStorage::new(file)?;
+        let storage = MmapStorage::new(file, Some(MAP_PAGE_SIZE))?;
         let next_pos = storage.len();
 
         unsafe {
@@ -56,7 +59,7 @@ impl MmapedAppendOnlyFile {
         }
 
         Ok(Self {
-            storage: RwLock::new(storage),
+            storage,
             next_pos: AtomicU64::new(next_pos),
         })
     }
@@ -82,8 +85,8 @@ impl MmapedAppendOnlyFile {
         //     ));
         // }
 
-        let next_pos = self.next_pos.load(Ordering::Acquire);
-        let mut storage = self.storage.upgradable_read();
+        // next_pos is the return value, the mut part is because if there is no space in the current underlying page, we need to move this to the next page boundary
+        let mut next_pos = self.next_pos.load(Ordering::Acquire);
 
         if next_pos > MAX_POS_OFFSET {
             return Err(Error::new(ErrorKind::Other, "offset position too big"));
@@ -95,55 +98,51 @@ impl MmapedAppendOnlyFile {
         let region_len = szbuf.len() as u64 + buf.len() as u64;
 
         let mmaped_region = unsafe {
-            match storage.get_mut(next_pos, region_len) {
-                Ok(slice) => slice,
-                Err(including) => {
-                    {
-                        let mut new_guard = RwLockUpgradableReadGuard::upgrade(storage);
-                        new_guard.extend(including)?;
-                        // the upgradable part here is only so we can assign to the storage variable again
-                        // we won't upgrade again
-                        storage = RwLockWriteGuard::downgrade_to_upgradable(new_guard);
-                    }
-                    storage.get_mut(next_pos, region_len).unwrap()
-                }
+            let region = self.storage.get_mut(next_pos, region_len)?;
+            let mapped_len = region.len() as u64;
+
+            // check if we could write everything in a contiguous chunk
+            if mapped_len == region_len {
+                self.next_pos
+                    .store(next_pos + region_len, Ordering::Release);
+                region
+            } else {
+                // if we can't, then we just skip that part and write in the next page and hope it fits
+                next_pos = next_pos + mapped_len;
+                self.next_pos
+                    .store(next_pos + region_len, Ordering::Release);
+                self.storage.get_mut(next_pos, region_len)?
             }
         };
 
-        self.next_pos
-            .store(next_pos + region_len, Ordering::Release);
+        if (mmaped_region.len() as u64) < region_len {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Couldn't map contiguous region, page size is smaller than blob size",
+            ));
+        }
 
         mmaped_region[0..szbuf.len()].copy_from_slice(&szbuf[..]);
         mmaped_region[szbuf.len()..].copy_from_slice(&buf[..]);
 
-        // self.ahandle.sync_data()?;
         Ok(Pos(next_pos))
     }
 
     /// Get the blob stored at position @pos
-    pub fn get_at(&self, pos: Pos) -> Result<Box<[u8]>, io::Error> {
+    pub fn get_at(&self, pos: Pos) -> Result<Option<&[u8]>, io::Error> {
         if pos.0 >= self.next_pos.load(Ordering::SeqCst) {
-            // it could also be an option, but it shouldn't happen in our usecase anyway
-            // and so, adding an option just for that may be bothersome
-            return Ok(vec![].into_boxed_slice());
+            return Ok(None);
         }
 
-        let storage = self.storage.read();
-        let szbuf = unsafe { storage.get(pos.into(), 4) };
+        let szbuf = unsafe { self.storage.get(pos.into(), 4) };
 
         let len = u32::from_le_bytes(szbuf.try_into().unwrap());
 
-        let mut v = vec![0u8; len as usize];
-
-        unsafe {
-            v.copy_from_slice(storage.get(pos.0 + 4, len as u64));
-        }
-
-        Ok(v.into())
+        Ok(Some(unsafe { self.storage.get(pos.0 + 4, len as u64) }))
     }
 
     pub fn sync(&self) -> Result<(), io::Error> {
-        self.storage.read().sync()?;
+        self.storage.sync()?;
         Ok(())
     }
 }
@@ -195,7 +194,31 @@ mod test {
         }
 
         for (pos, value) in reference.iter() {
-            assert_eq!(appender.get_at(*pos).unwrap()[..], value[..])
+            assert_eq!(appender.get_at(*pos).unwrap().unwrap()[..], value[..])
         }
+    }
+
+    #[test]
+    fn test_need_to_skip_space() {
+        // the appender does need to create the file, as it applies the initial formatting. This means
+        // we can't create a temp file directly, so instead we create a temporal directory and then the
+        // appender can create a file inside
+        let dir = tempdir().unwrap();
+        let mut path = dir.path().to_path_buf();
+        path.push("appender_skip_space");
+
+        let appender = MmapedAppendOnlyFile::new(path).unwrap();
+
+        let mut rng = StdRng::seed_from_u64(SEED);
+
+        for _ in 0..(MAP_PAGE_SIZE - 1) / MAX_BLOB_SIZE as u64 {
+            let mut buf = vec![0u8; MAX_BLOB_SIZE];
+            appender.append(&buf).unwrap();
+        }
+
+        let mut buf = vec![0u8; MAX_BLOB_SIZE];
+        let pos = appender.append(&buf[..]).unwrap();
+
+        assert_eq!(pos.0, dbg!(MAP_PAGE_SIZE))
     }
 }

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -108,6 +108,7 @@ impl MmapedAppendOnlyFile {
                 region
             } else {
                 // if we can't, then we just skip that part and write in the next page and hope it fits
+                // we don't write in two different pages in order to just be able to return slices to the mmaped region
                 next_pos = next_pos + mapped_len;
                 self.next_pos
                     .store(next_pos + region_len, Ordering::Release);

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -156,10 +156,10 @@ where
         Ok(())
     }
 
-    pub fn get(&self, key: &K) -> Result<Option<Box<[u8]>>, BTreeStoreError> {
+    pub fn get(&self, key: &K) -> Result<Option<&[u8]>, BTreeStoreError> {
         self.index
             .lookup(&key)
-            .map(|pos| self.flatfile.get_at((pos).into()))
+            .and_then(|pos| self.flatfile.get_at((pos).into()).transpose())
             .transpose()
             .map_err(|e| e.into())
     }

--- a/btree/src/storage.rs
+++ b/btree/src/storage.rs
@@ -10,81 +10,34 @@ use std::mem::ManuallyDrop;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
+pub const DEFAULT_PAGE_SIZE: u64 = (1 << 20) * 128; // 128mb
+
 pub struct MmapStorage {
     pages: ManuallyDrop<PageTable>,
     file_len: AtomicU64,
     allocated_size: AtomicU64,
     file: *mut File,
+    page_size: u64,
 }
 
 type PageId = u64;
-const PAGE_SIZE: u64 = (1 << 20) * 128; // 128mb
-
-struct Page {
-    map: UnsafeCell<MmapMut>,
-}
-
-impl Page {
-    fn new(map: MmapMut) -> Self {
-        Self {
-            map: UnsafeCell::new(map),
-        }
-    }
-
-    unsafe fn read(&self) -> *const u8 {
-        (*self.map.get()).as_ref().as_ptr()
-    }
-
-    unsafe fn write(&self) -> *mut u8 {
-        (*self.map.get()).as_mut().as_mut_ptr()
-    }
-
-    fn sync(&self) -> Result<(), io::Error> {
-        unsafe { (*self.map.get()).flush() }
-    }
-}
 
 struct PageTable {
     // TODO: A vector would be probably be a decent choice too
     lookup: Mutex<HashMap<PageId, Page>>,
+    page_size: u64,
 }
-
-impl PageTable {
-    unsafe fn get_page(&self, id: PageId) -> Option<&[u8]> {
-        self.lookup
-            .lock()
-            .unwrap()
-            .get(&id)
-            .map(|page| std::slice::from_raw_parts(page.read(), PAGE_SIZE.try_into().unwrap()))
-    }
-
-    unsafe fn get_page_mut(&self, id: PageId) -> Option<&mut [u8]> {
-        self.lookup
-            .lock()
-            .unwrap()
-            .get(&id)
-            .map(|page| std::slice::from_raw_parts_mut(page.write(), PAGE_SIZE.try_into().unwrap()))
-    }
-
-    fn sync(&self) -> Result<(), io::Error> {
-        for page in self.lookup.lock().unwrap().values() {
-            page.sync()?;
-        }
-
-        Ok(())
-    }
-
-    pub fn add_page(&self, id: PageId, page: Page) {
-        self.lookup.lock().unwrap().insert(id, page);
-    }
+struct Page {
+    map: UnsafeCell<MmapMut>,
 }
 
 impl MmapStorage {
-    pub fn new(file: File) -> Result<Self, io::Error> {
+    pub fn new(file: File, page_size: Option<u64>) -> Result<Self, io::Error> {
         let file_len = file.metadata()?.len();
 
-        let (page_id, _offset) = absolute_offset_to_relative(file_len);
-        let allocated_size = (page_id + 1) * PAGE_SIZE;
+        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        let (page_id, _offset) = absolute_offset_to_relative(page_size, file_len);
+        let allocated_size = (page_id + 1) * page_size;
 
         file.set_len(allocated_size)?;
 
@@ -93,6 +46,7 @@ impl MmapStorage {
 
         let pages = ManuallyDrop::new(PageTable {
             lookup: Mutex::new(HashMap::new()),
+            page_size,
         });
 
         Ok(MmapStorage {
@@ -100,22 +54,23 @@ impl MmapStorage {
             file,
             file_len: AtomicU64::new(file_len),
             allocated_size: AtomicU64::new(allocated_size),
+            page_size,
         })
     }
 
     /// this call is unsafe because get_mut is &self and not &mut self, so this could lead to mutable aliasing
     /// this panics if the location (+ count) is out of range, though
     pub unsafe fn get(&self, location: u64, count: u64) -> &[u8] {
-        let (page_id, offset) = absolute_offset_to_relative(location);
+        let (page_id, offset) = absolute_offset_to_relative(self.page_size, location);
         match self.pages.get_page(page_id as PageId) {
             Some(page) => {
-                &page[offset..min(offset + count as usize, PAGE_SIZE.try_into().unwrap())]
+                &page[offset..min(offset + count as usize, self.page_size.try_into().unwrap())]
             }
             None => {
                 let page = Page::new(
                     memmap::MmapOptions::new()
-                        .offset(page_id * PAGE_SIZE)
-                        .len(PAGE_SIZE as usize)
+                        .offset(page_id * self.page_size)
+                        .len(self.page_size as usize)
                         .map_mut(&*self.file)
                         .expect("couldn't mmap page"),
                 );
@@ -141,16 +96,17 @@ impl MmapStorage {
 
         let count: usize = count.try_into().unwrap();
 
-        let (page_id, offset) = absolute_offset_to_relative(location);
+        let (page_id, offset) = absolute_offset_to_relative(self.page_size, location);
 
         match self.pages.get_page_mut(page_id) {
             Some(page) => {
-                Ok(&mut page[offset..min(offset + count as usize, PAGE_SIZE.try_into().unwrap())])
+                Ok(&mut page
+                    [offset..min(offset + count as usize, self.page_size.try_into().unwrap())])
             }
             None => {
                 let page = memmap::MmapOptions::new()
-                    .offset(page_id * PAGE_SIZE)
-                    .len(PAGE_SIZE as usize)
+                    .offset(page_id * self.page_size)
+                    .len(self.page_size as usize)
                     .map_mut(&*self.file)
                     .expect("Couldn't map page");
 
@@ -163,8 +119,9 @@ impl MmapStorage {
 
     pub fn extend(&self, minimum_required_size: u64) -> Result<(), io::Error> {
         if minimum_required_size > self.allocated_size.load(Ordering::Acquire) {
-            let (page_id, _offset) = absolute_offset_to_relative(minimum_required_size);
-            let new_size = (page_id + 1) * PAGE_SIZE;
+            let (page_id, _offset) =
+                absolute_offset_to_relative(self.page_size, minimum_required_size);
+            let new_size = (page_id + 1) * self.page_size;
             // TODO: Is the new expanded section zeroed or something?
             unsafe {
                 (&mut *self.file).set_len(new_size)?;
@@ -187,6 +144,54 @@ impl MmapStorage {
     }
 }
 
+impl Page {
+    fn new(map: MmapMut) -> Self {
+        Self {
+            map: UnsafeCell::new(map),
+        }
+    }
+
+    unsafe fn read(&self) -> *const u8 {
+        (*self.map.get()).as_ref().as_ptr()
+    }
+
+    unsafe fn write(&self) -> *mut u8 {
+        (*self.map.get()).as_mut().as_mut_ptr()
+    }
+
+    fn sync(&self) -> Result<(), io::Error> {
+        unsafe { (*self.map.get()).flush() }
+    }
+}
+
+impl PageTable {
+    unsafe fn get_page(&self, id: PageId) -> Option<&[u8]> {
+        self.lookup
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|page| std::slice::from_raw_parts(page.read(), self.page_size.try_into().unwrap()))
+    }
+
+    unsafe fn get_page_mut(&self, id: PageId) -> Option<&mut [u8]> {
+        self.lookup.lock().unwrap().get(&id).map(|page| {
+            std::slice::from_raw_parts_mut(page.write(), self.page_size.try_into().unwrap())
+        })
+    }
+
+    fn sync(&self) -> Result<(), io::Error> {
+        for page in self.lookup.lock().unwrap().values() {
+            page.sync()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn add_page(&self, id: PageId, page: Page) {
+        self.lookup.lock().unwrap().insert(id, page);
+    }
+}
+
 impl Drop for MmapStorage {
     fn drop(&mut self) {
         // self.mmap has reference (with an erased lifetime) to the file handle, so we must ensure that it
@@ -199,9 +204,9 @@ impl Drop for MmapStorage {
     }
 }
 
-fn absolute_offset_to_relative(offset: u64) -> (PageId, usize) {
-    let page_id = offset / PAGE_SIZE;
-    let offset = offset % PAGE_SIZE;
+fn absolute_offset_to_relative(page_size: u64, offset: u64) -> (PageId, usize) {
+    let page_id = offset / page_size;
+    let offset = offset % page_size;
     (page_id, offset.try_into().unwrap())
 }
 
@@ -213,25 +218,27 @@ mod tests {
     #[test]
     fn mmap_pagination() {
         let file = tempfile().unwrap();
-        let mut storage = MmapStorage::new(file).unwrap();
+        let storage = MmapStorage::new(file, None).unwrap();
 
         let pages = [1u8, 5, 9];
         let mut results = vec![];
 
         for page in pages.iter() {
             {
-                for byte in unsafe { storage.get_mut(*page as u64 * PAGE_SIZE, PAGE_SIZE) }
-                    .expect("Couldn't expand file")
+                for byte in
+                    unsafe { storage.get_mut(*page as u64 * DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE) }
+                        .expect("Couldn't expand file")
                 {
                     *byte = *page;
                 }
             }
-            let result = unsafe { storage.get(*page as u64 * PAGE_SIZE, PAGE_SIZE) };
+            let result =
+                unsafe { storage.get(*page as u64 * DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE) };
             results.push((page, result));
         }
 
         for (page, result) in results {
-            assert_eq!(result.len(), PAGE_SIZE as usize);
+            assert_eq!(result.len(), DEFAULT_PAGE_SIZE as usize);
             // check the first and last elements to make sure that the ranges are mapped correctly
             for b in result.iter().take(10).chain(result.iter().rev().take(10)) {
                 assert_eq!(b, page);
@@ -242,16 +249,21 @@ mod tests {
     #[test]
     fn non_contiguous_chunk() {
         let file = tempfile().unwrap();
-        let mut storage = MmapStorage::new(file).unwrap();
+        let storage = MmapStorage::new(file, None).unwrap();
 
         assert_eq!(
-            unsafe { storage.get(PAGE_SIZE / 2, PAGE_SIZE).len() },
-            PAGE_SIZE as usize / 2
+            unsafe { storage.get(DEFAULT_PAGE_SIZE / 2, DEFAULT_PAGE_SIZE).len() },
+            DEFAULT_PAGE_SIZE as usize / 2
         );
 
         assert_eq!(
-            unsafe { storage.get_mut(PAGE_SIZE / 2, PAGE_SIZE).unwrap().len() },
-            PAGE_SIZE as usize / 2
+            unsafe {
+                storage
+                    .get_mut(DEFAULT_PAGE_SIZE / 2, DEFAULT_PAGE_SIZE)
+                    .unwrap()
+                    .len()
+            },
+            DEFAULT_PAGE_SIZE as usize / 2
         );
     }
 }

--- a/btree/src/storage.rs
+++ b/btree/src/storage.rs
@@ -1,50 +1,136 @@
 use memmap::MmapMut;
 use std::cell::UnsafeCell;
 
+use std::cmp::min;
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fs::File;
 use std::io;
 use std::mem::ManuallyDrop;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 
 pub struct MmapStorage {
-    mmap: ManuallyDrop<UnsafeCell<MmapMut>>,
+    pages: ManuallyDrop<PageTable>,
     file_len: AtomicU64,
-    allocated_size: u64,
+    allocated_size: AtomicU64,
     file: *mut File,
+}
+
+type PageId = u64;
+const PAGE_SIZE: u64 = (1 << 20) * 128; // 128mb
+
+struct Page {
+    map: UnsafeCell<MmapMut>,
+}
+
+impl Page {
+    fn new(map: MmapMut) -> Self {
+        Self {
+            map: UnsafeCell::new(map),
+        }
+    }
+
+    unsafe fn read(&self) -> *const u8 {
+        (*self.map.get()).as_ref().as_ptr()
+    }
+
+    unsafe fn write(&self) -> *mut u8 {
+        (*self.map.get()).as_mut().as_mut_ptr()
+    }
+
+    fn sync(&self) -> Result<(), io::Error> {
+        unsafe { (*self.map.get()).flush() }
+    }
+}
+
+struct PageTable {
+    // TODO: A vector would be probably be a decent choice too
+    lookup: Mutex<HashMap<PageId, Page>>,
+}
+
+impl PageTable {
+    unsafe fn get_page(&self, id: PageId) -> Option<&[u8]> {
+        self.lookup
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|page| std::slice::from_raw_parts(page.read(), PAGE_SIZE.try_into().unwrap()))
+    }
+
+    unsafe fn get_page_mut(&self, id: PageId) -> Option<&mut [u8]> {
+        self.lookup
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|page| std::slice::from_raw_parts_mut(page.write(), PAGE_SIZE.try_into().unwrap()))
+    }
+
+    fn sync(&self) -> Result<(), io::Error> {
+        for page in self.lookup.lock().unwrap().values() {
+            page.sync()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn add_page(&self, id: PageId, page: Page) {
+        self.lookup.lock().unwrap().insert(id, page);
+    }
 }
 
 impl MmapStorage {
     pub fn new(file: File) -> Result<Self, io::Error> {
         let file_len = file.metadata()?.len();
 
-        let allocated_size = file_len.next_power_of_two();
+        let (page_id, _offset) = absolute_offset_to_relative(file_len);
+        let allocated_size = (page_id + 1) * PAGE_SIZE;
+
         file.set_len(allocated_size)?;
 
         let boxed_file = Box::new(file);
         let file = Box::into_raw(boxed_file);
-        unsafe {
-            Ok(MmapStorage {
-                mmap: ManuallyDrop::new(UnsafeCell::new(MmapMut::map_mut(&*file)?)),
-                file,
-                file_len: AtomicU64::new(file_len),
-                allocated_size,
-            })
-        }
+
+        let pages = ManuallyDrop::new(PageTable {
+            lookup: Mutex::new(HashMap::new()),
+        });
+
+        Ok(MmapStorage {
+            pages,
+            file,
+            file_len: AtomicU64::new(file_len),
+            allocated_size: AtomicU64::new(allocated_size),
+        })
     }
 
     /// this call is unsafe because get_mut is &self and not &mut self, so this could lead to mutable aliasing
     /// this panics if the location (+ count) is out of range, though
     pub unsafe fn get(&self, location: u64, count: u64) -> &[u8] {
-        let location: usize = location.try_into().unwrap();
-        let count: usize = count.try_into().unwrap();
-        &(*self.mmap.get())[location..location + count]
+        let (page_id, offset) = absolute_offset_to_relative(location);
+        match self.pages.get_page(page_id as PageId) {
+            Some(page) => {
+                &page[offset..min(offset + count as usize, PAGE_SIZE.try_into().unwrap())]
+            }
+            None => {
+                let page = Page::new(
+                    memmap::MmapOptions::new()
+                        .offset(page_id * PAGE_SIZE)
+                        .len(PAGE_SIZE as usize)
+                        .map_mut(&*self.file)
+                        .expect("couldn't mmap page"),
+                );
+
+                self.pages.add_page(page_id, page);
+
+                self.get(location, count)
+            }
+        }
     }
 
     /// caller must enforce that there is no aliasing here
-    pub unsafe fn get_mut(&self, location: u64, count: u64) -> Result<&mut [u8], u64> {
-        if location + count > self.allocated_size {
-            return Err(location + count);
+    pub unsafe fn get_mut(&self, location: u64, count: u64) -> Result<&mut [u8], io::Error> {
+        if location + count > self.allocated_size.load(Ordering::SeqCst) {
+            self.extend(location + count)?;
         }
 
         // the file_len is only used in the destructor, to make the file's size on disk be the right one,
@@ -53,37 +139,47 @@ impl MmapStorage {
             self.file_len.store(location + count, Ordering::Release);
         }
 
-        let location: usize = location.try_into().unwrap();
         let count: usize = count.try_into().unwrap();
 
-        // this unwrap can't fail because we already checked for size before
-        // I don't think we need any extra synchronization here,
-        // at least I don't think get_mut modifies any shared state
+        let (page_id, offset) = absolute_offset_to_relative(location);
 
-        Ok((*self.mmap.get())
-            .get_mut(location..location + count)
-            .unwrap())
+        match self.pages.get_page_mut(page_id) {
+            Some(page) => {
+                Ok(&mut page[offset..min(offset + count as usize, PAGE_SIZE.try_into().unwrap())])
+            }
+            None => {
+                let page = memmap::MmapOptions::new()
+                    .offset(page_id * PAGE_SIZE)
+                    .len(PAGE_SIZE as usize)
+                    .map_mut(&*self.file)
+                    .expect("Couldn't map page");
+
+                self.pages.add_page(page_id, Page::new(page));
+
+                Ok(&mut self.pages.get_page_mut(page_id).unwrap()[offset..offset + count as usize])
+            }
+        }
     }
 
-    pub fn extend(&mut self, minimum_required_size: u64) -> Result<(), io::Error> {
-        if minimum_required_size > self.allocated_size {
-            self.allocated_size = minimum_required_size.next_power_of_two();
-
-            // we need to extend the file, so we unmap, extend and remap
+    pub fn extend(&self, minimum_required_size: u64) -> Result<(), io::Error> {
+        if minimum_required_size > self.allocated_size.load(Ordering::Acquire) {
+            let (page_id, _offset) = absolute_offset_to_relative(minimum_required_size);
+            let new_size = (page_id + 1) * PAGE_SIZE;
+            // TODO: Is the new expanded section zeroed or something?
             unsafe {
-                // it's really important to flush here
-                self.sync()?;
-                ManuallyDrop::drop(&mut self.mmap);
-                (&mut *self.file).set_len(self.allocated_size)?;
-                self.mmap = ManuallyDrop::new(UnsafeCell::new(MmapMut::map_mut(&*self.file)?));
+                (&mut *self.file).set_len(new_size)?;
             }
+            self.allocated_size.store(new_size, Ordering::Release);
+
+            self.sync()?;
         }
         Ok(())
     }
 
     pub fn sync(&self) -> Result<(), io::Error> {
         // there is nothing really unsafe here, we need the block only because of unsafe cell (at least nothing that is not already present in the memmap api)
-        unsafe { &*self.mmap.get() }.flush()
+        // unsafe { &*self.mmap.get() }.flush()
+        self.pages.sync()
     }
 
     pub fn len(&self) -> u64 {
@@ -96,11 +192,17 @@ impl Drop for MmapStorage {
         // self.mmap has reference (with an erased lifetime) to the file handle, so we must ensure that it
         // gets dropped first
         unsafe {
-            ManuallyDrop::drop(&mut self.mmap);
+            ManuallyDrop::drop(&mut self.pages);
             let file = Box::from_raw(self.file);
             file.set_len(self.file_len.load(Ordering::Acquire)).unwrap();
         }
     }
+}
+
+fn absolute_offset_to_relative(offset: u64) -> (PageId, usize) {
+    let page_id = offset / PAGE_SIZE;
+    let offset = offset % PAGE_SIZE;
+    (page_id, offset.try_into().unwrap())
 }
 
 #[cfg(test)]
@@ -109,23 +211,47 @@ mod tests {
     use tempfile::tempfile;
 
     #[test]
-    fn mmap_put_and_get() {
+    fn mmap_pagination() {
         let file = tempfile().unwrap();
         let mut storage = MmapStorage::new(file).unwrap();
 
-        let expected = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let pages = [1u8, 5, 9];
+        let mut results = vec![];
 
-        match unsafe { storage.get_mut(30, 10) } {
-            Ok(_) => panic!("Should need resize"),
-            Err(pos) => storage.extend(pos).unwrap(),
+        for page in pages.iter() {
+            {
+                for byte in unsafe { storage.get_mut(*page as u64 * PAGE_SIZE, PAGE_SIZE) }
+                    .expect("Couldn't expand file")
+                {
+                    *byte = *page;
+                }
+            }
+            let result = unsafe { storage.get(*page as u64 * PAGE_SIZE, PAGE_SIZE) };
+            results.push((page, result));
         }
 
-        unsafe { storage.get_mut(30, 10) }
-            .expect("Shouldn't need resize anymore")
-            .copy_from_slice(&expected);
+        for (page, result) in results {
+            assert_eq!(result.len(), PAGE_SIZE as usize);
+            // check the first and last elements to make sure that the ranges are mapped correctly
+            for b in result.iter().take(10).chain(result.iter().rev().take(10)) {
+                assert_eq!(b, page);
+            }
+        }
+    }
 
-        let result = unsafe { storage.get(30, expected.len().try_into().unwrap()) };
+    #[test]
+    fn non_contiguous_chunk() {
+        let file = tempfile().unwrap();
+        let mut storage = MmapStorage::new(file).unwrap();
 
-        assert_eq!(result, &expected[..]);
+        assert_eq!(
+            unsafe { storage.get(PAGE_SIZE / 2, PAGE_SIZE).len() },
+            PAGE_SIZE as usize / 2
+        );
+
+        assert_eq!(
+            unsafe { storage.get_mut(PAGE_SIZE / 2, PAGE_SIZE).unwrap().len() },
+            PAGE_SIZE as usize / 2
+        );
     }
 }

--- a/btree/src/storage.rs
+++ b/btree/src/storage.rs
@@ -11,7 +11,7 @@ use std::mem::ManuallyDrop;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Wrapper over an mmaped file with extension capabilities
-/// The underlying file is split into multiple pages, this makes way the pointers(slices) are never invalidated, at the expense of not being to able to 
+/// The underlying file is split into multiple pages, this makes way the pointers(slices) are never invalidated, at the expense of not being to able to
 /// operate on chunks spanning multiple pages as contiguous data.
 /// The API provided is mostly unsafe, as there is no aliasing checks, it's expected to be done at a higher level.
 pub struct MmapStorage {

--- a/btree/src/storage.rs
+++ b/btree/src/storage.rs
@@ -138,8 +138,6 @@ impl MmapStorage {
     }
 
     pub fn sync(&self) -> Result<(), io::Error> {
-        // there is nothing really unsafe here, we need the .read() only because of unsafe cell (at least nothing that is not already present in the memmap api)
-        // unsafe { &*self.mmap.get() }.flush()
         self.pages.sync()
     }
 


### PR DESCRIPTION
Based on https://github.com/input-output-hk/chain-libs/pull/292#discussion_r394167482

# About
Extend mmaped region by pages instead of unmapping and remapping whole file. Using a hashmap to translate absolute positions to (page, offset)

## Index (tree nodes/pages)

Now write transactions never need to wait for read transactions to end. This was needed previously when extending, as the read transactions had pointers that couldn't be invalidated. This means now readers and writers can't block each other.

## Appender
 This allows returning slices to the maped area, removing the need for cloning on reads.
### Possible problem
 As blobs are of arbitrary size, unlike tree nodes, it's possible they may not fit in the remaining space of a (the current) page, in that case they are written in the next page and the skipped space remains unused. This may be problematic is the page size is too small with respect to the blob sizes, but it seems to be the simpler solution.