### PR TITLE
Add timeout to GitHub CI test jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
           - os: ubuntu-latest
             toolchain: nightly
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
Saw 6 hour workflow runs lately due to a hangup in tests.