### PR TITLE
Fix and improve caching in GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
             git ls-remote --heads https://github.com/rust-lang/crates.io-index.git master |
             cut -f 1
           )
+          echo "$commit"
           echo "::set-output name=head::$commit"
 
       - name: Cache cargo registry index

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
   update_deps:
     name: Update dependencies
     runs-on: ubuntu-latest
+    outputs:
+      crates-io-index-head: ${{ steps.ls-crates-io-index.outputs.head }}
     steps:
 
       - uses: actions/checkout@v2
@@ -21,23 +23,37 @@ jobs:
           toolchain: stable
           override: true
 
+      - id: ls-crates-io-index
+        name: Get head commit hash of crates.io registry index
+        shell: bash
+        run: |
+          commit=$(
+            git ls-remote --heads https://github.com/rust-lang/crates.io-index.git master |
+            cut -f 1
+          )
+          echo "::set-output name=head::$commit"
+
+      - name: Cache cargo registry index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry/index
+          key: cargo-index-v1-${{ steps.ls-crates-io-index.outputs.head }}
+          restore-keys: |
+            cargo-index-v1-
+
       - name: Generate Cargo.lock
         run: cargo generate-lockfile
 
-      - name: Cargo registry cache
-        id: cache-deps
+      - id: cache-deps
+        name: Cache dependency crates
         uses: actions/cache@v1
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          path: ~/.cargo/registry/cache
+          key: cargo-deps-v1-${{ hashFiles('Cargo.lock') }}
 
       - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
         name: Fetch dependencies
         run: cargo fetch --locked
-
-      - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
-        name: Prune crate sources from cache
-        run: rm -rf ~/.cargo/registry/src
 
       - name: Upload Cargo.lock
         uses: actions/upload-artifact@v2
@@ -74,11 +90,23 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Restore cargo registry cache
+      # https://github.com/actions/virtual-environments/issues/895
+      # https://github.com/actions/virtual-environments/issues/936
+      - if: ${{ runner.os == 'Windows' }}
+        name: Clean up cargo registry files
+        run: rm -r -fo $env:UserProfile\.cargo\registry
+
+      - name: Restore cargo registry index
         uses: actions/cache@v1
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          path: ~/.cargo/registry/index
+          key: cargo-index-v1-${{ needs.update-deps.outputs.crates-io-index-head }}
+
+      - name: Restore dependency crates
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry/cache
+          key: cargo-deps-v1-${{ hashFiles('Cargo.lock') }}
 
       - name: Build
         uses: actions-rs/cargo@v1
@@ -121,11 +149,17 @@ jobs:
           command: fmt
           args: --all -- --check
 
-      - name: Restore dependency crates from cache
+      - name: Restore cargo registry index
         uses: actions/cache@v1
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          path: ~/.cargo/registry/index
+          key: cargo-index-v1-${{ needs.update-deps.outputs.crates-io-index-head }}
+
+      - name: Restore dependency crates
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry/cache
+          key: cargo-deps-v1-${{ hashFiles('Cargo.lock') }}
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,14 +113,14 @@ jobs:
         continue-on-error: false
         with:
           command: build
-          args: --all-targets ${{ matrix.mode }} --locked --offline
+          args: --all-targets ${{ matrix.mode }} --locked
 
       - name: Run tests
         uses: actions-rs/cargo@v1
         continue-on-error: false
         with:
           command: test
-          args: ${{ matrix.mode }} --locked --offline
+          args: ${{ matrix.mode }} --locked
 
   lints:
     name: Lints


### PR DESCRIPTION
There should be no weird failures to unlink git pack files
in the cargo registry index on Windows.

Use two caches side by side, one for the registry index and
another for dependency crates.