### PR TITLE
Make values generic and add range query

### DIFF
--- a/btree/benches/benchmark.rs
+++ b/btree/benches/benchmark.rs
@@ -60,14 +60,11 @@ fn single_key_insertion(c: &mut Criterion) {
             let r: u64 = rng.gen();
             let key = if r % 2 == 0 { r + 1 } else { r };
 
-            let blob_to_insert = random_blob(&mut rng);
+            let blob_to_insert: Box<[u8]> = random_blob(&mut rng);
             tree.insert(U64Key(key), &blob_to_insert[..]).unwrap_or(());
 
             assert_eq!(
-                tree.get(&U64Key(key))
-                    .unwrap()
-                    .expect("Key not found")
-                    .as_ref(),
+                tree.get(&U64Key(key)).unwrap().expect("Key not found"),
                 &blob_to_insert[..]
             );
         })
@@ -102,10 +99,7 @@ fn single_key_search(c: &mut Criterion) {
         b.iter(|| {
             let key: u64 = rng.gen_range(0, n);
             assert_eq!(
-                tree.get(&U64Key(key))
-                    .unwrap()
-                    .expect("Key not found")
-                    .as_ref(),
+                tree.get(&U64Key(key)).unwrap().expect("Key not found"),
                 &data.get(&key).unwrap()[..]
             )
         })

--- a/btree/benches/benchmark.rs
+++ b/btree/benches/benchmark.rs
@@ -1,4 +1,4 @@
-use btree::{BTreeStore, Storeable};
+use btree::{BTreeStore, FixedSize, Storeable};
 use criterion::{criterion_group, criterion_main, Criterion};
 extern crate rand;
 use crate::rand::rngs::StdRng;
@@ -24,8 +24,11 @@ impl<'a> Storeable<'a> for U64Key {
     fn read(buf: &'a [u8]) -> Result<Self::Output, Self::Error> {
         Ok(U64Key(LittleEndian::read_u64(buf)))
     }
-    fn as_output(self) -> Self {
-        self
+}
+
+impl FixedSize for U64Key {
+    fn max_size() -> usize {
+        std::mem::size_of::<Self>()
     }
 }
 

--- a/btree/examples/blockindex.rs
+++ b/btree/examples/blockindex.rs
@@ -1,4 +1,4 @@
-use btree::{BTreeStore, Storeable};
+use btree::{BTreeStore, FixedSize, Storeable};
 use hex;
 use std::io;
 use std::io::BufRead;
@@ -58,8 +58,10 @@ impl<'a> Storeable<'a> for Key {
         buf.read_exact(&mut bytes).expect("deserialize failed");
         Ok(Key(bytes))
     }
+}
 
-    fn as_output(self) -> Self::Output {
-        self
+impl FixedSize for Key {
+    fn max_size() -> usize {
+        std::mem::size_of::<Self>()
     }
 }

--- a/btree/src/arrayview.rs
+++ b/btree/src/arrayview.rs
@@ -309,10 +309,6 @@ impl<'a> Storeable<'a> for u32 {
     fn read(buf: &'a [u8]) -> Result<Self::Output, Self::Error> {
         Ok(LittleEndian::read_u32(buf))
     }
-
-    fn as_output(self) -> Self::Output {
-        self
-    }
 }
 
 impl<'a> Storeable<'a> for u64 {
@@ -325,10 +321,6 @@ impl<'a> Storeable<'a> for u64 {
 
     fn read(buf: &'a [u8]) -> Result<Self::Output, Self::Error> {
         Ok(LittleEndian::read_u64(buf))
-    }
-
-    fn as_output(self) -> Self::Output {
-        self
     }
 }
 

--- a/btree/src/arrayview.rs
+++ b/btree/src/arrayview.rs
@@ -72,9 +72,10 @@ where
     }
 
     // TODO: add a marker type so this only can be used on sorted views?
-    pub(crate) fn binary_search<'me, Q: 'me>(&'me self, element: Q) -> Result<usize, usize>
+    pub(crate) fn binary_search<'me, Q: 'me>(&'me self, element: &Q) -> Result<usize, usize>
     where
-        Q: Borrow<E> + Eq + PartialEq,
+        Q: Ord,
+        E: Borrow<Q>,
     {
         let stride = usize::from(&self.element_size);
         let data: &'me [u8] = self.data.as_ref();
@@ -87,7 +88,7 @@ where
             .map(|slice| E::read(&slice[..]).unwrap())
             .collect();
 
-        de.binary_search_by_key(&element.borrow(), |s| s.borrow())
+        de.binary_search_by_key(&element.borrow(), |s| s.borrow().borrow())
     }
 
     pub(crate) fn linear_search<'me, Q: 'me>(&'me self, element: Q) -> Option<usize>

--- a/btree/src/btreeindex/backtrack.rs
+++ b/btree/src/btreeindex/backtrack.rs
@@ -35,60 +35,88 @@ where
     phantom_key: PhantomData<[K]>,
 }
 
-// lifetimes on this are a bit bothersome with four 'linear' (re) borrows, there may be some way of refactoring this things, but that would probably need to be done higher in
-// the hierarchy
-/// type to operate on the current element in the stack (branch) of nodes. This borrows the backtrack and acts as a proxy, in order to make borrowing simpler, because
-// XXX: having a left sibling means anchor is not None, and having a sibling in general means parent is not None also, maybe this invariants could be expressed in the type structure
 pub struct DeleteNextElement<'a, 'b: 'a, 'c: 'b, 'd: 'c, K>
 where
     K: Key,
 {
+    pub next_element: NextElement<'a, 'b, 'c, 'd, K>,
+    pub mut_context: Option<MutableContext<'a, 'b, 'c, 'd, K>>,
+}
+
+// lifetimes on this are a bit bothersome with four 'linear' (re) borrows, there may be some way of refactoring this things, but that would probably need to be done higher in
+// the hierarchy
+/// type to operate on the current element in the stack (branch) of nodes. This borrows the backtrack and acts as a proxy, in order to make borrowing simpler, because
+// XXX: having a left sibling means anchor is not None, and having a sibling in general means parent is not None also, maybe this invariants could be expressed in the type structure
+pub struct NextElement<'a, 'b: 'a, 'c: 'b, 'd: 'c, K>
+where
+    K: Key,
+{
     pub next: PageRefMut<'a>,
-    pub parent: Option<PageRefMut<'a>>,
     // anchor is an index into the keys array of a node used to find the current node in the parent without searching. The leftmost(lowest) child has None as anchor
     // this means it's inmediate right sibling would have anchor of 0, and so on.
     pub anchor: Option<usize>,
     pub left: Option<PageRef<'a>>,
     pub right: Option<PageRef<'a>>,
-    backtrack: &'a mut DeleteBacktrack<'b, 'c, 'd, K>,
+    backtrack: &'a DeleteBacktrack<'b, 'c, 'd, K>,
 }
 
-impl<'a, 'b: 'a, 'c: 'b, 'd: 'c, K> DeleteNextElement<'a, 'b, 'c, 'd, K>
+pub struct MutableContext<'a, 'b: 'a, 'c: 'b, 'd: 'c, K>
 where
     K: Key,
 {
-    pub fn mut_left_sibling(&self, key_size: usize) -> PageRefMut<'a> {
-        let left_id = self.left.as_ref().unwrap().id();
-        match self.backtrack.tx.mut_page(dbg!(left_id)).unwrap() {
+    parent: PageRefMut<'a>,
+    // anchor is an index into the keys array of a node used to find the current node in the parent without searching. The leftmost(lowest) child has None as anchor
+    // this means it's inmediate right sibling would have anchor of 0, and so on.
+    current_id: PageId,
+    left_id: Option<PageId>,
+    right_id: Option<PageId>,
+    backtrack: &'a DeleteBacktrack<'b, 'c, 'd, K>,
+}
+
+impl<'a, 'b: 'a, 'c: 'b, 'd: 'c, K> MutableContext<'a, 'b, 'c, 'd, K>
+where
+    K: Key,
+{
+    pub fn mut_left_sibling(&mut self, key_size: usize) -> (PageRefMut<'a>, &mut PageRefMut<'a>) {
+        let sibling = match self.backtrack.tx.mut_page(self.left_id.unwrap()).unwrap() {
             MutablePage::InTransaction(handle) => handle,
             MutablePage::NeedsParentRedirect(redirect_pointers) => {
-                redirect_pointers.redirect_parent_in_tx::<K>(key_size, self.parent.clone().unwrap())
+                redirect_pointers.redirect_parent_in_tx::<K>(key_size, &mut self.parent)
             }
-        }
+        };
+
+        (sibling, &mut self.parent)
     }
 
-    pub fn mut_right_sibling(&self, key_size: usize) -> PageRefMut<'a> {
-        let right_id = self.right.as_ref().unwrap().id();
-        match self.backtrack.tx.mut_page(dbg!(right_id)).unwrap() {
+    pub fn mut_right_sibling(&mut self, key_size: usize) -> (PageRefMut<'a>, &mut PageRefMut<'a>) {
+        let sibling = match self.backtrack.tx.mut_page(self.right_id.unwrap()).unwrap() {
             MutablePage::InTransaction(handle) => handle,
             MutablePage::NeedsParentRedirect(redirect_pointers) => {
-                redirect_pointers.redirect_parent_in_tx::<K>(key_size, self.parent.clone().unwrap())
+                redirect_pointers.redirect_parent_in_tx::<K>(key_size, &mut self.parent)
             }
+        };
+
+        (sibling, &mut self.parent)
+    }
+
+    /// delete right sibling of current node, this just adds the id to the list of free pages *after* the transaction is confirmed
+    pub fn delete_right_sibling(&self) -> Result<(), ()> {
+        match self.right_id {
+            None => Err(()),
+            Some(right_id) => Ok(self.backtrack.delete_node(right_id)),
         }
     }
 
     /// delete current node, this just adds the id to the list of free pages *after* the transaction is confirmed
     pub fn delete_node(&self) {
-        let id = self.next.id();
-        self.backtrack.delete_node(id)
+        self.backtrack.delete_node(self.current_id)
     }
+}
 
-    /// delete right sibling of current node, this just adds the id to the list of free pages *after* the transaction is confirmed
-    pub fn delete_right_sibling(&self) {
-        let id = self.right.as_ref().map(|handle| handle.id()).unwrap();
-        self.backtrack.delete_node(dbg!(id))
-    }
-
+impl<'a, 'b: 'a, 'c: 'b, 'd: 'c, K> NextElement<'a, 'b, 'c, 'd, K>
+where
+    K: Key,
+{
     pub fn set_root(&self, id: PageId) {
         self.backtrack.tx.current_root.set(id)
     }
@@ -228,28 +256,47 @@ where
             transaction::MutablePage::InTransaction(handle) => handle,
         };
 
-        let (parent, left, right) = if let Some((parent, _anchor, left, right)) = parent_info {
-            let left = left.and_then(|id| self.tx.get_page(id));
-            let right = right.and_then(|id| self.tx.get_page(id));
-            let parent = match self.tx.mut_page(*parent).unwrap() {
-                MutablePage::InTransaction(handle) => handle,
-                _ => unreachable!(),
-            };
+        let mut_context = match parent_info {
+            Some((parent, _anchor, left_id, right_id)) => {
+                let parent = match self.tx.mut_page(*parent)? {
+                    MutablePage::InTransaction(handle) => handle,
+                    _ => unreachable!(),
+                };
+                Some(MutableContext {
+                    parent,
+                    // anchor is an index into the keys array of a node used to find the current node in the parent without searching. The leftmost(lowest) child has None as anchor
+                    // this means it's inmediate right sibling would have anchor of 0, and so on.
+                    left_id,
+                    right_id,
+                    current_id: id,
+                    backtrack: self,
+                })
+            }
+            None => None,
+        };
 
-            (Some(parent), left, right)
-        } else {
-            (None, None, None)
+        let (left, right) = match parent_info {
+            Some((_parent, _anchor, left, right)) => {
+                let left = left.and_then(|id| self.tx.get_page(id));
+                let right = right.and_then(|id| self.tx.get_page(id));
+
+                (left, right)
+            }
+            None => (None, None),
         };
 
         let anchor = parent_info.and_then(|(_, anchor, _, _)| anchor);
-
-        Ok(Some(DeleteNextElement {
+        let next_element = NextElement {
             next,
-            parent,
             anchor,
             left,
             right,
             backtrack: self,
+        };
+
+        Ok(Some(DeleteNextElement {
+            next_element,
+            mut_context,
         }))
     }
 
@@ -329,7 +376,7 @@ where
 
         let key_buffer_size = usize::try_from(self.tx.key_buffer_size).unwrap();
 
-        match self.tx.mut_page(id)? {
+        match self.tx.mut_page(dbg!(id))? {
             transaction::MutablePage::NeedsParentRedirect(rename_in_parents) => {
                 // this part may be tricky, we need to recursively clone and redirect all the path
                 // from the root to the node we are writing to. We need the backtrack stack, because

--- a/btree/src/btreeindex/iter.rs
+++ b/btree/src/btreeindex/iter.rs
@@ -1,0 +1,279 @@
+use super::version_management::transaction::ReadTransaction;
+
+use super::node::{Node, NodeRef};
+
+use std::borrow::Borrow;
+
+use crate::FixedSize;
+
+use super::PageId;
+
+use std::marker::PhantomData;
+use std::ops::{Bound, RangeBounds};
+
+pub struct BTreeIterator<'a, R, Q, K, V>
+where
+    R: RangeBounds<Q>,
+    K: Borrow<Q>,
+{
+    range: R,
+    tx: ReadTransaction<'a>,
+    phantom_data: PhantomData<(Q, K, V)>,
+    // usually b+trees have pointers between leaves, but doing this in a copy on write tree is not possible (or at least it requires cloning all the leaves at each operation),
+    // so we use a stack to keep track of parents
+    // the second parameter is used to keep track of what's the next descendant of that node
+    stack: Vec<(PageId, usize)>,
+    current_position: usize,
+    current_leaf: PageId,
+}
+
+impl<'a, R, Q, K: FixedSize, V: FixedSize> BTreeIterator<'a, R, Q, K, V>
+where
+    R: RangeBounds<Q>,
+    K: Borrow<Q>,
+    Q: Ord,
+{
+    pub(super) fn new(tx: ReadTransaction<'a>, range: R) -> Self {
+        let mut stack = vec![];
+        let mut current = tx.get_page(tx.root()).unwrap();
+
+        let (leaf, starting_pos) = match range.start_bound() {
+            Bound::Excluded(start) | Bound::Included(start) => {
+                // find the starting leaf, and populate the stack with the path leading to it
+                // this is the only search needed, as afterwards we just go in-order
+                loop {
+                    let is_internal = current.as_node(|node: Node<K, &[u8]>| {
+                        node.try_as_internal().map(|inode| {
+                            let upper_pivot = match inode.keys().binary_search(start) {
+                                Ok(pos) => pos + 1,
+                                Err(pos) => pos,
+                            };
+
+                            let children_len = inode.children().len();
+
+                            let pivot = if upper_pivot < children_len {
+                                upper_pivot
+                            } else {
+                                children_len.checked_sub(1).unwrap()
+                            };
+
+                            let new_current_id = inode.children().get(pivot);
+                            (new_current_id, pivot)
+                        })
+                    });
+
+                    if let Some((new_current_id, upper_pivot)) = is_internal {
+                        stack.push((current.id(), upper_pivot));
+                        current = tx.get_page(new_current_id).unwrap();
+                    } else {
+                        break current.as_node(|node: Node<K, &[u8]>| {
+                            let excluded = match range.start_bound() {
+                                Bound::Excluded(_) => true,
+                                _ => false,
+                            };
+
+                            match node.as_leaf::<V>().keys().binary_search(start) {
+                                Ok(pos) => (current.id(), pos + if excluded { 1 } else { 0 }),
+                                Err(pos) => (current.id(), pos + 1),
+                            }
+                        });
+                    }
+                }
+            }
+            Bound::Unbounded => {
+                let current_position = 0;
+                let mut current_leaf = None;
+                descend_leftmost::<_, _, K, V>(
+                    &tx,
+                    tx.root(),
+                    |internal_node_page| stack.push((internal_node_page, 0)),
+                    |leaf_node_page| current_leaf = Some(leaf_node_page),
+                );
+
+                (current_leaf.unwrap(), current_position)
+            }
+        };
+
+        BTreeIterator {
+            tx,
+            range,
+            stack,
+            phantom_data: PhantomData,
+            current_position: starting_pos,
+            current_leaf: leaf,
+        }
+    }
+}
+
+impl<'a, R, Q, K: FixedSize, V: FixedSize> Iterator for BTreeIterator<'a, R, Q, K, V>
+where
+    K: Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord,
+{
+    type Item = V;
+    fn next(&mut self) -> Option<V> {
+        let current_position = self.current_position;
+
+        enum NextStep<T> {
+            EndReached,
+            InLeaf(T),
+            MoveToRightSibling,
+        }
+
+        let next = self
+            .tx
+            .get_page(self.current_leaf)
+            .unwrap()
+            .as_node(|node: Node<K, &[u8]>| {
+                match node.as_leaf::<V>().keys().try_get(current_position) {
+                    None => NextStep::MoveToRightSibling,
+                    Some(key) => {
+                        let is_in_bounds = match self.range.end_bound() {
+                            Bound::Included(end) => key.borrow().borrow() <= end,
+                            Bound::Excluded(end) => key.borrow().borrow() < end,
+                            Bound::Unbounded => true,
+                        };
+                        if is_in_bounds {
+                            NextStep::InLeaf(
+                                node.as_leaf::<V>()
+                                    .values()
+                                    .try_get(current_position)
+                                    .map(|v| v.borrow().clone())
+                                    .unwrap(),
+                            )
+                        } else {
+                            NextStep::EndReached
+                        }
+                    }
+                }
+            });
+
+        match next {
+            NextStep::InLeaf(v) => {
+                self.current_position += 1;
+                Some(v)
+            }
+            NextStep::EndReached => None,
+            NextStep::MoveToRightSibling => {
+                while let Some((internal_node, last_position)) = self.stack.pop() {
+                    let next = last_position + 1;
+                    if let Some(child) = self
+                        .tx
+                        .get_page(internal_node)
+                        .unwrap()
+                        .as_node(|node: Node<K, &[u8]>| node.as_internal().children().try_get(next))
+                    {
+                        self.stack.push((internal_node, next));
+                        let stack = &mut self.stack;
+
+                        let current_leaf = &mut self.current_leaf;
+                        let current_position = &mut self.current_position;
+                        descend_leftmost::<_, _, K, V>(
+                            &self.tx,
+                            child,
+                            |internal_node_page| {
+                                stack.push((internal_node_page, 0));
+                            },
+                            |leaf_node_page| {
+                                *current_leaf = leaf_node_page;
+                                *current_position = 0;
+                            },
+                        );
+                        return self.next();
+                    }
+                }
+
+                None
+            }
+        }
+    }
+}
+
+fn descend_leftmost<'a, I, L, K, V>(
+    tx: &'a ReadTransaction<'a>,
+    starting_node: PageId,
+    mut on_internal: I,
+    on_leaf: L,
+) where
+    I: FnMut(PageId),
+    L: FnOnce(PageId),
+    K: FixedSize,
+    V: FixedSize,
+{
+    let mut current = tx.get_page(starting_node).unwrap();
+    loop {
+        let next = current.as_node(|node: Node<K, &[u8]>| {
+            node.try_as_internal().map(|inode| {
+                on_internal(current.id());
+                inode.children().get(0)
+            })
+        });
+
+        if let Some(new_current_id) = next {
+            current = tx.get_page(new_current_id).unwrap();
+        } else {
+            on_leaf(current.id());
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::btreeindex::tests::new_tree;
+
+    use crate::tests::U64Key;
+
+    #[test]
+    fn range_query_empty_tree() {
+        let tree = new_tree();
+
+        let a = 10u64;
+        let b = 11u64;
+        let mut found = tree.range(U64Key(a)..U64Key(b));
+        assert!(found.next().is_none());
+    }
+
+    #[quickcheck]
+    fn qc_range_query_included_excluded(a: u64, b: u64) -> bool {
+        let tree = new_tree();
+        let n: u64 = 2000;
+
+        tree.insert_many((0..n).into_iter().map(|i| (U64Key(i), i)))
+            .unwrap();
+
+        let found: Vec<_> = tree.range(U64Key(a)..U64Key(b)).collect();
+        let expected: Vec<_> = (a..std::cmp::min(b, n)).into_iter().collect();
+
+        found == expected
+    }
+
+    #[quickcheck]
+    fn qc_range_query_included_included(a: u64, b: u64) -> bool {
+        let tree = new_tree();
+        let n: u64 = 2000;
+
+        tree.insert_many((0..n).into_iter().map(|i| (U64Key(i), i)))
+            .unwrap();
+
+        let found: Vec<_> = tree.range(U64Key(a)..=U64Key(b)).collect();
+        let expected: Vec<_> = (a..=std::cmp::min(b, n)).into_iter().collect();
+
+        found == expected
+    }
+
+    #[test]
+    fn range_query_unbounded() {
+        let tree = new_tree();
+        let n: u64 = 2000;
+
+        tree.insert_many((0..n).into_iter().map(|i| (U64Key(i), i)))
+            .unwrap();
+
+        let found: Vec<_> = tree.range(..).collect();
+
+        assert_eq!(found, (0..n).into_iter().collect::<Vec<_>>());
+    }
+}

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -914,7 +914,7 @@ mod tests {
             .unwrap();
 
         let key_to_delete = U64Key(delete);
-        assert!(tree.lookup(&key_to_delete).is_some());
+        assert!(tree.get(&key_to_delete, |v| v.cloned()).is_some());
 
         dbg!("tree before");
         tree.debug_print();
@@ -924,10 +924,10 @@ mod tests {
         dbg!("tree after");
         tree.debug_print();
 
-        assert!(dbg!(tree.lookup(&key_to_delete)).is_none());
+        assert!(dbg!(tree.get(&key_to_delete, |v| v.cloned())).is_none());
 
         for i in (0..n).into_iter().filter(|n| *n != delete) {
-            assert!(tree.lookup(&U64Key(dbg!(i))).is_some());
+            assert!(tree.get(&U64Key(i), |v| v.cloned()).is_some());
         }
     }
 
@@ -948,13 +948,15 @@ mod tests {
         for k in xs {
             reference.remove(&U64Key(k));
             tree.delete(&U64Key(k)).unwrap_or(());
-            assert!(tree.lookup(&U64Key(k)).is_none());
+            assert!(tree.get(&U64Key(k), |v| v.cloned()).is_none());
         }
 
-        let prop = reference.iter().all(|(k, v)| match tree.lookup(dbg!(k)) {
-            Some(l) => *v == l,
-            None => false,
-        });
+        let prop = reference
+            .iter()
+            .all(|(k, v)| match tree.get(k, |v| v.cloned()) {
+                Some(l) => *v == l,
+                None => false,
+            });
 
         prop
     }

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -77,14 +77,7 @@ where
 
         let first_page_id = metadata.page_manager.new_id();
 
-        let mut root_page = match pages.mut_page(first_page_id) {
-            Ok(page) => page,
-            Err(_) => {
-                pages.extend(first_page_id)?;
-                // this is infallible now
-                pages.mut_page(first_page_id).unwrap()
-            }
-        };
+        let mut root_page = pages.mut_page(first_page_id)?;
 
         root_page.as_slice(|page| {
             Node::<K, &mut [u8]>::new_leaf(key_buffer_size.try_into().unwrap(), page);
@@ -243,7 +236,7 @@ where
 
     pub(crate) fn insert_in_leaf<'a, 'b: 'a>(
         &self,
-        mut leaf: PageRefMut<'a, 'b>,
+        mut leaf: PageRefMut<'a>,
         key: K,
         value: Value,
     ) -> Result<Option<(K, Node<K, MemPage>)>, BTreeStoreError> {

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -68,7 +68,7 @@ where
     ) -> Result<BTree<K>, BTreeStoreError> {
         let mut metadata = Metadata::new();
 
-        let pages_storage = crate::storage::MmapStorage::new(tree_file)?;
+        let pages_storage = crate::storage::MmapStorage::new(tree_file, None)?;
 
         let mut pages = Pages::new(PagesInitializationParams {
             storage: pages_storage,
@@ -117,7 +117,7 @@ where
         static_settings_file: impl AsRef<Path>,
     ) -> Result<BTree<K>, BTreeStoreError> {
         let tree_file = OpenOptions::new().write(true).read(true).open(tree_file)?;
-        let pages_storage = crate::storage::MmapStorage::new(tree_file)?;
+        let pages_storage = crate::storage::MmapStorage::new(tree_file, None)?;
 
         let mut static_settings_file = OpenOptions::new()
             .write(true)

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -543,7 +543,7 @@ where
                                 }
                                 RebalanceResult::MergeIntoLeft(add_params) => {
                                     let (sibling, parent) = mut_context.mut_left_sibling();
-                                    add_params.merge_into_left(parent, anchor, sibling);
+                                    add_params.merge_into_left(parent, anchor, sibling)?;
                                     mut_context.delete_node();
                                     Ok(Some(
                                         anchor
@@ -553,7 +553,7 @@ where
                                 }
                                 RebalanceResult::MergeIntoSelf(add_params) => {
                                     let (sibling, parent) = mut_context.mut_right_sibling();
-                                    add_params.merge_into_self(parent, anchor, sibling);
+                                    add_params.merge_into_self(parent, anchor, sibling)?;
                                     let new_anchor = anchor.map_or(0, |n| n + 1);
                                     mut_context
                                         .delete_right_sibling()

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -350,7 +350,8 @@ where
         })
     }
 
-    // TODO: Consider other kind of ranges.
+    /// perform a range query. The returned iterator holds a read-only transaction for it's entire lifetime.
+    /// This avoids pages to be collected, so it may better for it to not be long-lived.
     pub fn range<R, Q>(&self, range: R) -> BTreeIterator<R, Q, K, V>
     where
         K: Borrow<Q>,

--- a/btree/src/btreeindex/node/leaf_node.rs
+++ b/btree/src/btreeindex/node/leaf_node.rs
@@ -576,7 +576,7 @@ mod tests {
     use super::*;
     use crate::btreeindex::node::tests::{internal_page, internal_page_mut, pages};
     use crate::btreeindex::pages::borrow::{Immutable, Mutable};
-    use crate::btreeindex::pages::Pages;
+    use crate::btreeindex::pages::{PageHandle, Pages};
     use crate::btreeindex::*;
     use crate::tests::U64Key;
     use std::mem::size_of;

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -236,9 +236,11 @@ mod tests {
     use std::mem::size_of;
     use tempfile::tempfile;
 
+    pub const PAGE_SIZE: u64 = (1 << 20) * 128; // 128mb
+
     pub fn pages() -> Pages {
         let page_size = 8 + 8 + 3 * size_of::<U64Key>() + 5 * size_of::<PageId>() + 4 + 8;
-        let storage = MmapStorage::new(tempfile().unwrap(), None).unwrap();
+        let storage = MmapStorage::new(tempfile().unwrap(), PAGE_SIZE).unwrap();
         let params = PagesInitializationParams {
             storage,
             page_size: page_size as u16,
@@ -246,7 +248,6 @@ mod tests {
         };
 
         let pages = Pages::new(params);
-        pages.mut_page(300).unwrap();
         pages
     }
 

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -248,7 +248,6 @@ mod tests {
 
         let mut page = pages.mut_page(page_id).unwrap();
 
-        let key_buffer_size = size_of::<U64Key>();
         page.as_slice(|slice| {
             InternalNode::<U64Key, &mut [u8]>::init(slice);
         });

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -238,14 +238,14 @@ mod tests {
 
     pub fn pages() -> Pages {
         let page_size = 8 + 8 + 3 * size_of::<U64Key>() + 5 * size_of::<PageId>() + 4 + 8;
-        let storage = MmapStorage::new(tempfile().unwrap()).unwrap();
+        let storage = MmapStorage::new(tempfile().unwrap(), None).unwrap();
         let params = PagesInitializationParams {
             storage,
             page_size: page_size as u16,
             key_buffer_size: size_of::<U64Key>() as u32,
         };
 
-        let mut pages = Pages::new(params);
+        let pages = Pages::new(params);
         pages.extend(300).unwrap();
         pages
     }

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -246,7 +246,7 @@ mod tests {
         };
 
         let pages = Pages::new(params);
-        pages.extend(300).unwrap();
+        pages.mut_page(300).unwrap();
         pages
     }
 

--- a/btree/src/btreeindex/node/mod.rs
+++ b/btree/src/btreeindex/node/mod.rs
@@ -4,7 +4,7 @@ pub mod leaf_node;
 use marker::*;
 use std::marker::PhantomData;
 
-use crate::Key;
+use crate::FixedSize;
 pub(crate) use internal_node::{InternalInsertStatus, InternalNode};
 pub(crate) use leaf_node::{LeafInsertStatus, LeafNode};
 
@@ -13,26 +13,21 @@ const TAG_SIZE: usize = 8;
 
 pub struct Node<K, T> {
     data: T,
-    key_buffer_size: usize,
     phantom: PhantomData<[K]>,
 }
 
 /// Trait used to abstract over the input for the rebalance algorithm, taking a Node<K, &[u8]> could be enough in normal cases, but this allows things like RAIIGuards
 pub trait NodeRef {
-    fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+    fn as_node<K, R>(&self, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
     where
-        K: Key;
+        K: FixedSize;
 }
 
 /// Trait used to abstract over the input for the rebalance algorithm, taking a Node<K, &mut [u8]> could be enough in normal cases, but this allows things like RAIIGuards
 pub trait NodeRefMut: NodeRef {
-    fn as_node_mut<K, R>(
-        &mut self,
-        key_buffer_size: usize,
-        f: impl FnOnce(Node<K, &mut [u8]>) -> R,
-    ) -> R
+    fn as_node_mut<K, R>(&mut self, f: impl FnOnce(Node<K, &mut [u8]>) -> R) -> R
     where
-        K: Key;
+        K: FixedSize;
 }
 
 pub(crate) enum NodeTag {
@@ -99,27 +94,25 @@ impl<N: NodeRef> SiblingsArg<N> {
 
 impl<'b, K, T> Node<K, T>
 where
-    K: Key,
+    K: FixedSize,
     T: AsMut<[u8]> + AsRef<[u8]> + 'b,
 {
-    pub(crate) fn new_internal(key_buffer_size: usize, buffer: T) -> Node<K, T> {
+    pub(crate) fn new_internal(buffer: T) -> Node<K, T> {
         let mut buffer = buffer;
         buffer.as_mut()[0..TAG_SIZE].copy_from_slice(&0u64.to_le_bytes());
-        InternalNode::<K, &mut [u8]>::init(key_buffer_size, &mut buffer.as_mut()[8..]);
+        InternalNode::<K, &mut [u8]>::init(&mut buffer.as_mut()[8..]);
         Node {
             data: buffer,
-            key_buffer_size,
             phantom: PhantomData,
         }
     }
 
-    pub(crate) fn new_leaf(key_buffer_size: usize, buffer: T) -> Node<K, T> {
+    pub(crate) fn new_leaf<V: FixedSize>(buffer: T) -> Node<K, T> {
         let mut buffer = buffer;
         buffer.as_mut()[0..TAG_SIZE].copy_from_slice(&1u64.to_le_bytes());
-        LeafNode::<K, &mut [u8]>::init(key_buffer_size, &mut buffer.as_mut()[8..]);
+        LeafNode::<K, V, &mut [u8]>::init(&mut buffer.as_mut()[8..]);
         Node {
             data: buffer,
-            key_buffer_size,
             phantom: PhantomData,
         }
     }
@@ -130,23 +123,19 @@ where
         // the unsafe part is actually in Node::from_raw, so at this point we don't care that much
         match self.get_tag() {
             NodeTag::Internal => unsafe {
-                Some(InternalNode::from_raw(
-                    self.key_buffer_size,
-                    &mut self.data.as_mut()[TAG_SIZE..],
-                ))
+                Some(InternalNode::from_raw(&mut self.data.as_mut()[TAG_SIZE..]))
             },
             NodeTag::Leaf => None,
         }
     }
 
-    pub(crate) fn try_as_leaf_mut<'i: 'b>(&'i mut self) -> Option<LeafNode<'b, K, &mut [u8]>> {
+    pub(crate) fn try_as_leaf_mut<'i: 'b, V: FixedSize>(
+        &'i mut self,
+    ) -> Option<LeafNode<'b, K, V, &mut [u8]>> {
         // the unsafe part is actually in Node::from_raw, so at this point we don't care that much
         match self.get_tag() {
             NodeTag::Leaf => unsafe {
-                Some(LeafNode::from_raw(
-                    self.key_buffer_size,
-                    &mut self.data.as_mut()[TAG_SIZE..],
-                ))
+                Some(LeafNode::from_raw(&mut self.data.as_mut()[TAG_SIZE..]))
             },
             NodeTag::Internal => None,
         }
@@ -156,20 +145,19 @@ where
         self.try_as_internal_mut().unwrap()
     }
 
-    pub(crate) fn as_leaf_mut(&mut self) -> LeafNode<K, &mut [u8]> {
+    pub(crate) fn as_leaf_mut<V: FixedSize>(&mut self) -> LeafNode<K, V, &mut [u8]> {
         self.try_as_leaf_mut().unwrap()
     }
 }
 
 impl<'b, K, T> Node<K, T>
 where
-    K: Key,
+    K: FixedSize,
     T: AsRef<[u8]> + 'b,
 {
-    pub(crate) unsafe fn from_raw(data: T, key_buffer_size: usize) -> Node<K, T> {
+    pub(crate) unsafe fn from_raw(data: T) -> Node<K, T> {
         Node {
             data,
-            key_buffer_size,
             phantom: PhantomData,
         }
     }
@@ -186,25 +174,19 @@ where
 
     pub(crate) fn try_as_internal<'i: 'b>(&'i self) -> Option<InternalNode<'b, K, &[u8]>> {
         match self.get_tag() {
-            NodeTag::Internal => Some(InternalNode::view(
-                self.key_buffer_size,
-                &self.data.as_ref()[LEN_SIZE..],
-            )),
+            NodeTag::Internal => Some(InternalNode::view(&self.data.as_ref()[LEN_SIZE..])),
             NodeTag::Leaf => None,
         }
     }
 
-    pub(crate) fn try_as_leaf<'i: 'b>(&'i self) -> Option<LeafNode<'b, K, &[u8]>> {
+    pub(crate) fn try_as_leaf<'i: 'b, V: FixedSize>(&'i self) -> Option<LeafNode<'b, K, V, &[u8]>> {
         match self.get_tag() {
-            NodeTag::Leaf => Some(LeafNode::view(
-                self.key_buffer_size,
-                &self.data.as_ref()[LEN_SIZE..],
-            )),
+            NodeTag::Leaf => Some(LeafNode::view(&self.data.as_ref()[LEN_SIZE..])),
             NodeTag::Internal => None,
         }
     }
 
-    pub(crate) fn as_leaf(&self) -> LeafNode<K, &[u8]> {
+    pub(crate) fn as_leaf<V: FixedSize>(&self) -> LeafNode<K, V, &[u8]> {
         self.try_as_leaf().unwrap()
     }
 
@@ -215,7 +197,7 @@ where
 
 impl<'b, K> Node<K, crate::mem_page::MemPage>
 where
-    K: Key,
+    K: FixedSize,
 {
     pub(crate) fn to_page(self) -> crate::mem_page::MemPage {
         self.data
@@ -244,7 +226,6 @@ mod tests {
         let params = PagesInitializationParams {
             storage,
             page_size: page_size as u16,
-            key_buffer_size: size_of::<U64Key>() as u32,
         };
 
         let pages = Pages::new(params);
@@ -254,7 +235,7 @@ mod tests {
     pub fn allocate_internal() -> Node<U64Key, MemPage> {
         let page_size = 8 + 8 + 3 * size_of::<U64Key>() + 4 * size_of::<PageId>();
         let page = MemPage::new(page_size);
-        Node::new_internal(std::mem::size_of::<U64Key>(), page)
+        Node::new_internal(page)
     }
 
     pub fn internal_page_mut(
@@ -269,10 +250,10 @@ mod tests {
 
         let key_buffer_size = size_of::<U64Key>();
         page.as_slice(|slice| {
-            InternalNode::<U64Key, &mut [u8]>::init(key_buffer_size, slice);
+            InternalNode::<U64Key, &mut [u8]>::init(slice);
         });
 
-        page.as_node_mut(key_buffer_size, |mut node| {
+        page.as_node_mut(|mut node| {
             let mut iter = keys.iter();
 
             if let Some(first_key) = iter.next() {
@@ -337,12 +318,11 @@ mod tests {
 
         let buffer = MemPage::new(mem_size);
         buffer.as_ref().len();
-        let mut node: Node<U64Key, MemPage> =
-            Node::new_internal(std::mem::size_of::<U64Key>(), buffer);
+        let mut node: Node<U64Key, MemPage> = Node::new_internal(buffer);
 
         let mut allocate = || {
             let page = MemPage::new(mem_size);
-            Node::new_internal(std::mem::size_of::<U64Key>(), page)
+            Node::new_internal(page)
         };
 
         node.as_internal_mut()
@@ -405,11 +385,11 @@ mod tests {
         let i3 = insertions[2];
 
         let buffer = MemPage::new(mem_size);
-        let mut node: Node<U64Key, MemPage> = Node::new_leaf(std::mem::size_of::<U64Key>(), buffer);
+        let mut node: Node<U64Key, MemPage> = Node::new_leaf::<u64>(buffer);
 
         let mut allocate = || {
             let page = MemPage::new(mem_size);
-            Node::new_leaf(std::mem::size_of::<U64Key>(), page)
+            Node::new_leaf::<u64>(page)
         };
 
         match node.as_leaf_mut().insert(U64Key(i1), i1, &mut allocate) {
@@ -422,7 +402,7 @@ mod tests {
         };
         match node.as_leaf_mut().insert(U64Key(i3), i3, &mut allocate) {
             LeafInsertStatus::Split(U64Key(2), new_node) => {
-                let new_leaf = new_node.as_leaf();
+                let new_leaf = new_node.as_leaf::<u64>();
                 assert_eq!(new_leaf.keys().len(), 2);
                 assert_eq!(new_leaf.keys().get(0), U64Key(2));
                 assert_eq!(new_leaf.keys().get(1), U64Key(3));
@@ -435,9 +415,9 @@ mod tests {
             }
         };
 
-        assert_eq!(node.as_leaf().keys().len(), 1);
-        assert_eq!(node.as_leaf().keys().get(0), U64Key(1));
-        assert_eq!(node.as_leaf().values().len(), 1);
-        assert_eq!(node.as_leaf().values().get(0), 1);
+        assert_eq!(node.as_leaf::<u64>().keys().len(), 1);
+        assert_eq!(node.as_leaf::<u64>().keys().get(0), U64Key(1));
+        assert_eq!(node.as_leaf::<u64>().values().len(), 1);
+        assert_eq!(node.as_leaf::<u64>().values().get(0), 1);
     }
 }

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -166,6 +166,7 @@ pub mod borrow {
 
     pub struct BorrowRAIIGuard(Arc<BorrowGuard>);
 
+    // TODO: There is nothing to stop anyone from creating an Immutable instance with a Exclusive borrow guard
     pub struct Immutable<'a> {
         pub borrow: &'a [u8],
         pub borrow_guard: BorrowRAIIGuard,
@@ -173,6 +174,15 @@ pub mod borrow {
     pub struct Mutable<'a> {
         pub borrow: &'a mut [u8],
         pub borrow_guard: BorrowRAIIGuard,
+    }
+
+    impl<'a> Clone for Immutable<'a> {
+        fn clone(&self) -> Immutable<'a> {
+            Immutable {
+                borrow: self.borrow,
+                borrow_guard: BorrowRAIIGuard(self.borrow_guard.0.clone()),
+            }
+        }
     }
 }
 
@@ -185,6 +195,17 @@ pub struct PageHandle<'a, Borrow: 'a> {
 impl<'a, T> PageHandle<'a, T> {
     pub fn id(&self) -> PageId {
         self.id
+    }
+}
+
+use std::clone::Clone;
+impl<'a> Clone for PageHandle<'a, borrow::Immutable<'a>> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            borrow: self.borrow.clone(),
+            page_marker: PhantomData,
+        }
     }
 }
 

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -100,8 +100,8 @@ impl Pages {
         Ok(())
     }
 
-    pub fn extend(&mut self, to: PageId) -> Result<(), std::io::Error> {
-        let storage = &mut self.storage;
+    pub fn extend(&self, to: PageId) -> Result<(), std::io::Error> {
+        let storage = &self.storage;
 
         let from = u64::from(to.checked_sub(1).expect("0 page is used as a null ptr"))
             * u64::from(self.page_size);

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -1,7 +1,7 @@
 use crate::btreeindex::node::Node;
 use crate::btreeindex::PageId;
 use crate::storage::MmapStorage;
-use crate::Key;
+use crate::FixedSize;
 use std::marker::PhantomData;
 use std::sync::Mutex;
 
@@ -24,16 +24,11 @@ unsafe impl Sync for Pages {}
 pub struct PagesInitializationParams {
     pub storage: MmapStorage,
     pub page_size: u16,
-    pub key_buffer_size: u32,
 }
 
 impl Pages {
     pub fn new(params: PagesInitializationParams) -> Self {
-        let PagesInitializationParams {
-            storage,
-            page_size,
-            key_buffer_size: _,
-        } = params;
+        let PagesInitializationParams { storage, page_size } = params;
 
         Pages {
             storage,
@@ -200,79 +195,69 @@ impl<'a> PageHandle<'a, borrow::Mutable<'a>> {
 }
 
 impl<'a> super::node::NodeRef for PageHandle<'a, borrow::Immutable<'a>> {
-    fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+    fn as_node<K, R>(&self, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
     where
-        K: Key,
+        K: FixedSize,
     {
         let page = self.borrow.borrow;
 
-        let node = unsafe { Node::<K, &[u8]>::from_raw(page.as_ref(), key_buffer_size) };
+        let node = unsafe { Node::<K, &[u8]>::from_raw(page.as_ref()) };
 
         f(node)
     }
 }
 
 impl<'a> super::node::NodeRef for &PageHandle<'a, borrow::Immutable<'a>> {
-    fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+    fn as_node<K, R>(&self, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
     where
-        K: Key,
+        K: FixedSize,
     {
         let page = self.borrow.borrow;
 
-        let node = unsafe { Node::<K, &[u8]>::from_raw(page.as_ref(), key_buffer_size) };
+        let node = unsafe { Node::<K, &[u8]>::from_raw(page.as_ref()) };
 
         f(node)
     }
 }
 
 impl<'a> super::node::NodeRef for PageHandle<'a, borrow::Mutable<'a>> {
-    fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+    fn as_node<K, R>(&self, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
     where
-        K: Key,
+        K: FixedSize,
     {
-        let node =
-            unsafe { Node::<K, &[u8]>::from_raw(self.borrow.borrow.as_ref(), key_buffer_size) };
+        let node = unsafe { Node::<K, &[u8]>::from_raw(self.borrow.borrow.as_ref()) };
 
         f(node)
     }
 }
 
 impl<'a> super::node::NodeRef for &mut PageHandle<'a, borrow::Mutable<'a>> {
-    fn as_node<K, R>(&self, key_buffer_size: usize, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
+    fn as_node<K, R>(&self, f: impl FnOnce(Node<K, &[u8]>) -> R) -> R
     where
-        K: Key,
+        K: FixedSize,
     {
-        let node =
-            unsafe { Node::<K, &[u8]>::from_raw(self.borrow.borrow.as_ref(), key_buffer_size) };
+        let node = unsafe { Node::<K, &[u8]>::from_raw(self.borrow.borrow.as_ref()) };
 
         f(node)
     }
 }
 
 impl<'a> super::node::NodeRefMut for PageHandle<'a, borrow::Mutable<'a>> {
-    fn as_node_mut<K, R>(
-        &mut self,
-        key_buffer_size: usize,
-        f: impl FnOnce(Node<K, &mut [u8]>) -> R,
-    ) -> R
+    fn as_node_mut<K, R>(&mut self, f: impl FnOnce(Node<K, &mut [u8]>) -> R) -> R
     where
-        K: Key,
+        K: FixedSize,
     {
-        let node = unsafe { Node::<K, &mut [u8]>::from_raw(self.borrow.borrow, key_buffer_size) };
+        let node = unsafe { Node::<K, &mut [u8]>::from_raw(self.borrow.borrow) };
         f(node)
     }
 }
 
 impl<'a> super::node::NodeRefMut for &mut PageHandle<'a, borrow::Mutable<'a>> {
-    fn as_node_mut<K, R>(
-        &mut self,
-        key_buffer_size: usize,
-        f: impl FnOnce(Node<K, &mut [u8]>) -> R,
-    ) -> R
+    fn as_node_mut<K, R>(&mut self, f: impl FnOnce(Node<K, &mut [u8]>) -> R) -> R
     where
-        K: Key,
+        K: FixedSize,
     {
-        let node = unsafe { Node::<K, &mut [u8]>::from_raw(self.borrow.borrow, key_buffer_size) };
+        let node = unsafe { Node::<K, &mut [u8]>::from_raw(self.borrow.borrow) };
         f(node)
     }
 }

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -101,15 +101,6 @@ impl Pages {
         Ok(())
     }
 
-    // pub fn extend(&self, to: PageId) -> Result<(), std::io::Error> {
-    //     let storage = &self.storage;
-
-    //     let from = u64::from(to.checked_sub(1).expect("0 page is used as a null ptr"))
-    //         * u64::from(self.page_size);
-
-    //     storage.extend(from + u64::from(self.page_size))
-    // }
-
     pub(crate) fn sync_file(&self) -> Result<(), std::io::Error> {
         self.storage.sync()
     }

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -73,14 +73,13 @@ impl TransactionManager {
         self.latest_version.read().clone()
     }
 
-    pub fn read_transaction<'a>(&self, pages: &'a RwLock<Pages>) -> ReadTransaction<'a> {
-        let guard = pages.read();
-        ReadTransaction::new(self.latest_version(), guard)
+    pub fn read_transaction<'a>(&self, pages: &'a Pages) -> ReadTransaction<'a> {
+        ReadTransaction::new(self.latest_version(), pages)
     }
 
     pub fn insert_transaction<'me, 'index: 'me>(
         &'me self,
-        pages: &'index RwLock<Pages>,
+        pages: &'index Pages,
         key_buffer_size: u32,
     ) -> WriteTransaction<'me, 'index> {
         let page_manager = self.page_manager.lock().unwrap();

--- a/btree/src/btreeindex/version_management/mod.rs
+++ b/btree/src/btreeindex/version_management/mod.rs
@@ -80,7 +80,6 @@ impl TransactionManager {
     pub fn insert_transaction<'me, 'index: 'me>(
         &'me self,
         pages: &'index Pages,
-        key_buffer_size: u32,
     ) -> WriteTransaction<'me, 'index> {
         let page_manager = self.page_manager.lock().unwrap();
         let versions = self.versions.lock().unwrap();
@@ -91,7 +90,6 @@ impl TransactionManager {
             page_manager,
             versions,
             self.latest_version.clone(),
-            key_buffer_size,
         )
     }
 

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -1,9 +1,12 @@
 use super::Version;
 use crate::btreeindex::{
-    borrow::{Immutable, Mutable},
     node::NodeRefMut,
     page_manager::PageManager,
-    Node, PageHandle, PageId, Pages,
+    pages::{
+        borrow::{Immutable, Mutable},
+        PageHandle,
+    },
+    Node, PageId, Pages,
 };
 use crate::FixedSize;
 use parking_lot::RwLock;
@@ -47,7 +50,7 @@ impl<'a> ReadTransaction<'a> {
         self.version.root
     }
 
-    pub fn get_page(&self, id: PageId) -> Option<PageHandle<Immutable>> {
+    pub fn get_page(&self, id: PageId) -> Option<PageRef<'a>> {
         self.pages.get_page(id)
     }
 }

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -21,7 +21,9 @@ const MAGIC_SIZE: usize = 8;
 const MAGIC: [u8; MAGIC_SIZE] = [0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88];
 const DATA_START: u64 = 4096;
 
-const MAP_PAGE_SIZE: u64 = crate::storage::DEFAULT_PAGE_SIZE;
+/// Page size of underlying storage. If a blob can't be stored in the current page, we write it at the beginning of the next page.
+/// As this may lead to wasted space, is important to choose the page size accordingly with the expected blob sizes
+const MAP_PAGE_SIZE: u64 = (1 << 20) * 128; // 128mb, this allows 8 max size blobs
 
 /// Appender store blob of data (each of maximum size of 16 Mb) offering
 /// also a direct access to known index whilst it is appended
@@ -49,7 +51,7 @@ impl MmapedAppendOnlyFile {
             .write(true)
             .open(&filename)?;
 
-        let storage = MmapStorage::new(file, Some(MAP_PAGE_SIZE))?;
+        let storage = MmapStorage::new(file, MAP_PAGE_SIZE)?;
         let next_pos = storage.len();
 
         unsafe {

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -209,10 +209,10 @@ mod test {
 
         let appender = MmapedAppendOnlyFile::new(path).unwrap();
 
-        let mut rng = StdRng::seed_from_u64(SEED);
+        let rng = StdRng::seed_from_u64(SEED);
 
         for _ in 0..(MAP_PAGE_SIZE - 1) / MAX_BLOB_SIZE as u64 {
-            let mut buf = vec![0u8; MAX_BLOB_SIZE];
+            let buf = vec![0u8; MAX_BLOB_SIZE];
             appender.append(&buf).unwrap();
         }
 

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -209,16 +209,14 @@ mod test {
 
         let appender = MmapedAppendOnlyFile::new(path).unwrap();
 
-        let rng = StdRng::seed_from_u64(SEED);
-
         for _ in 0..(MAP_PAGE_SIZE - 1) / MAX_BLOB_SIZE as u64 {
             let buf = vec![0u8; MAX_BLOB_SIZE];
             appender.append(&buf).unwrap();
         }
 
-        let mut buf = vec![0u8; MAX_BLOB_SIZE];
+        let buf = vec![0u8; MAX_BLOB_SIZE];
         let pos = appender.append(&buf[..]).unwrap();
 
-        assert_eq!(pos.0, dbg!(MAP_PAGE_SIZE))
+        assert_eq!(pos.0, MAP_PAGE_SIZE)
     }
 }

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -1,14 +1,15 @@
 use crate::storage::MmapStorage;
-use parking_lot::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
+
 use std::convert::TryInto;
 use std::io::{self, Error, ErrorKind, Write};
+
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{fs, path};
 
 pub const SZ_BITS: usize = 24;
 pub const POS_BITS: u64 = 40;
-pub const MAX_BLOB_SIZE: usize = 2 << SZ_BITS; // 16MB blob
-pub const MAX_POS_OFFSET: u64 = 2 << POS_BITS - 1; // last possible position 1byte below 1TB
+pub const MAX_BLOB_SIZE: usize = 1 << SZ_BITS; // 16MB blob
+pub const MAX_POS_OFFSET: u64 = 1 << POS_BITS - 1; // last possible position 1byte below 1TB
 
 /// Position of a blob in an appender
 ///
@@ -20,10 +21,12 @@ const MAGIC_SIZE: usize = 8;
 const MAGIC: [u8; MAGIC_SIZE] = [0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88];
 const DATA_START: u64 = 4096;
 
+const MAP_PAGE_SIZE: u64 = crate::storage::DEFAULT_PAGE_SIZE;
+
 /// Appender store blob of data (each of maximum size of 16 Mb) offering
 /// also a direct access to known index whilst it is appended
 pub struct MmapedAppendOnlyFile {
-    storage: RwLock<MmapStorage>,
+    storage: MmapStorage,
     next_pos: AtomicU64,
 }
 
@@ -46,7 +49,7 @@ impl MmapedAppendOnlyFile {
             .write(true)
             .open(&filename)?;
 
-        let storage = MmapStorage::new(file)?;
+        let storage = MmapStorage::new(file, Some(MAP_PAGE_SIZE))?;
         let next_pos = storage.len();
 
         unsafe {
@@ -56,7 +59,7 @@ impl MmapedAppendOnlyFile {
         }
 
         Ok(Self {
-            storage: RwLock::new(storage),
+            storage,
             next_pos: AtomicU64::new(next_pos),
         })
     }
@@ -82,8 +85,8 @@ impl MmapedAppendOnlyFile {
         //     ));
         // }
 
-        let next_pos = self.next_pos.load(Ordering::Acquire);
-        let mut storage = self.storage.upgradable_read();
+        // next_pos is the return value, the mut part is because if there is no space in the current underlying page, we need to move this to the next page boundary
+        let mut next_pos = self.next_pos.load(Ordering::Acquire);
 
         if next_pos > MAX_POS_OFFSET {
             return Err(Error::new(ErrorKind::Other, "offset position too big"));
@@ -95,55 +98,51 @@ impl MmapedAppendOnlyFile {
         let region_len = szbuf.len() as u64 + buf.len() as u64;
 
         let mmaped_region = unsafe {
-            match storage.get_mut(next_pos, region_len) {
-                Ok(slice) => slice,
-                Err(including) => {
-                    {
-                        let mut new_guard = RwLockUpgradableReadGuard::upgrade(storage);
-                        new_guard.extend(including)?;
-                        // the upgradable part here is only so we can assign to the storage variable again
-                        // we won't upgrade again
-                        storage = RwLockWriteGuard::downgrade_to_upgradable(new_guard);
-                    }
-                    storage.get_mut(next_pos, region_len).unwrap()
-                }
+            let region = self.storage.get_mut(next_pos, region_len)?;
+            let mapped_len = region.len() as u64;
+
+            // check if we could write everything in a contiguous chunk
+            if mapped_len == region_len {
+                self.next_pos
+                    .store(next_pos + region_len, Ordering::Release);
+                region
+            } else {
+                // if we can't, then we just skip that part and write in the next page and hope it fits
+                next_pos = next_pos + mapped_len;
+                self.next_pos
+                    .store(next_pos + region_len, Ordering::Release);
+                self.storage.get_mut(next_pos, region_len)?
             }
         };
 
-        self.next_pos
-            .store(next_pos + region_len, Ordering::Release);
+        if (mmaped_region.len() as u64) < region_len {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Couldn't map contiguous region, page size is smaller than blob size",
+            ));
+        }
 
         mmaped_region[0..szbuf.len()].copy_from_slice(&szbuf[..]);
         mmaped_region[szbuf.len()..].copy_from_slice(&buf[..]);
 
-        // self.ahandle.sync_data()?;
         Ok(Pos(next_pos))
     }
 
     /// Get the blob stored at position @pos
-    pub fn get_at(&self, pos: Pos) -> Result<Box<[u8]>, io::Error> {
+    pub fn get_at(&self, pos: Pos) -> Result<Option<&[u8]>, io::Error> {
         if pos.0 >= self.next_pos.load(Ordering::SeqCst) {
-            // it could also be an option, but it shouldn't happen in our usecase anyway
-            // and so, adding an option just for that may be bothersome
-            return Ok(vec![].into_boxed_slice());
+            return Ok(None);
         }
 
-        let storage = self.storage.read();
-        let szbuf = unsafe { storage.get(pos.into(), 4) };
+        let szbuf = unsafe { self.storage.get(pos.into(), 4) };
 
         let len = u32::from_le_bytes(szbuf.try_into().unwrap());
 
-        let mut v = vec![0u8; len as usize];
-
-        unsafe {
-            v.copy_from_slice(storage.get(pos.0 + 4, len as u64));
-        }
-
-        Ok(v.into())
+        Ok(Some(unsafe { self.storage.get(pos.0 + 4, len as u64) }))
     }
 
     pub fn sync(&self) -> Result<(), io::Error> {
-        self.storage.read().sync()?;
+        self.storage.sync()?;
         Ok(())
     }
 }
@@ -195,7 +194,31 @@ mod test {
         }
 
         for (pos, value) in reference.iter() {
-            assert_eq!(appender.get_at(*pos).unwrap()[..], value[..])
+            assert_eq!(appender.get_at(*pos).unwrap().unwrap()[..], value[..])
         }
+    }
+
+    #[test]
+    fn test_need_to_skip_space() {
+        // the appender does need to create the file, as it applies the initial formatting. This means
+        // we can't create a temp file directly, so instead we create a temporal directory and then the
+        // appender can create a file inside
+        let dir = tempdir().unwrap();
+        let mut path = dir.path().to_path_buf();
+        path.push("appender_skip_space");
+
+        let appender = MmapedAppendOnlyFile::new(path).unwrap();
+
+        let mut rng = StdRng::seed_from_u64(SEED);
+
+        for _ in 0..(MAP_PAGE_SIZE - 1) / MAX_BLOB_SIZE as u64 {
+            let mut buf = vec![0u8; MAX_BLOB_SIZE];
+            appender.append(&buf).unwrap();
+        }
+
+        let mut buf = vec![0u8; MAX_BLOB_SIZE];
+        let pos = appender.append(&buf[..]).unwrap();
+
+        assert_eq!(pos.0, dbg!(MAP_PAGE_SIZE))
     }
 }

--- a/btree/src/flatfile.rs
+++ b/btree/src/flatfile.rs
@@ -108,6 +108,7 @@ impl MmapedAppendOnlyFile {
                 region
             } else {
                 // if we can't, then we just skip that part and write in the next page and hope it fits
+                // we don't write in two different pages in order to just be able to return slices to the mmaped region
                 next_pos = next_pos + mapped_len;
                 self.next_pos
                     .store(next_pos + region_len, Ordering::Release);

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -42,6 +42,8 @@ pub enum BTreeStoreError {
     KeyNotFound,
     #[error("wrong magic number")]
     WrongMagicNumber,
+    #[error("write implementation not compatible with read")]
+    InconsistentWriteRead,
 }
 
 pub struct BTreeStore<K>

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -156,10 +156,10 @@ where
         Ok(())
     }
 
-    pub fn get(&self, key: &K) -> Result<Option<Box<[u8]>>, BTreeStoreError> {
+    pub fn get(&self, key: &K) -> Result<Option<&[u8]>, BTreeStoreError> {
         self.index
             .lookup(&key)
-            .map(|pos| self.flatfile.get_at((pos).into()))
+            .and_then(|pos| self.flatfile.get_at((pos).into()).transpose())
             .transpose()
             .map_err(|e| e.into())
     }

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -26,8 +26,7 @@ use std::path::Path;
 
 use thiserror::Error;
 
-// TODO: rename to file offset or something?
-type Value = u64;
+type Offset = u64;
 
 #[derive(Error, Debug)]
 pub enum BTreeStoreError {
@@ -47,15 +46,15 @@ pub enum BTreeStoreError {
 
 pub struct BTreeStore<K>
 where
-    K: Key,
+    K: FixedSize,
 {
-    index: BTree<K>,
+    index: BTree<K, Offset>,
     flatfile: MmapedAppendOnlyFile,
 }
 
 impl<K> BTreeStore<K>
 where
-    K: Key,
+    K: FixedSize,
 {
     pub fn new(
         path: impl AsRef<Path>,
@@ -83,7 +82,7 @@ where
             .write(true)
             .open(path.as_ref().join(METADATA_FILE))?;
 
-        let index = BTree::<K>::new(
+        let index = BTree::<K, Offset>::new(
             metadata_file,
             tree_file,
             static_settings_file,
@@ -159,7 +158,11 @@ where
     pub fn get(&self, key: &K) -> Result<Option<&[u8]>, BTreeStoreError> {
         self.index
             .lookup(&key)
-            .and_then(|pos| self.flatfile.get_at((pos).into()).transpose())
+            .and_then(|pos| {
+                self.flatfile
+                    .get_at(pos.borrow().clone().into())
+                    .transpose()
+            })
             .transpose()
             .map_err(|e| e.into())
     }
@@ -173,20 +176,22 @@ pub trait Storeable<'a>: Sized {
     type Output: Borrow<Self> + 'a;
     fn write(&self, buf: &mut [u8]) -> Result<(), Self::Error>;
     fn read(buf: &'a [u8]) -> Result<Self::Output, Self::Error>;
-    fn as_output(self) -> Self::Output;
 }
 
-pub trait Key: for<'a> Storeable<'a> + Ord + Clone + Debug {}
-impl<T> Key for T
-where
-    T: for<'a> Storeable<'a> + Ord + Clone + Debug,
-    for<'a> <Self as Storeable<'a>>::Output: Borrow<T>,
-{
+pub trait FixedSize: for<'a> Storeable<'a> + Ord + Clone + Debug {
+    /// max size for an element of this type
+    fn max_size() -> usize;
+}
+
+impl FixedSize for Offset {
+    fn max_size() -> usize {
+        std::mem::size_of::<Offset>()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Storeable;
+    use super::{FixedSize, Storeable};
     use crate::BTreeStore;
     use byteorder::{ByteOrder, LittleEndian};
     #[derive(Debug, Clone, Ord, Eq, PartialEq, PartialOrd)]
@@ -203,9 +208,11 @@ mod tests {
         fn read(buf: &'a [u8]) -> Result<Self::Output, Self::Error> {
             Ok(U64Key(LittleEndian::read_u64(buf)))
         }
+    }
 
-        fn as_output(self) -> Self::Output {
-            self
+    impl FixedSize for U64Key {
+        fn max_size() -> usize {
+            std::mem::size_of::<U64Key>()
         }
     }
 

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -159,7 +159,7 @@ where
 
     pub fn get(&self, key: &K) -> Result<Option<&[u8]>, BTreeStoreError> {
         self.index
-            .get(&key)
+            .get(&key, |offset| offset.cloned())
             .and_then(|pos| {
                 self.flatfile
                     .get_at(pos.borrow().clone().into())

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -159,7 +159,7 @@ where
 
     pub fn get(&self, key: &K) -> Result<Option<&[u8]>, BTreeStoreError> {
         self.index
-            .lookup(&key)
+            .get(&key)
             .and_then(|pos| {
                 self.flatfile
                     .get_at(pos.borrow().clone().into())

--- a/btree/src/storage.rs
+++ b/btree/src/storage.rs
@@ -10,81 +10,34 @@ use std::mem::ManuallyDrop;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
+pub const DEFAULT_PAGE_SIZE: u64 = (1 << 20) * 128; // 128mb
+
 pub struct MmapStorage {
     pages: ManuallyDrop<PageTable>,
     file_len: AtomicU64,
     allocated_size: AtomicU64,
     file: *mut File,
+    page_size: u64,
 }
 
 type PageId = u64;
-const PAGE_SIZE: u64 = (1 << 20) * 128; // 128mb
-
-struct Page {
-    map: UnsafeCell<MmapMut>,
-}
-
-impl Page {
-    fn new(map: MmapMut) -> Self {
-        Self {
-            map: UnsafeCell::new(map),
-        }
-    }
-
-    unsafe fn read(&self) -> *const u8 {
-        (*self.map.get()).as_ref().as_ptr()
-    }
-
-    unsafe fn write(&self) -> *mut u8 {
-        (*self.map.get()).as_mut().as_mut_ptr()
-    }
-
-    fn sync(&self) -> Result<(), io::Error> {
-        unsafe { (*self.map.get()).flush() }
-    }
-}
 
 struct PageTable {
     // TODO: A vector would be probably be a decent choice too
     lookup: Mutex<HashMap<PageId, Page>>,
+    page_size: u64,
 }
-
-impl PageTable {
-    unsafe fn get_page(&self, id: PageId) -> Option<&[u8]> {
-        self.lookup
-            .lock()
-            .unwrap()
-            .get(&id)
-            .map(|page| std::slice::from_raw_parts(page.read(), PAGE_SIZE.try_into().unwrap()))
-    }
-
-    unsafe fn get_page_mut(&self, id: PageId) -> Option<&mut [u8]> {
-        self.lookup
-            .lock()
-            .unwrap()
-            .get(&id)
-            .map(|page| std::slice::from_raw_parts_mut(page.write(), PAGE_SIZE.try_into().unwrap()))
-    }
-
-    fn sync(&self) -> Result<(), io::Error> {
-        for page in self.lookup.lock().unwrap().values() {
-            page.sync()?;
-        }
-
-        Ok(())
-    }
-
-    pub fn add_page(&self, id: PageId, page: Page) {
-        self.lookup.lock().unwrap().insert(id, page);
-    }
+struct Page {
+    map: UnsafeCell<MmapMut>,
 }
 
 impl MmapStorage {
-    pub fn new(file: File) -> Result<Self, io::Error> {
+    pub fn new(file: File, page_size: Option<u64>) -> Result<Self, io::Error> {
         let file_len = file.metadata()?.len();
 
-        let (page_id, _offset) = absolute_offset_to_relative(file_len);
-        let allocated_size = (page_id + 1) * PAGE_SIZE;
+        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        let (page_id, _offset) = absolute_offset_to_relative(page_size, file_len);
+        let allocated_size = (page_id + 1) * page_size;
 
         file.set_len(allocated_size)?;
 
@@ -93,6 +46,7 @@ impl MmapStorage {
 
         let pages = ManuallyDrop::new(PageTable {
             lookup: Mutex::new(HashMap::new()),
+            page_size,
         });
 
         Ok(MmapStorage {
@@ -100,22 +54,23 @@ impl MmapStorage {
             file,
             file_len: AtomicU64::new(file_len),
             allocated_size: AtomicU64::new(allocated_size),
+            page_size,
         })
     }
 
     /// this call is unsafe because get_mut is &self and not &mut self, so this could lead to mutable aliasing
     /// this panics if the location (+ count) is out of range, though
     pub unsafe fn get(&self, location: u64, count: u64) -> &[u8] {
-        let (page_id, offset) = absolute_offset_to_relative(location);
+        let (page_id, offset) = absolute_offset_to_relative(self.page_size, location);
         match self.pages.get_page(page_id as PageId) {
             Some(page) => {
-                &page[offset..min(offset + count as usize, PAGE_SIZE.try_into().unwrap())]
+                &page[offset..min(offset + count as usize, self.page_size.try_into().unwrap())]
             }
             None => {
                 let page = Page::new(
                     memmap::MmapOptions::new()
-                        .offset(page_id * PAGE_SIZE)
-                        .len(PAGE_SIZE as usize)
+                        .offset(page_id * self.page_size)
+                        .len(self.page_size as usize)
                         .map_mut(&*self.file)
                         .expect("couldn't mmap page"),
                 );
@@ -141,16 +96,17 @@ impl MmapStorage {
 
         let count: usize = count.try_into().unwrap();
 
-        let (page_id, offset) = absolute_offset_to_relative(location);
+        let (page_id, offset) = absolute_offset_to_relative(self.page_size, location);
 
         match self.pages.get_page_mut(page_id) {
             Some(page) => {
-                Ok(&mut page[offset..min(offset + count as usize, PAGE_SIZE.try_into().unwrap())])
+                Ok(&mut page
+                    [offset..min(offset + count as usize, self.page_size.try_into().unwrap())])
             }
             None => {
                 let page = memmap::MmapOptions::new()
-                    .offset(page_id * PAGE_SIZE)
-                    .len(PAGE_SIZE as usize)
+                    .offset(page_id * self.page_size)
+                    .len(self.page_size as usize)
                     .map_mut(&*self.file)
                     .expect("Couldn't map page");
 
@@ -163,8 +119,9 @@ impl MmapStorage {
 
     pub fn extend(&self, minimum_required_size: u64) -> Result<(), io::Error> {
         if minimum_required_size > self.allocated_size.load(Ordering::Acquire) {
-            let (page_id, _offset) = absolute_offset_to_relative(minimum_required_size);
-            let new_size = (page_id + 1) * PAGE_SIZE;
+            let (page_id, _offset) =
+                absolute_offset_to_relative(self.page_size, minimum_required_size);
+            let new_size = (page_id + 1) * self.page_size;
             // TODO: Is the new expanded section zeroed or something?
             unsafe {
                 (&mut *self.file).set_len(new_size)?;
@@ -187,6 +144,54 @@ impl MmapStorage {
     }
 }
 
+impl Page {
+    fn new(map: MmapMut) -> Self {
+        Self {
+            map: UnsafeCell::new(map),
+        }
+    }
+
+    unsafe fn read(&self) -> *const u8 {
+        (*self.map.get()).as_ref().as_ptr()
+    }
+
+    unsafe fn write(&self) -> *mut u8 {
+        (*self.map.get()).as_mut().as_mut_ptr()
+    }
+
+    fn sync(&self) -> Result<(), io::Error> {
+        unsafe { (*self.map.get()).flush() }
+    }
+}
+
+impl PageTable {
+    unsafe fn get_page(&self, id: PageId) -> Option<&[u8]> {
+        self.lookup
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|page| std::slice::from_raw_parts(page.read(), self.page_size.try_into().unwrap()))
+    }
+
+    unsafe fn get_page_mut(&self, id: PageId) -> Option<&mut [u8]> {
+        self.lookup.lock().unwrap().get(&id).map(|page| {
+            std::slice::from_raw_parts_mut(page.write(), self.page_size.try_into().unwrap())
+        })
+    }
+
+    fn sync(&self) -> Result<(), io::Error> {
+        for page in self.lookup.lock().unwrap().values() {
+            page.sync()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn add_page(&self, id: PageId, page: Page) {
+        self.lookup.lock().unwrap().insert(id, page);
+    }
+}
+
 impl Drop for MmapStorage {
     fn drop(&mut self) {
         // self.mmap has reference (with an erased lifetime) to the file handle, so we must ensure that it
@@ -199,9 +204,9 @@ impl Drop for MmapStorage {
     }
 }
 
-fn absolute_offset_to_relative(offset: u64) -> (PageId, usize) {
-    let page_id = offset / PAGE_SIZE;
-    let offset = offset % PAGE_SIZE;
+fn absolute_offset_to_relative(page_size: u64, offset: u64) -> (PageId, usize) {
+    let page_id = offset / page_size;
+    let offset = offset % page_size;
     (page_id, offset.try_into().unwrap())
 }
 
@@ -213,25 +218,27 @@ mod tests {
     #[test]
     fn mmap_pagination() {
         let file = tempfile().unwrap();
-        let mut storage = MmapStorage::new(file).unwrap();
+        let storage = MmapStorage::new(file, None).unwrap();
 
         let pages = [1u8, 5, 9];
         let mut results = vec![];
 
         for page in pages.iter() {
             {
-                for byte in unsafe { storage.get_mut(*page as u64 * PAGE_SIZE, PAGE_SIZE) }
-                    .expect("Couldn't expand file")
+                for byte in
+                    unsafe { storage.get_mut(*page as u64 * DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE) }
+                        .expect("Couldn't expand file")
                 {
                     *byte = *page;
                 }
             }
-            let result = unsafe { storage.get(*page as u64 * PAGE_SIZE, PAGE_SIZE) };
+            let result =
+                unsafe { storage.get(*page as u64 * DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE) };
             results.push((page, result));
         }
 
         for (page, result) in results {
-            assert_eq!(result.len(), PAGE_SIZE as usize);
+            assert_eq!(result.len(), DEFAULT_PAGE_SIZE as usize);
             // check the first and last elements to make sure that the ranges are mapped correctly
             for b in result.iter().take(10).chain(result.iter().rev().take(10)) {
                 assert_eq!(b, page);
@@ -242,16 +249,21 @@ mod tests {
     #[test]
     fn non_contiguous_chunk() {
         let file = tempfile().unwrap();
-        let mut storage = MmapStorage::new(file).unwrap();
+        let storage = MmapStorage::new(file, None).unwrap();
 
         assert_eq!(
-            unsafe { storage.get(PAGE_SIZE / 2, PAGE_SIZE).len() },
-            PAGE_SIZE as usize / 2
+            unsafe { storage.get(DEFAULT_PAGE_SIZE / 2, DEFAULT_PAGE_SIZE).len() },
+            DEFAULT_PAGE_SIZE as usize / 2
         );
 
         assert_eq!(
-            unsafe { storage.get_mut(PAGE_SIZE / 2, PAGE_SIZE).unwrap().len() },
-            PAGE_SIZE as usize / 2
+            unsafe {
+                storage
+                    .get_mut(DEFAULT_PAGE_SIZE / 2, DEFAULT_PAGE_SIZE)
+                    .unwrap()
+                    .len()
+            },
+            DEFAULT_PAGE_SIZE as usize / 2
         );
     }
 }

--- a/btree/src/storage.rs
+++ b/btree/src/storage.rs
@@ -1,50 +1,136 @@
 use memmap::MmapMut;
 use std::cell::UnsafeCell;
 
+use std::cmp::min;
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fs::File;
 use std::io;
 use std::mem::ManuallyDrop;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 
 pub struct MmapStorage {
-    mmap: ManuallyDrop<UnsafeCell<MmapMut>>,
+    pages: ManuallyDrop<PageTable>,
     file_len: AtomicU64,
-    allocated_size: u64,
+    allocated_size: AtomicU64,
     file: *mut File,
+}
+
+type PageId = u64;
+const PAGE_SIZE: u64 = (1 << 20) * 128; // 128mb
+
+struct Page {
+    map: UnsafeCell<MmapMut>,
+}
+
+impl Page {
+    fn new(map: MmapMut) -> Self {
+        Self {
+            map: UnsafeCell::new(map),
+        }
+    }
+
+    unsafe fn read(&self) -> *const u8 {
+        (*self.map.get()).as_ref().as_ptr()
+    }
+
+    unsafe fn write(&self) -> *mut u8 {
+        (*self.map.get()).as_mut().as_mut_ptr()
+    }
+
+    fn sync(&self) -> Result<(), io::Error> {
+        unsafe { (*self.map.get()).flush() }
+    }
+}
+
+struct PageTable {
+    // TODO: A vector would be probably be a decent choice too
+    lookup: Mutex<HashMap<PageId, Page>>,
+}
+
+impl PageTable {
+    unsafe fn get_page(&self, id: PageId) -> Option<&[u8]> {
+        self.lookup
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|page| std::slice::from_raw_parts(page.read(), PAGE_SIZE.try_into().unwrap()))
+    }
+
+    unsafe fn get_page_mut(&self, id: PageId) -> Option<&mut [u8]> {
+        self.lookup
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|page| std::slice::from_raw_parts_mut(page.write(), PAGE_SIZE.try_into().unwrap()))
+    }
+
+    fn sync(&self) -> Result<(), io::Error> {
+        for page in self.lookup.lock().unwrap().values() {
+            page.sync()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn add_page(&self, id: PageId, page: Page) {
+        self.lookup.lock().unwrap().insert(id, page);
+    }
 }
 
 impl MmapStorage {
     pub fn new(file: File) -> Result<Self, io::Error> {
         let file_len = file.metadata()?.len();
 
-        let allocated_size = file_len.next_power_of_two();
+        let (page_id, _offset) = absolute_offset_to_relative(file_len);
+        let allocated_size = (page_id + 1) * PAGE_SIZE;
+
         file.set_len(allocated_size)?;
 
         let boxed_file = Box::new(file);
         let file = Box::into_raw(boxed_file);
-        unsafe {
-            Ok(MmapStorage {
-                mmap: ManuallyDrop::new(UnsafeCell::new(MmapMut::map_mut(&*file)?)),
-                file,
-                file_len: AtomicU64::new(file_len),
-                allocated_size,
-            })
-        }
+
+        let pages = ManuallyDrop::new(PageTable {
+            lookup: Mutex::new(HashMap::new()),
+        });
+
+        Ok(MmapStorage {
+            pages,
+            file,
+            file_len: AtomicU64::new(file_len),
+            allocated_size: AtomicU64::new(allocated_size),
+        })
     }
 
     /// this call is unsafe because get_mut is &self and not &mut self, so this could lead to mutable aliasing
     /// this panics if the location (+ count) is out of range, though
     pub unsafe fn get(&self, location: u64, count: u64) -> &[u8] {
-        let location: usize = location.try_into().unwrap();
-        let count: usize = count.try_into().unwrap();
-        &(*self.mmap.get())[location..location + count]
+        let (page_id, offset) = absolute_offset_to_relative(location);
+        match self.pages.get_page(page_id as PageId) {
+            Some(page) => {
+                &page[offset..min(offset + count as usize, PAGE_SIZE.try_into().unwrap())]
+            }
+            None => {
+                let page = Page::new(
+                    memmap::MmapOptions::new()
+                        .offset(page_id * PAGE_SIZE)
+                        .len(PAGE_SIZE as usize)
+                        .map_mut(&*self.file)
+                        .expect("couldn't mmap page"),
+                );
+
+                self.pages.add_page(page_id, page);
+
+                self.get(location, count)
+            }
+        }
     }
 
     /// caller must enforce that there is no aliasing here
-    pub unsafe fn get_mut(&self, location: u64, count: u64) -> Result<&mut [u8], u64> {
-        if location + count > self.allocated_size {
-            return Err(location + count);
+    pub unsafe fn get_mut(&self, location: u64, count: u64) -> Result<&mut [u8], io::Error> {
+        if location + count > self.allocated_size.load(Ordering::SeqCst) {
+            self.extend(location + count)?;
         }
 
         // the file_len is only used in the destructor, to make the file's size on disk be the right one,
@@ -53,37 +139,47 @@ impl MmapStorage {
             self.file_len.store(location + count, Ordering::Release);
         }
 
-        let location: usize = location.try_into().unwrap();
         let count: usize = count.try_into().unwrap();
 
-        // this unwrap can't fail because we already checked for size before
-        // I don't think we need any extra synchronization here,
-        // at least I don't think get_mut modifies any shared state
+        let (page_id, offset) = absolute_offset_to_relative(location);
 
-        Ok((*self.mmap.get())
-            .get_mut(location..location + count)
-            .unwrap())
+        match self.pages.get_page_mut(page_id) {
+            Some(page) => {
+                Ok(&mut page[offset..min(offset + count as usize, PAGE_SIZE.try_into().unwrap())])
+            }
+            None => {
+                let page = memmap::MmapOptions::new()
+                    .offset(page_id * PAGE_SIZE)
+                    .len(PAGE_SIZE as usize)
+                    .map_mut(&*self.file)
+                    .expect("Couldn't map page");
+
+                self.pages.add_page(page_id, Page::new(page));
+
+                Ok(&mut self.pages.get_page_mut(page_id).unwrap()[offset..offset + count as usize])
+            }
+        }
     }
 
-    pub fn extend(&mut self, minimum_required_size: u64) -> Result<(), io::Error> {
-        if minimum_required_size > self.allocated_size {
-            self.allocated_size = minimum_required_size.next_power_of_two();
-
-            // we need to extend the file, so we unmap, extend and remap
+    pub fn extend(&self, minimum_required_size: u64) -> Result<(), io::Error> {
+        if minimum_required_size > self.allocated_size.load(Ordering::Acquire) {
+            let (page_id, _offset) = absolute_offset_to_relative(minimum_required_size);
+            let new_size = (page_id + 1) * PAGE_SIZE;
+            // TODO: Is the new expanded section zeroed or something?
             unsafe {
-                // it's really important to flush here
-                self.sync()?;
-                ManuallyDrop::drop(&mut self.mmap);
-                (&mut *self.file).set_len(self.allocated_size)?;
-                self.mmap = ManuallyDrop::new(UnsafeCell::new(MmapMut::map_mut(&*self.file)?));
+                (&mut *self.file).set_len(new_size)?;
             }
+            self.allocated_size.store(new_size, Ordering::Release);
+
+            self.sync()?;
         }
         Ok(())
     }
 
     pub fn sync(&self) -> Result<(), io::Error> {
         // there is nothing really unsafe here, we need the block only because of unsafe cell (at least nothing that is not already present in the memmap api)
-        unsafe { &*self.mmap.get() }.flush()
+        // unsafe { &*self.mmap.get() }.flush()
+        self.pages.sync()
     }
 
     pub fn len(&self) -> u64 {
@@ -96,11 +192,17 @@ impl Drop for MmapStorage {
         // self.mmap has reference (with an erased lifetime) to the file handle, so we must ensure that it
         // gets dropped first
         unsafe {
-            ManuallyDrop::drop(&mut self.mmap);
+            ManuallyDrop::drop(&mut self.pages);
             let file = Box::from_raw(self.file);
             file.set_len(self.file_len.load(Ordering::Acquire)).unwrap();
         }
     }
+}
+
+fn absolute_offset_to_relative(offset: u64) -> (PageId, usize) {
+    let page_id = offset / PAGE_SIZE;
+    let offset = offset % PAGE_SIZE;
+    (page_id, offset.try_into().unwrap())
 }
 
 #[cfg(test)]
@@ -109,23 +211,47 @@ mod tests {
     use tempfile::tempfile;
 
     #[test]
-    fn mmap_put_and_get() {
+    fn mmap_pagination() {
         let file = tempfile().unwrap();
         let mut storage = MmapStorage::new(file).unwrap();
 
-        let expected = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let pages = [1u8, 5, 9];
+        let mut results = vec![];
 
-        match unsafe { storage.get_mut(30, 10) } {
-            Ok(_) => panic!("Should need resize"),
-            Err(pos) => storage.extend(pos).unwrap(),
+        for page in pages.iter() {
+            {
+                for byte in unsafe { storage.get_mut(*page as u64 * PAGE_SIZE, PAGE_SIZE) }
+                    .expect("Couldn't expand file")
+                {
+                    *byte = *page;
+                }
+            }
+            let result = unsafe { storage.get(*page as u64 * PAGE_SIZE, PAGE_SIZE) };
+            results.push((page, result));
         }
 
-        unsafe { storage.get_mut(30, 10) }
-            .expect("Shouldn't need resize anymore")
-            .copy_from_slice(&expected);
+        for (page, result) in results {
+            assert_eq!(result.len(), PAGE_SIZE as usize);
+            // check the first and last elements to make sure that the ranges are mapped correctly
+            for b in result.iter().take(10).chain(result.iter().rev().take(10)) {
+                assert_eq!(b, page);
+            }
+        }
+    }
 
-        let result = unsafe { storage.get(30, expected.len().try_into().unwrap()) };
+    #[test]
+    fn non_contiguous_chunk() {
+        let file = tempfile().unwrap();
+        let mut storage = MmapStorage::new(file).unwrap();
 
-        assert_eq!(result, &expected[..]);
+        assert_eq!(
+            unsafe { storage.get(PAGE_SIZE / 2, PAGE_SIZE).len() },
+            PAGE_SIZE as usize / 2
+        );
+
+        assert_eq!(
+            unsafe { storage.get_mut(PAGE_SIZE / 2, PAGE_SIZE).unwrap().len() },
+            PAGE_SIZE as usize / 2
+        );
     }
 }

--- a/btree/src/storage.rs
+++ b/btree/src/storage.rs
@@ -11,7 +11,7 @@ use std::mem::ManuallyDrop;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Wrapper over an mmaped file with extension capabilities
-/// The underlying file is split into multiple pages, this makes way the pointers(slices) are never invalidated, at the expense of not being to able to 
+/// The underlying file is split into multiple pages, this makes way the pointers(slices) are never invalidated, at the expense of not being to able to
 /// operate on chunks spanning multiple pages as contiguous data.
 /// The API provided is mostly unsafe, as there is no aliasing checks, it's expected to be done at a higher level.
 pub struct MmapStorage {

--- a/btree/src/storage.rs
+++ b/btree/src/storage.rs
@@ -138,8 +138,6 @@ impl MmapStorage {
     }
 
     pub fn sync(&self) -> Result<(), io::Error> {
-        // there is nothing really unsafe here, we need the .read() only because of unsafe cell (at least nothing that is not already present in the memmap api)
-        // unsafe { &*self.mmap.get() }.flush()
         self.pages.sync()
     }
 


### PR DESCRIPTION
Depends(branches from) on #313 

### Make the "value" of the btree a generic, so the tree can store anything (that can be written to a fixed size buffer, at least) instead of only u64.

Rename the `Key` trait for `FixedSize` with a `max_size()` type function. Still not really sure if traits are really a good fit for this, but it makes things more simple not having to pass the size around all the time.

#### Question
Is it worth having something like this (both examples overly simplified)
```rust
trait AsBytes {} 
trait FromBytes {}

struct BTree<K, V> where
    K: AsBytes + FromBytes + FixedSize + Ord
    V: AsBytes + FromBytes + FixedSize {
}
```
over this (but maybe with `impl AsRef<[u8]>` or something)
```rust
struct BTree {
    fn insert(key: &[u8], value: &[u8]) { }
    fn get(key: &[u8]) -> &[u8] {}
}
```

### Add range query / iterator

The part above makes a lot of noise in the diffs, but this is basically the **iter.rs** file, so I think it's tolerable to keep this together, but this may be split if preferred.

