### PR TITLE
Fix deps for missing new chain-test-utils

### DIFF
--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -26,10 +26,10 @@ thiserror = "1.0"
 lazy_static = { version = "1.3.0", optional = true }
 cardano-legacy-address = { path= "../cardano-legacy-address" }
 rand_chacha = { version = "0.2", optional = true }
-chain-test-utils = { path = "../chain-test-utils" }
+chain-test-utils = { path = "../chain-test-utils", optional = true }
 
 [features]
-property-test-api = ["quickcheck", "quickcheck_macros", "lazy_static", "rand_chacha", "ed25519-bip32"]
+property-test-api = ["chain-test-utils", "quickcheck", "quickcheck_macros", "lazy_static", "rand_chacha", "ed25519-bip32"]
 with-bench = []
 
 [dev-dependencies]

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0"
 lazy_static = { version = "1.3.0", optional = true }
 cardano-legacy-address = { path= "../cardano-legacy-address" }
 rand_chacha = { version = "0.2", optional = true }
+chain-test-utils = { path = "../chain-test-utils" }
 
 [features]
 property-test-api = ["quickcheck", "quickcheck_macros", "lazy_static", "rand_chacha", "ed25519-bip32"]


### PR DESCRIPTION
Until completely removal of the `feature-test-api` the new crate should be included also in non-dev deps.