### PR TITLE
gRPC: Support legacy "node-id-bin" metadata

### DIFF
--- a/chain-network/Cargo.toml
+++ b/chain-network/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = "0.1"
 futures = "0.3"
 pin-project = "0.4"
 prost = "0.6"
+rand_core = "0.5"
 thiserror = "1.0"
 
 [dependencies.tonic]

--- a/chain-network/src/grpc/client.rs
+++ b/chain-network/src/grpc/client.rs
@@ -19,6 +19,7 @@ use tonic::transport;
 use std::convert::{TryFrom, TryInto};
 
 /// Builder to customize the gRPC client.
+#[derive(Default)]
 pub struct Builder {
     legacy_node_id: Option<legacy::NodeId>,
 }

--- a/chain-network/src/grpc/client.rs
+++ b/chain-network/src/grpc/client.rs
@@ -1,4 +1,5 @@
 use super::convert;
+use super::legacy;
 use super::proto;
 use super::streaming::{InboundStream, OutboundStream};
 use crate::data::block::{Block, BlockEvent, BlockId, BlockIds, Header};
@@ -10,12 +11,64 @@ use futures::prelude::*;
 use tonic::body::{Body, BoxBody};
 use tonic::client::GrpcService;
 use tonic::codegen::{HttpBody, StdError};
+use tonic::metadata::MetadataValue;
 
-use std::convert::TryFrom;
+#[cfg(feature = "transport")]
+use tonic::transport;
+
+use std::convert::{TryFrom, TryInto};
+
+/// Builder to customize the gRPC client.
+pub struct Builder {
+    legacy_node_id: Option<legacy::NodeId>,
+}
+
+impl Builder {
+    pub fn new() -> Self {
+        Builder {
+            legacy_node_id: None,
+        }
+    }
+
+    /// Make the client add "node-id-bin" metadata with the passed value
+    /// into subscription requests, for backward compatibility with
+    /// jormungandr versions prior to 0.9.
+    pub fn legacy_node_id(&mut self, node_id: legacy::NodeId) -> &mut Self {
+        self.legacy_node_id = Some(node_id);
+        self
+    }
+
+    pub fn build<T>(&self, service: T) -> Client<T>
+    where
+        T: GrpcService<BoxBody>,
+        T::ResponseBody: Body + HttpBody + Send + 'static,
+        T::Error: Into<StdError>,
+        <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
+    {
+        Client {
+            inner: proto::node_client::NodeClient::new(service),
+            legacy_node_id: self.legacy_node_id,
+        }
+    }
+
+    #[cfg(feature = "transport")]
+    pub async fn connect<D>(&self, dst: D) -> Result<Client<transport::Channel>, transport::Error>
+    where
+        D: TryInto<transport::Endpoint>,
+        D::Error: Into<StdError>,
+    {
+        let inner = proto::node_client::NodeClient::connect(dst).await?;
+        Ok(Client {
+            inner,
+            legacy_node_id: self.legacy_node_id,
+        })
+    }
+}
 
 #[derive(Clone)]
 pub struct Client<T> {
     inner: proto::node_client::NodeClient<T>,
+    legacy_node_id: Option<legacy::NodeId>,
 }
 
 /// The inbound subscription stream of block events.
@@ -28,14 +81,13 @@ pub type FragmentSubscription = InboundStream<proto::Fragment, Fragment>;
 pub type GossipSubscription = InboundStream<proto::Gossip, Gossip>;
 
 #[cfg(feature = "transport")]
-impl Client<tonic::transport::Channel> {
-    pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+impl Client<transport::Channel> {
+    pub async fn connect<D>(dst: D) -> Result<Self, transport::Error>
     where
-        D: std::convert::TryInto<tonic::transport::Endpoint>,
+        D: TryInto<transport::Endpoint>,
         D::Error: Into<StdError>,
     {
-        let inner = proto::node_client::NodeClient::connect(dst).await?;
-        Ok(Client { inner })
+        Builder::new().connect(dst).await
     }
 }
 
@@ -47,9 +99,16 @@ where
     <T::ResponseBody as HttpBody>::Error: Into<StdError> + Send,
 {
     pub fn new(service: T) -> Self {
-        Client {
-            inner: proto::node_client::NodeClient::new(service),
+        Builder::new().build(service)
+    }
+
+    fn subscription_request<S>(&self, outbound: S) -> tonic::Request<S> {
+        let mut req = tonic::Request::new(outbound);
+        if let Some(node_id) = self.legacy_node_id {
+            let val = MetadataValue::from_bytes(node_id.as_bytes());
+            req.metadata_mut().insert_bin("node-id-bin", val);
         }
+        req
     }
 }
 
@@ -205,8 +264,8 @@ where
     where
         S: Stream<Item = Header> + Send + Sync + 'static,
     {
-        let outbound = OutboundStream::new(outbound);
-        let inbound = self.inner.block_subscription(outbound).await?.into_inner();
+        let req = self.subscription_request(OutboundStream::new(outbound));
+        let inbound = self.inner.block_subscription(req).await?.into_inner();
         Ok(InboundStream::new(inbound))
     }
 
@@ -222,12 +281,8 @@ where
     where
         S: Stream<Item = Fragment> + Send + Sync + 'static,
     {
-        let outbound = OutboundStream::new(outbound);
-        let inbound = self
-            .inner
-            .fragment_subscription(outbound)
-            .await?
-            .into_inner();
+        let req = self.subscription_request(OutboundStream::new(outbound));
+        let inbound = self.inner.fragment_subscription(req).await?.into_inner();
         Ok(InboundStream::new(inbound))
     }
 
@@ -239,8 +294,8 @@ where
     where
         S: Stream<Item = Gossip> + Send + Sync + 'static,
     {
-        let outbound = OutboundStream::new(outbound);
-        let inbound = self.inner.gossip_subscription(outbound).await?.into_inner();
+        let req = self.subscription_request(OutboundStream::new(outbound));
+        let inbound = self.inner.gossip_subscription(req).await?.into_inner();
         Ok(InboundStream::new(inbound))
     }
 }

--- a/chain-network/src/grpc/legacy.rs
+++ b/chain-network/src/grpc/legacy.rs
@@ -1,0 +1,23 @@
+//! Support for legacy features.
+
+use rand_core::RngCore;
+
+const NODE_ID_LEN: usize = 24;
+
+/// Represents a randomly generated node ID such as was present in subscription
+/// requests and responses in Jormungandr versions prior to 0.9
+/// (as implemented in the old `network-grpc` crate).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct NodeId([u8; NODE_ID_LEN]);
+
+impl NodeId {
+    pub fn generate(rng: &mut impl RngCore) -> Result<Self, rand_core::Error> {
+        let mut bytes = [0; NODE_ID_LEN];
+        rng.try_fill_bytes(&mut bytes)?;
+        Ok(NodeId(bytes))
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}

--- a/chain-network/src/grpc/mod.rs
+++ b/chain-network/src/grpc/mod.rs
@@ -6,6 +6,8 @@ mod proto {
 pub mod client;
 pub mod server;
 
+pub mod legacy;
+
 mod convert;
 mod streaming;
 

--- a/chain-network/src/grpc/server.rs
+++ b/chain-network/src/grpc/server.rs
@@ -14,6 +14,7 @@ use std::net::SocketAddr;
 pub type Server<T> = proto::node_server::NodeServer<NodeService<T>>;
 
 /// Builder to customize the gRPC server.
+#[derive(Default)]
 pub struct Builder {
     legacy_node_id: Option<legacy::NodeId>,
 }

--- a/chain-network/src/lib.rs
+++ b/chain-network/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 pub mod core;
 pub mod data;
 pub mod error;


### PR DESCRIPTION
With the optional legacy feature, come `Builder` APIs for the client and the server.

Needed for https://github.com/input-output-hk/jormungandr/issues/2301