### PR TITLE
Make cargo fmt fast again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,9 @@ jobs:
           path: ~/.cargo/registry/index
           key: cargo-index-v1-${{ needs.update-deps.outputs.crates-io-index-head }}
 
+      - name: Print rustfmt version
+        run: rustfmt --version
+
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         continue-on-error: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,18 +143,18 @@ jobs:
           components: rustfmt, clippy
           override: true
 
+      - name: Restore cargo registry index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry/index
+          key: cargo-index-v1-${{ needs.update-deps.outputs.crates-io-index-head }}
+
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         continue-on-error: false
         with:
           command: fmt
           args: --all -- --check
-
-      - name: Restore cargo registry index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry/index
-          key: cargo-index-v1-${{ needs.update-deps.outputs.crates-io-index-head }}
 
       - name: Restore dependency crates
         uses: actions/cache@v1


### PR DESCRIPTION
Who knew that a simple formatting check command needs a fresh index of the dependencies?