### PR TITLE
return error instead of unwrap in address read

### DIFF
--- a/chain-impl-mockchain/src/legacy.rs
+++ b/chain-impl-mockchain/src/legacy.rs
@@ -35,7 +35,8 @@ impl Readable for UtxoDeclaration {
         for _ in 0..nb_entries {
             let value = Value::read(buf)?;
             let addr_size = buf.get_u16()? as usize;
-            let addr = OldAddress::try_from(buf.get_slice(addr_size)?).unwrap();
+            let addr = OldAddress::try_from(buf.get_slice(addr_size)?)
+                .map_err(|err| ReadError::StructureInvalid(format!("{}", err)))?;
             addrs.push((addr, value))
         }
 


### PR DESCRIPTION
It's better to return return an error when deserializing, instead of a panic. I'm not sure if `InvalidStructure` was meant for this kind of thing, or maybe it should be a new kind of `ReadError`.