### PR TITLE
remove GH Actions reduntant runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
-# copy of https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 name: Continuous integration
 


### PR DESCRIPTION
Tests are run on every push so there is no need to trigger them again
when opening a pull request.