### PR TITLE
API to encode public address in subscription requests

### DIFF
--- a/chain-network/src/grpc/convert.rs
+++ b/chain-network/src/grpc/convert.rs
@@ -93,7 +93,7 @@ pub(super) fn decode_peer(meta: &MetadataMap) -> Result<Peer, Error> {
 }
 
 pub(super) fn encode_peer(peer: &Peer, meta: &mut MetadataMap) {
-    let addr = format!("{}", peer.addr());
+    let addr = peer.addr().to_string();
     meta.insert(PEER_ADDRESS_HEADER, MetadataValue::from_str(&addr).unwrap());
 }
 

--- a/chain-network/src/grpc/convert.rs
+++ b/chain-network/src/grpc/convert.rs
@@ -6,7 +6,7 @@ use crate::data::{
     p2p::Peer,
 };
 use crate::error::{self, Error};
-use tonic::metadata::MetadataMap;
+use tonic::metadata::{MetadataMap, MetadataValue};
 use tonic::{Code, Status};
 
 use std::convert::TryFrom;
@@ -90,6 +90,11 @@ pub(super) fn decode_peer(meta: &MetadataMap) -> Result<Peer, Error> {
         )
     })?;
     Ok(address.into())
+}
+
+pub(super) fn encode_peer(peer: &Peer, meta: &mut MetadataMap) {
+    let addr = format!("{}", peer.addr());
+    meta.insert(PEER_ADDRESS_HEADER, MetadataValue::from_str(&addr).unwrap());
 }
 
 pub trait FromProtobuf<R>: Sized {


### PR DESCRIPTION
Provide a client side way to set the public peer address in a metadata
header of subscription requests. This functionality was lost in the tokio 0.2 rework (#294).

Previously, node IDs were encoded in a different metadata header.