### PR TITLE
Fall back to transport address as the peer address for server-side subscriptions

### DIFF
--- a/chain-network/src/grpc/server.rs
+++ b/chain-network/src/grpc/server.rs
@@ -179,7 +179,7 @@ where
         req: tonic::Request<tonic::Streaming<proto::Header>>,
     ) -> Result<tonic::Response<Self::BlockSubscriptionStream>, tonic::Status> {
         let service = self.block_service()?;
-        let peer = convert::decode_peer(req.metadata())?;
+        let peer = convert::decode_peer(req.metadata(), req.remote_addr())?;
         let inbound = InboundStream::new(req.into_inner());
         let outbound = service.block_subscription(peer, Box::pin(inbound)).await?;
         let res = OutboundTryStream::new(outbound);
@@ -194,7 +194,7 @@ where
         req: tonic::Request<tonic::Streaming<proto::Fragment>>,
     ) -> Result<tonic::Response<Self::FragmentSubscriptionStream>, tonic::Status> {
         let service = self.fragment_service()?;
-        let peer = convert::decode_peer(req.metadata())?;
+        let peer = convert::decode_peer(req.metadata(), req.remote_addr())?;
         let inbound = InboundStream::new(req.into_inner());
         let outbound = service
             .fragment_subscription(peer, Box::pin(inbound))
@@ -211,7 +211,7 @@ where
         req: tonic::Request<tonic::Streaming<proto::Gossip>>,
     ) -> Result<tonic::Response<Self::GossipSubscriptionStream>, tonic::Status> {
         let service = self.gossip_service()?;
-        let peer = convert::decode_peer(req.metadata())?;
+        let peer = convert::decode_peer(req.metadata(), req.remote_addr())?;
         let inbound = InboundStream::new(req.into_inner());
         let outbound = service.gossip_subscription(peer, Box::pin(inbound)).await?;
         let res = OutboundTryStream::new(outbound);


### PR DESCRIPTION
If the `peer-address` metadata value in server-side subscription requests does not provide the public address, use the remote peer address from the request.