### PR TITLE
Voting Plan update: allow for different kind of payloads to be submitted

### DIFF
--- a/chain-impl-mockchain/src/certificate/mod.rs
+++ b/chain-impl-mockchain/src/certificate/mod.rs
@@ -8,10 +8,10 @@ mod test;
 
 use crate::transaction::{Payload, PayloadData, PayloadSlice};
 
-pub use self::vote_cast::{VoteCast, VoteCastPayload};
+pub use self::vote_cast::VoteCast;
 pub use self::vote_plan::{
-    ExternalProposalDocument, ExternalProposalId, Proposal, Proposals, PushProposal, VoteOptions,
-    VotePlan, VotePlanId,
+    ExternalProposalDocument, ExternalProposalId, Proposal, Proposals, PushProposal, VotePlan,
+    VotePlanId,
 };
 pub use delegation::{OwnerStakeDelegation, StakeDelegation};
 pub use pool::{

--- a/chain-impl-mockchain/src/certificate/test.rs
+++ b/chain-impl-mockchain/src/certificate/test.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::accounting::account::DelegationType;
 use crate::block::BlockDate;
 use crate::rewards::TaxType;
+use crate::vote;
 #[cfg(test)]
 use chain_core::mempack::{ReadBuf, Readable};
 use chain_crypto::{testing, Ed25519};
@@ -123,16 +124,10 @@ impl Arbitrary for PoolRegistration {
     }
 }
 
-impl Arbitrary for VoteOptions {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        Self::new_length(u8::arbitrary(g))
-    }
-}
-
 impl Arbitrary for Proposal {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let external_id = ExternalProposalId::arbitrary(g);
-        let funding_plan = VoteOptions::arbitrary(g);
+        let funding_plan = vote::Options::arbitrary(g);
 
         Self::new(external_id, funding_plan)
     }
@@ -169,7 +164,7 @@ impl Arbitrary for VoteCast {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let vote_plan = VotePlanId::arbitrary(g);
         let proposal_index = u8::arbitrary(g);
-        let payload = VoteCastPayload::empty();
+        let payload = vote::Payload::arbitrary(g);
 
         VoteCast::new(vote_plan, proposal_index, payload)
     }

--- a/chain-impl-mockchain/src/certificate/test.rs
+++ b/chain-impl-mockchain/src/certificate/test.rs
@@ -155,8 +155,9 @@ impl Arbitrary for VotePlan {
         let vote_end = BlockDate::arbitrary(g);
         let committee_end = BlockDate::arbitrary(g);
         let proposals = Proposals::arbitrary(g);
+        let payload_type = vote::PayloadType::arbitrary(g);
 
-        Self::new(vote_start, vote_end, committee_end, proposals)
+        Self::new(vote_start, vote_end, committee_end, proposals, payload_type)
     }
 }
 

--- a/chain-impl-mockchain/src/ledger/recovery.rs
+++ b/chain-impl-mockchain/src/ledger/recovery.rs
@@ -41,7 +41,7 @@ use crate::account::AccountAlg;
 use crate::accounting::account::{
     AccountState, DelegationRatio, DelegationType, LastRewards, SpendingCounter,
 };
-use crate::certificate::{PoolId, PoolRegistration, Proposal, Proposals, VoteOptions, VotePlan};
+use crate::certificate::{PoolId, PoolRegistration, Proposal, Proposals, VotePlan};
 use crate::config::ConfigParam;
 use crate::date::BlockDate;
 use crate::fragment::FragmentId;
@@ -54,6 +54,7 @@ use crate::stake::{PoolLastRewards, PoolState};
 use crate::transaction::Output;
 use crate::update::{UpdateProposal, UpdateProposalId, UpdateProposalState, UpdateVoterId};
 use crate::value::Value;
+use crate::vote;
 use crate::{config, key, multisig, utxo};
 use chain_addr::{Address, Discrimination};
 use chain_core::mempack::{ReadBuf, Readable};
@@ -884,7 +885,8 @@ fn pack_vote_proposal<W: std::io::Write>(
 
 fn unpack_proposal<R: std::io::BufRead>(codec: &mut Codec<R>) -> Result<Proposal, std::io::Error> {
     let external_id = unpack_digestof(codec)?;
-    let options = VoteOptions::new_length(codec.get_u8()?);
+    let options = vote::Options::new_length(codec.get_u8()?)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::Other, error))?;
     Ok(Proposal::new(external_id, options))
 }
 

--- a/chain-impl-mockchain/src/testing/gen/vote.rs
+++ b/chain-impl-mockchain/src/testing/gen/vote.rs
@@ -2,9 +2,10 @@ use super::TestGen;
 use crate::{
     block::BlockDate,
     certificate::{
-        ExternalProposalId, Proposal, Proposals, PushProposal, VoteCastPayload, VoteOptions,
+        ExternalProposalId, Proposal, Proposals, PushProposal,
         VotePlan, VoteCast
     },
+    vote,
 };
 use chain_core::property::BlockDate as BlockDateProp;
 use chain_crypto::digest::DigestOf;
@@ -16,7 +17,7 @@ impl VoteTestGen {
     pub fn proposal() -> Proposal {
         Proposal::new(
             VoteTestGen::external_proposal_id(),
-            VoteOptions::new_length(4),
+            vote::Options::new_length(4).unwrap(),
         )
     }
 
@@ -59,8 +60,8 @@ impl VoteTestGen {
         )
     }
 
-    pub fn vote_cast_payload() -> VoteCastPayload {
-        VoteCastPayload::new(TestGen::bytes().to_vec())
+    pub fn vote_cast_payload() -> vote::Payload {
+        vote::Payload::public(vote::Choice::new(1))
     }
 
     pub fn vote_cast_for(vote_plan: &VotePlan) -> VoteCast {

--- a/chain-impl-mockchain/src/testing/gen/vote.rs
+++ b/chain-impl-mockchain/src/testing/gen/vote.rs
@@ -48,6 +48,7 @@ impl VoteTestGen {
             BlockDate::from_epoch_slot_id(2, 0),
             BlockDate::from_epoch_slot_id(3, 0),
             VoteTestGen::proposals(3),
+            vote::PayloadType::Public
         )
     }
 
@@ -57,6 +58,7 @@ impl VoteTestGen {
             BlockDate::from_epoch_slot_id(2, 0),
             BlockDate::from_epoch_slot_id(3, 0),
             VoteTestGen::proposals(count),
+            vote::PayloadType::Public
         )
     }
 

--- a/chain-impl-mockchain/src/vote/choice.rs
+++ b/chain-impl-mockchain/src/vote/choice.rs
@@ -138,7 +138,7 @@ mod tests {
             TestResult::from_bool(options.is_err())
         } else {
             let options = options.expect("non `0` options should always be valid");
-            TestResult::from_bool(options.as_byte() == num_choices % Options::NUM_CHOICES_MAX)
+            TestResult::from_bool(options.as_byte() == num_choices)
         }
     }
 }

--- a/chain-impl-mockchain/src/vote/choice.rs
+++ b/chain-impl-mockchain/src/vote/choice.rs
@@ -1,0 +1,144 @@
+use core::ops::Range;
+use thiserror::Error;
+
+/// error that may occur when creating a new `Options` using
+/// the `new_length` function.
+///
+/// This function will mark all `Options` with a length of `0` options
+/// as invalid.
+#[derive(Debug, Error)]
+#[error("Invalid multi choice option {num_choices}")]
+pub struct InvalidOptionsLength {
+    num_choices: u8,
+}
+
+/// options for the vote
+///
+/// currently this is a 4bits structure, allowing up to 16 choices
+/// however we may allow more complex object to be set in
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Options {
+    options_range: Range<u8>,
+}
+
+/// a choice
+///
+/// A `Choice` is a representation of a choice that has been made and must
+/// be compliant with the `Options`. A way to validate it is with `Options::validate`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct Choice(u8);
+
+impl Options {
+    const NUM_CHOICES_MAX: u8 = 0b0001_0000;
+
+    /// create a new `Options` with the given number of available choices
+    ///
+    /// available choices will go from `0` to `num_choices` not included.
+    pub fn new_length(num_choices: u8) -> Result<Self, InvalidOptionsLength> {
+        if num_choices > 0 && num_choices <= Self::NUM_CHOICES_MAX {
+            let options_range = Range {
+                start: 0,
+                end: num_choices,
+            };
+            Ok(Self { options_range })
+        } else {
+            Err(InvalidOptionsLength { num_choices })
+        }
+    }
+
+    /// get the byte representation of the `Options`
+    pub(crate) fn as_byte(&self) -> u8 {
+        self.options_range.end
+    }
+
+    /// validate the given `Choice` against the available `Options`
+    ///
+    /// returns `true` if the choice is valid, `false` otherwise. By _valid_
+    /// it is meant as in the context of the available `Options`. There is
+    /// obviously no wrong choices to make, only lessons to learn.
+    pub fn validate(&self, choice: Choice) -> bool {
+        self.options_range.contains(&choice.0)
+    }
+
+    pub fn choice_range(&self) -> &core::ops::Range<u8> {
+        &self.options_range
+    }
+}
+
+impl Choice {
+    pub fn new(choice: u8) -> Self {
+        Choice(choice)
+    }
+
+    pub fn as_byte(self) -> u8 {
+        self.0
+    }
+}
+
+#[cfg(any(test, feature = "property-test-api"))]
+mod property {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for Options {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Self::new_length(u8::arbitrary(g)).unwrap_or_else(|_| Options::new_length(1).unwrap())
+        }
+    }
+
+    impl Arbitrary for Choice {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            Self::new(u8::arbitrary(g))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::TestResult;
+    use quickcheck_macros::quickcheck;
+
+    fn validate_choices<I>(options: &Options, choices: I, expected: bool)
+    where
+        I: IntoIterator<Item = Choice>,
+    {
+        for (index, choice) in choices.into_iter().enumerate() {
+            if options.validate(choice) != expected {
+                panic!(
+                    "Choice 0b{choice:08b} ({index}) is not validated properly against 0b{options:08b}",
+                    choice = choice.as_byte(),
+                    index = index,
+                    options = options.as_byte()
+                )
+            }
+        }
+    }
+
+    fn test_with_length(num_choices: u8) {
+        let options = Options::new_length(num_choices).unwrap();
+
+        validate_choices(&options, (0..num_choices).map(Choice::new), true);
+
+        validate_choices(&options, (num_choices..=u8::MAX).map(Choice::new), false);
+    }
+
+    #[test]
+    fn check_validations() {
+        for length in 1..=Options::NUM_CHOICES_MAX {
+            test_with_length(length)
+        }
+    }
+
+    #[quickcheck]
+    pub fn vote_options_max(num_choices: u8) -> TestResult {
+        let options = Options::new_length(num_choices);
+
+        if num_choices == 0 || num_choices > Options::NUM_CHOICES_MAX {
+            TestResult::from_bool(options.is_err())
+        } else {
+            let options = options.expect("non `0` options should always be valid");
+            TestResult::from_bool(options.as_byte() == num_choices % Options::NUM_CHOICES_MAX)
+        }
+    }
+}

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -48,6 +48,12 @@ pub enum VoteError {
         num_proposals: usize,
         vote: VoteCast,
     },
+
+    #[error("{received:?} is not the expected payload type, expected {expected:?}")]
+    InvalidPayloadType {
+        received: vote::PayloadType,
+        expected: vote::PayloadType,
+    },
 }
 
 impl ProposalManager {
@@ -177,6 +183,7 @@ impl VotePlanManager {
     /// * if the proposal index is not one one of the proposal listed
     /// * if the block_date show it is no longer valid to cast a vote for any
     ///   of the managed proposals
+    /// * if the payload type of the vote is not the expected one
     ///
     pub fn vote(
         &self,
@@ -194,6 +201,11 @@ impl VotePlanManager {
                 start: self.plan().vote_start(),
                 end: self.plan().vote_end(),
                 vote: cast,
+            })
+        } else if self.plan().payload_type() != cast.payload().payload_type() {
+            Err(VoteError::InvalidPayloadType {
+                expected: self.plan().payload_type(),
+                received: cast.payload().payload_type(),
             })
         } else {
             let proposal_managers = self.proposal_managers.vote(identifier, cast)?;

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -1,7 +1,8 @@
 use crate::{
-    certificate::{Proposal, VoteCast, VoteCastPayload, VotePlan, VotePlanId},
+    certificate::{Proposal, VoteCast, VotePlan, VotePlanId},
     date::BlockDate,
     transaction::UnspecifiedAccountIdentifier,
+    vote,
 };
 use imhamt::Hamt;
 use std::{collections::hash_map::DefaultHasher, sync::Arc};
@@ -24,7 +25,7 @@ struct ProposalManagers(Vec<ProposalManager>);
 
 #[derive(Clone, PartialEq, Eq)]
 struct ProposalManager {
-    votes_by_voters: Hamt<DefaultHasher, UnspecifiedAccountIdentifier, VoteCastPayload>,
+    votes_by_voters: Hamt<DefaultHasher, UnspecifiedAccountIdentifier, vote::Payload>,
 }
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -218,7 +219,7 @@ mod tests {
     #[test]
     pub fn proposal_manager_insert_vote() {
         let vote_plan = VoteTestGen::vote_plan();
-        let vote_cast_payload = VoteCastPayload::new(vec![1u8]);
+        let vote_cast_payload = vote::Payload::public(vote::Choice::new(1));
         let vote_cast = VoteCast::new(vote_plan.to_id(), 0, vote_cast_payload.clone());
 
         let mut proposal_manager = ProposalManager::new(vote_plan.proposals().get(0).unwrap());

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -440,6 +440,7 @@ mod tests {
             BlockDate::from_epoch_slot_id(2, 0),
             BlockDate::from_epoch_slot_id(3, 0),
             VoteTestGen::proposals(3),
+            vote::PayloadType::Public,
         );
 
         let vote_plan_manager = VotePlanManager::new(vote_plan.clone());
@@ -469,6 +470,7 @@ mod tests {
             BlockDate::from_epoch_slot_id(2, 0),
             BlockDate::from_epoch_slot_id(3, 0),
             VoteTestGen::proposals(3),
+            vote::PayloadType::Public,
         );
 
         let vote_plan_manager = VotePlanManager::new(vote_plan.clone());

--- a/chain-impl-mockchain/src/vote/mod.rs
+++ b/chain-impl-mockchain/src/vote/mod.rs
@@ -14,5 +14,5 @@ pub use self::{
     committee::CommitteeId,
     ledger::{VotePlanLedger, VotePlanLedgerError},
     manager::{VoteError, VotePlanManager},
-    payload::Payload,
+    payload::{Payload, PayloadType, TryFromIntError},
 };

--- a/chain-impl-mockchain/src/vote/mod.rs
+++ b/chain-impl-mockchain/src/vote/mod.rs
@@ -3,12 +3,16 @@
 //! module).
 //!
 
+mod choice;
 mod committee;
 mod ledger;
 mod manager;
+mod payload;
 
 pub use self::{
+    choice::{Choice, Options},
     committee::CommitteeId,
     ledger::{VotePlanLedger, VotePlanLedgerError},
     manager::{VoteError, VotePlanManager},
+    payload::Payload,
 };

--- a/chain-impl-mockchain/src/vote/payload.rs
+++ b/chain-impl-mockchain/src/vote/payload.rs
@@ -1,0 +1,86 @@
+use crate::vote::Choice;
+use chain_core::mempack::{ReadBuf, ReadError};
+use std::convert::{TryFrom, TryInto as _};
+use thiserror::Error;
+use typed_bytes::ByteBuilder;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[repr(u8)]
+pub enum PayloadType {
+    Public = 1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Payload {
+    Public { choice: Choice },
+}
+
+#[derive(Debug, Error)]
+pub enum TryFromIntError {
+    #[error("Found a `0` PayloadType. This is unexpected and known to be an error to read a 0.")]
+    Zero,
+    #[error("invalid value for a PayloadType")]
+    InvalidValue { value: u8 },
+}
+
+impl Payload {
+    pub fn public(choice: Choice) -> Self {
+        Self::Public { choice }
+    }
+
+    pub fn payload_type(&self) -> PayloadType {
+        match self {
+            Self::Public { .. } => PayloadType::Public,
+        }
+    }
+
+    pub(crate) fn serialize_in<T>(&self, bb: ByteBuilder<T>) -> ByteBuilder<T> {
+        let payload_type = self.payload_type();
+
+        match self {
+            Self::Public { choice } => bb.u8(payload_type as u8).u8(choice.as_byte()),
+        }
+    }
+
+    pub(crate) fn read<'a>(buf: &mut ReadBuf<'a>) -> Result<Self, ReadError> {
+        let t = buf
+            .get_u8()?
+            .try_into()
+            .map_err(|e: TryFromIntError| ReadError::StructureInvalid(e.to_string()))?;
+
+        match t {
+            PayloadType::Public => buf.get_u8().map(Choice::new).map(Self::public),
+        }
+    }
+}
+
+impl TryFrom<u8> for PayloadType {
+    type Error = TryFromIntError;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Err(TryFromIntError::Zero),
+            1 => Ok(Self::Public),
+            _ => Err(TryFromIntError::InvalidValue { value }),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "property-test-api"))]
+mod tests {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for PayloadType {
+        fn arbitrary<G: Gen>(_g: &mut G) -> Self {
+            Self::Public
+        }
+    }
+
+    impl Arbitrary for Payload {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            match PayloadType::arbitrary(g) {
+                PayloadType::Public => Payload::public(Choice::arbitrary(g)),
+            }
+        }
+    }
+}

--- a/chain-impl-mockchain/src/vote/payload.rs
+++ b/chain-impl-mockchain/src/vote/payload.rs
@@ -65,6 +65,12 @@ impl TryFrom<u8> for PayloadType {
     }
 }
 
+impl Default for PayloadType {
+    fn default() -> Self {
+        PayloadType::Public
+    }
+}
+
 #[cfg(any(test, feature = "property-test-api"))]
 mod tests {
     use super::*;

--- a/chain-impl-mockchain/src/vote/payload.rs
+++ b/chain-impl-mockchain/src/vote/payload.rs
@@ -4,6 +4,16 @@ use std::convert::{TryFrom, TryInto as _};
 use thiserror::Error;
 use typed_bytes::ByteBuilder;
 
+/// the `PayloadType` to use for a vote plan
+///
+/// this defines how the vote must be published on chain.
+/// Be careful because the default is set to `Public`.
+///
+/// ```
+/// use chain_impl_mockchain::vote::PayloadType;
+/// assert_eq!(PayloadType::Public, PayloadType::default());
+/// ```
+///
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 #[repr(u8)]
 pub enum PayloadType {


### PR DESCRIPTION
Refactor and add concept for `Payload` that are public so can propose votes that users are publicly giving away their choice.