### PR TITLE
made vote finish exclusive

### DIFF
--- a/chain-impl-mockchain/src/certificate/vote_plan.rs
+++ b/chain-impl-mockchain/src/certificate/vote_plan.rs
@@ -205,7 +205,7 @@ impl VotePlan {
 
     #[inline]
     pub fn committee_finished(&self, date: BlockDate) -> bool {
-        self.committee_end < date
+        self.committee_end <= date
     }
 
     /// tells if it is possible to do the committee operations at the given date
@@ -378,9 +378,9 @@ mod tests {
         );
 
         assert!(vote_plan.vote_started(vote_start));
-        assert!(!vote_plan.vote_finished(vote_end));
+        assert!(vote_plan.vote_finished(vote_end));
         assert!(vote_plan.committee_started(vote_end));
-        assert!(!vote_plan.committee_finished(committee_finished));
+        assert!(vote_plan.committee_finished(committee_finished));
     }
 
     #[test]

--- a/chain-impl-mockchain/src/certificate/vote_plan.rs
+++ b/chain-impl-mockchain/src/certificate/vote_plan.rs
@@ -186,7 +186,7 @@ impl VotePlan {
 
     #[inline]
     pub fn vote_finished(&self, date: BlockDate) -> bool {
-        self.vote_end < date
+        self.vote_end <= date
     }
 
     /// tells if it is possible to vote at the given date


### PR DESCRIPTION
Test 'vote::manager::tests::vote_plan_manager_can_vote' failed for case:

```
VotePlan { 
vote_start: BlockDate { epoch: 6, slot_id: 13 }, 
vote_end: BlockDate { epoch: 55, slot_id: 48 }, 
committee_end: BlockDate { epoch: 86, slot_id: 89 }, proposals: Proposals {....}
}
```

`BlockDate { epoch: 55, slot_id: 48 })`

expected result was that can_vote should return false, but it returns true.

Applied fix in commit for this corner case.