### PR TITLE
Fix the length of legacy node IDs

### DIFF
--- a/chain-network/src/grpc/legacy.rs
+++ b/chain-network/src/grpc/legacy.rs
@@ -2,7 +2,7 @@
 
 use rand_core::RngCore;
 
-const NODE_ID_LEN: usize = 24;
+const NODE_ID_LEN: usize = 32;
 
 /// Represents a randomly generated node ID such as was present in subscription
 /// requests and responses in Jormungandr versions prior to 0.9


### PR DESCRIPTION
It's 32 bytes, dummy.

Needed for https://github.com/input-output-hk/jormungandr/issues/2301