### PR TITLE
Add btree update operation

### DIFF
--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -2,7 +2,6 @@ mod backtrack;
 mod metadata;
 // FIXME: allow dead code momentarily, because all of the delete algorithms are unused, and placing the directive with more granularity would be too troublesome
 mod iter;
-#[allow(dead_code)]
 mod node;
 mod page_manager;
 mod pages;
@@ -24,7 +23,7 @@ use std::borrow::Borrow;
 
 use crate::FixedSize;
 
-use backtrack::{DeleteBacktrack, InsertBacktrack};
+use backtrack::{DeleteBacktrack, InsertBacktrack, UpdateBacktrack};
 use std::convert::{TryFrom, TryInto};
 use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom};
@@ -399,6 +398,15 @@ where
         }
 
         current
+    }
+
+    pub fn update(&self, key: &K, value: V) -> Result<(), BTreeStoreError> {
+        let mut tx = self.transaction_manager.insert_transaction(&self.pages);
+
+        UpdateBacktrack::new_search_for(&mut tx, key).update(value)?;
+
+        tx.commit::<K>();
+        Ok(())
     }
 
     /// delete given key from the tree, this doesn't sync the file to disk
@@ -914,9 +922,6 @@ mod tests {
         let key_to_delete = U64Key(delete);
         assert!(tree.get(&key_to_delete, |v| v.cloned()).is_some());
 
-        dbg!("tree before");
-        tree.debug_print();
-
         tree.delete(&key_to_delete).unwrap();
 
         dbg!("tree after");
@@ -957,6 +962,22 @@ mod tests {
             });
 
         prop
+    }
+
+    #[test]
+    fn test_update() {
+        let tree = new_tree();
+
+        let n: u64 = 2000;
+
+        tree.insert_many((0..n).into_iter().map(|i| (U64Key(i), i)))
+            .unwrap();
+
+        assert_eq!(tree.get(&U64Key(100), |v| v.cloned()), Some(100));
+
+        tree.update(&U64Key(100), 120).unwrap();
+
+        assert_eq!(tree.get(&U64Key(100), |v| v.cloned()), Some(120));
     }
 
     #[test]

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -174,7 +174,7 @@ where
     }
 
     pub fn insert_async(&self, key: K, value: V) -> Result<(), BTreeStoreError> {
-        let mut tx = self.transaction_manager.insert_transaction(&self.pages);
+        let mut tx = self.transaction_manager.write_transaction(&self.pages);
 
         self.insert(&mut tx, key, value)?;
 
@@ -195,7 +195,7 @@ where
         &self,
         iter: impl IntoIterator<Item = (K, V)>,
     ) -> Result<(), BTreeStoreError> {
-        let mut tx = self.transaction_manager.insert_transaction(&self.pages);
+        let mut tx = self.transaction_manager.write_transaction(&self.pages);
 
         for (key, value) in iter {
             self.insert(&mut tx, key, value)?;
@@ -401,7 +401,7 @@ where
     }
 
     pub fn update(&self, key: &K, value: V) -> Result<(), BTreeStoreError> {
-        let mut tx = self.transaction_manager.insert_transaction(&self.pages);
+        let mut tx = self.transaction_manager.write_transaction(&self.pages);
 
         UpdateBacktrack::new_search_for(&mut tx, key).update(value)?;
 
@@ -411,7 +411,7 @@ where
 
     /// delete given key from the tree, this doesn't sync the file to disk
     pub fn delete(&self, key: &K) -> Result<(), BTreeStoreError> {
-        let mut tx = self.transaction_manager.insert_transaction(&self.pages);
+        let mut tx = self.transaction_manager.write_transaction(&self.pages);
 
         let result = self.delete_async(key, &mut tx);
 

--- a/btree/src/btreeindex/node/leaf_node.rs
+++ b/btree/src/btreeindex/node/leaf_node.rs
@@ -298,7 +298,7 @@ where
         Ok(())
     }
 
-    fn values_mut(&mut self) -> ValuesMut<V> {
+    pub(crate) fn values_mut(&mut self) -> ValuesMut<V> {
         let len = self.keys().len();
 
         let base = KEYS_START + (self.max_keys * K::max_size());

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -122,7 +122,7 @@ pub mod borrow {
 
             if self
                 .borrows
-                .get(dbg!(&id))
+                .get(&id)
                 .and_then(|weak| weak.upgrade())
                 .is_some()
             {

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -77,7 +77,7 @@ impl TransactionManager {
         ReadTransaction::new(self.latest_version(), pages)
     }
 
-    pub fn insert_transaction<'me, 'index: 'me>(
+    pub fn write_transaction<'me, 'index: 'me>(
         &'me self,
         pages: &'index Pages,
     ) -> WriteTransaction<'me, 'index> {


### PR DESCRIPTION
Branched from #304 mostly because to avoid a messy rebase later.

## Add update value operation for the btree

Although tihs was already possible with a delete followed by an update, the implementation is really simple and avoids unnecessary rebalances.