### PR TITLE
add bft leader id getter

### DIFF
--- a/chain-impl-mockchain/src/header/header.rs
+++ b/chain-impl-mockchain/src/header/header.rs
@@ -8,6 +8,7 @@ use crate::chaineval::{HeaderContentEvalContext, HeaderGPContentEvalContext};
 use crate::chaintypes::{ChainLength, HeaderId};
 use crate::date::BlockDate;
 use crate::fragment::{BlockContentHash, BlockContentSize};
+use crate::key::BftLeaderId;
 use crate::leadership;
 
 use std::fmt::{self, Debug};
@@ -224,6 +225,14 @@ impl Header {
     pub fn get_stakepool_id(&self) -> Option<PoolId> {
         match self.block_version() {
             BlockVersion::KesVrfproof => Some(self.get_cstruct().gp_node_id().into()),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn get_bft_leader_id(&self) -> Option<BftLeaderId> {
+        match self.block_version() {
+            BlockVersion::Ed25519Signed => Some(self.get_cstruct().bft_leader_id().into()),
             _ => None,
         }
     }


### PR DESCRIPTION
I realized/remembered that the jormungandr explorer has an `unimplemented!` for the bft leader id tracking per block, because there is no way of getting the leader id (I think). [code here](https://github.com/input-output-hk/jormungandr/blob/e661d520896d4cceacd14a30affdf1025157ec32/jormungandr/src/explorer/indexing.rs#L226)

Nobody seems to be using it in bft mode anyway, but it's just a few lines of code.

Feel free to close this if there is actually a way to get the id that I missed.

