### PR TITLE
chain-storage is not needed in the chain-impl-mockchain

### DIFF
--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -12,7 +12,6 @@ chain-core = { path = "../chain-core" }
 chain-addr = { path = "../chain-addr" }
 chain-crypto = { path = "../chain-crypto" }
 chain-ser = { path = "../chain-ser" }
-chain-storage = { path = "../chain-storage" }
 chain-time = { path = "../chain-time" }
 typed-bytes = { path = "../typed-bytes" }
 rand_core = "0.5"
@@ -41,6 +40,7 @@ chain-core = { path = "../chain-core", features=["property-test-api"]}
 chain-crypto = { path = "../chain-crypto", features=["property-test-api"]}
 chain-time = { path = "../chain-time", features=["property-test-api"]}
 chain-addr = { path = "../chain-addr", features=["property-test-api"]}
+chain-storage = { path = "../chain-storage" }
 ed25519-bip32 = "0.3"
 rand_chacha = "0.2"
 lazy_static = "1.3.0"

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -8,7 +8,6 @@
 
 use crate::chaintypes::{ChainLength, HeaderId};
 use crate::ledger::Ledger;
-use chain_storage::BlockStoreConnection;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hint::unreachable_unchecked;
 use std::sync::{Arc, Weak};
@@ -188,10 +187,11 @@ impl Multiverse<Ledger> {
     /// Get the chain state at block 'k' from memory if present;
     /// otherwise reconstruct it by reading blocks from storage and
     /// applying them to the nearest ancestor state that we do have.
+    #[cfg(test)]
     pub fn get_from_storage(
         &mut self,
         k: HeaderId,
-        store: &mut BlockStoreConnection<crate::block::Block>,
+        store: &mut chain_storage::BlockStoreConnection<crate::block::Block>,
     ) -> Result<Ref<Ledger>, chain_storage::Error> {
         if let Some(r) = self.get_ref(&k) {
             return Ok(r);


### PR DESCRIPTION
remove a dependency from chain-impl-mockchain: `chain-storage` is not needed, only for a test.