### PR TITLE
Don't rely on metadata to identify subsription peers

### DIFF
--- a/chain-network/src/grpc/client.rs
+++ b/chain-network/src/grpc/client.rs
@@ -3,21 +3,19 @@ use super::proto;
 use super::streaming::{InboundStream, OutboundStream};
 use crate::data::block::{Block, BlockEvent, BlockId, BlockIds, Header};
 use crate::data::fragment::{Fragment, FragmentIds};
-use crate::data::{Gossip, Peer, Peers};
+use crate::data::{Gossip, Peers};
 use crate::error::{Error, HandshakeError};
 use crate::PROTOCOL_VERSION;
 use futures::prelude::*;
 use tonic::body::{Body, BoxBody};
 use tonic::client::GrpcService;
 use tonic::codegen::{HttpBody, StdError};
-use tonic::Request;
 
 use std::convert::TryFrom;
 
 #[derive(Clone)]
 pub struct Client<T> {
     inner: proto::node_client::NodeClient<T>,
-    public_peer: Option<Peer>,
 }
 
 /// The inbound subscription stream of block events.
@@ -37,10 +35,7 @@ impl Client<tonic::transport::Channel> {
         D::Error: Into<StdError>,
     {
         let inner = proto::node_client::NodeClient::connect(dst).await?;
-        Ok(Client {
-            inner,
-            public_peer: None,
-        })
+        Ok(Client { inner })
     }
 }
 
@@ -54,22 +49,7 @@ where
     pub fn new(service: T) -> Self {
         Client {
             inner: proto::node_client::NodeClient::new(service),
-            public_peer: None,
         }
-    }
-
-    /// Sets public peer address advertized to the remote peer
-    /// in subscription requests.
-    pub fn set_public_peer(&mut self, peer: Peer) {
-        self.public_peer = Some(peer);
-    }
-
-    fn new_subscription_request<S>(&self, outbound: S) -> Request<OutboundStream<S>> {
-        let mut req = Request::new(OutboundStream::new(outbound));
-        if let Some(peer) = &self.public_peer {
-            convert::encode_peer(peer, req.metadata_mut());
-        }
-        req
     }
 }
 
@@ -225,8 +205,8 @@ where
     where
         S: Stream<Item = Header> + Send + Sync + 'static,
     {
-        let req = self.new_subscription_request(outbound);
-        let inbound = self.inner.block_subscription(req).await?.into_inner();
+        let outbound = OutboundStream::new(outbound);
+        let inbound = self.inner.block_subscription(outbound).await?.into_inner();
         Ok(InboundStream::new(inbound))
     }
 
@@ -242,8 +222,12 @@ where
     where
         S: Stream<Item = Fragment> + Send + Sync + 'static,
     {
-        let req = self.new_subscription_request(outbound);
-        let inbound = self.inner.fragment_subscription(req).await?.into_inner();
+        let outbound = OutboundStream::new(outbound);
+        let inbound = self
+            .inner
+            .fragment_subscription(outbound)
+            .await?
+            .into_inner();
         Ok(InboundStream::new(inbound))
     }
 
@@ -255,8 +239,8 @@ where
     where
         S: Stream<Item = Gossip> + Send + Sync + 'static,
     {
-        let req = self.new_subscription_request(outbound);
-        let inbound = self.inner.gossip_subscription(req).await?.into_inner();
+        let outbound = OutboundStream::new(outbound);
+        let inbound = self.inner.gossip_subscription(outbound).await?.into_inner();
         Ok(InboundStream::new(inbound))
     }
 }

--- a/chain-network/src/grpc/convert.rs
+++ b/chain-network/src/grpc/convert.rs
@@ -6,7 +6,7 @@ use crate::data::{
     p2p::Peer,
 };
 use crate::error::{self, Error};
-use tonic::metadata::{MetadataMap, MetadataValue};
+use tonic::metadata::MetadataMap;
 use tonic::{Code, Status};
 
 use std::convert::TryFrom;
@@ -90,11 +90,6 @@ pub(super) fn decode_peer(meta: &MetadataMap) -> Result<Peer, Error> {
         )
     })?;
     Ok(address.into())
-}
-
-pub(super) fn encode_peer(peer: &Peer, meta: &mut MetadataMap) {
-    let addr = peer.addr().to_string();
-    meta.insert(PEER_ADDRESS_HEADER, MetadataValue::from_str(&addr).unwrap());
 }
 
 pub trait FromProtobuf<R>: Sized {

--- a/chain-network/src/grpc/convert.rs
+++ b/chain-network/src/grpc/convert.rs
@@ -6,16 +6,10 @@ use crate::data::{
     p2p::Peer,
 };
 use crate::error::{self, Error};
-use tonic::metadata::MetadataMap;
 use tonic::{Code, Status};
 
 use std::convert::TryFrom;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-
-// Name of the binary metadata key used to pass the peer address in subscription requests.
-// TODO: replace with a custom transport that passes the peer identification
-// to the service instance.
-const PEER_ADDRESS_HEADER: &'static str = "peer-address";
 
 pub(super) fn error_into_grpc(err: Error) -> Status {
     use error::Code::*;
@@ -68,28 +62,6 @@ impl From<Status> for Error {
     fn from(status: Status) -> Self {
         error_from_grpc(status)
     }
-}
-
-pub(super) fn decode_peer(meta: &MetadataMap) -> Result<Peer, Error> {
-    let address = meta.get(PEER_ADDRESS_HEADER).ok_or_else(|| {
-        Error::new(
-            error::Code::Internal,
-            format!("missing metadata {}", PEER_ADDRESS_HEADER),
-        )
-    })?;
-    let address = address.to_str().map_err(|e| {
-        Error::new(
-            error::Code::Internal,
-            format!("invalid metadata value in {}: {}", PEER_ADDRESS_HEADER, e),
-        )
-    })?;
-    let address: SocketAddr = address.parse().map_err(|e| {
-        Error::new(
-            error::Code::Internal,
-            format!("invalid socket address in {}: {}", PEER_ADDRESS_HEADER, e),
-        )
-    })?;
-    Ok(address.into())
 }
 
 pub trait FromProtobuf<R>: Sized {


### PR DESCRIPTION
Revert #368 and use only the remote peer address on the server side to identify peers for subscriptions.