### PR TITLE
Automatically tally votes on chain if the votes are public

### DIFF
--- a/chain-impl-mockchain/src/certificate/mod.rs
+++ b/chain-impl-mockchain/src/certificate/mod.rs
@@ -242,6 +242,7 @@ pub enum SignedCertificate {
     PoolUpdate(PoolUpdate, <PoolUpdate as Payload>::Auth),
     VotePlan(VotePlan, <VotePlan as Payload>::Auth),
     VoteCast(VoteCast, <VoteCast as Payload>::Auth),
+    VoteTally(VoteTally, <VoteTally as Payload>::Auth),
 }
 
 #[cfg(test)]

--- a/chain-impl-mockchain/src/certificate/test.rs
+++ b/chain-impl-mockchain/src/certificate/test.rs
@@ -171,9 +171,16 @@ impl Arbitrary for VoteCast {
     }
 }
 
+impl Arbitrary for VoteTally {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let vote_plan_id = VotePlanId::arbitrary(g);
+        Self::new_public(vote_plan_id)
+    }
+}
+
 impl Arbitrary for Certificate {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let option = u8::arbitrary(g) % 7;
+        let option = u8::arbitrary(g) % 8;
         match option {
             0 => Certificate::StakeDelegation(Arbitrary::arbitrary(g)),
             1 => Certificate::OwnerStakeDelegation(Arbitrary::arbitrary(g)),
@@ -182,6 +189,7 @@ impl Arbitrary for Certificate {
             4 => Certificate::PoolUpdate(Arbitrary::arbitrary(g)),
             5 => Certificate::VotePlan(Arbitrary::arbitrary(g)),
             6 => Certificate::VoteCast(Arbitrary::arbitrary(g)),
+            7 => Certificate::VoteTally(Arbitrary::arbitrary(g)),
             _ => panic!("unimplemented"),
         }
     }

--- a/chain-impl-mockchain/src/certificate/vote_tally.rs
+++ b/chain-impl-mockchain/src/certificate/vote_tally.rs
@@ -67,7 +67,7 @@ impl VoteTally {
 }
 
 impl TallyProof {
-    fn serialize_in(&self, bb: ByteBuilder<Self>) -> ByteBuilder<Self> {
+    pub fn serialize_in(&self, bb: ByteBuilder<Self>) -> ByteBuilder<Self> {
         match self {
             Self::Public { id, signature } => bb.u8(0).bytes(id.as_ref()).bytes(signature.as_ref()),
         }

--- a/chain-impl-mockchain/src/certificate/vote_tally.rs
+++ b/chain-impl-mockchain/src/certificate/vote_tally.rs
@@ -1,0 +1,167 @@
+use crate::{
+    certificate::{CertificateSlice, VotePlanId},
+    transaction::{
+        Payload, PayloadAuthData, PayloadData, PayloadSlice, SingleAccountBindingSignature,
+        TransactionBindingAuthData,
+    },
+    vote::{CommitteeId, PayloadType, TryFromIntError},
+};
+use chain_core::{
+    mempack::{ReadBuf, ReadError, Readable},
+    property,
+};
+use chain_crypto::Verification;
+use typed_bytes::{ByteArray, ByteBuilder};
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub struct VoteTally {
+    id: VotePlanId,
+    payload: VoteTallyPayload,
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub enum VoteTallyPayload {
+    Public,
+}
+
+pub enum TallyProof {
+    Public {
+        id: CommitteeId,
+        signature: SingleAccountBindingSignature,
+    },
+}
+
+impl VoteTallyPayload {
+    pub fn payload_type(&self) -> PayloadType {
+        match self {
+            Self::Public => PayloadType::Public,
+        }
+    }
+}
+
+impl VoteTally {
+    pub fn new_public(id: VotePlanId) -> Self {
+        Self {
+            id,
+            payload: VoteTallyPayload::Public,
+        }
+    }
+
+    pub fn id(&self) -> &VotePlanId {
+        &self.id
+    }
+
+    pub fn tally_type(&self) -> PayloadType {
+        self.payload.payload_type()
+    }
+
+    pub fn serialize_in(&self, bb: ByteBuilder<Self>) -> ByteBuilder<Self> {
+        bb.bytes(self.id().as_ref())
+            .u8(self.payload.payload_type() as u8)
+    }
+
+    pub fn serialize(&self) -> ByteArray<Self> {
+        self.serialize_in(ByteBuilder::new()).finalize()
+    }
+}
+
+impl TallyProof {
+    fn serialize_in(&self, bb: ByteBuilder<Self>) -> ByteBuilder<Self> {
+        match self {
+            Self::Public { id, signature } => bb.u8(0).bytes(id.as_ref()).bytes(signature.as_ref()),
+        }
+    }
+
+    pub fn verify<'a>(
+        &self,
+        tally: &VoteTally,
+        verify_data: &TransactionBindingAuthData<'a>,
+        committee: &[CommitteeId],
+    ) -> Verification {
+        match self {
+            Self::Public { id, signature } => {
+                if tally.tally_type() != PayloadType::Public || !committee.contains(id) {
+                    Verification::Failed
+                } else {
+                    let pk = id.public_key();
+
+                    signature.verify_slice(&pk, verify_data)
+                }
+            }
+        }
+    }
+}
+
+/* Auth/Payload ************************************************************* */
+
+impl Payload for VoteTally {
+    const HAS_DATA: bool = true;
+    const HAS_AUTH: bool = true; // TODO: true it is the Committee signatures
+    type Auth = TallyProof;
+
+    fn payload_data(&self) -> PayloadData<Self> {
+        PayloadData(
+            self.serialize_in(ByteBuilder::new())
+                .finalize_as_vec()
+                .into(),
+            std::marker::PhantomData,
+        )
+    }
+
+    fn payload_auth_data(auth: &Self::Auth) -> PayloadAuthData<Self> {
+        PayloadAuthData(
+            auth.serialize_in(ByteBuilder::new())
+                .finalize_as_vec()
+                .into(),
+            std::marker::PhantomData,
+        )
+    }
+
+    fn to_certificate_slice(p: PayloadSlice<'_, Self>) -> Option<CertificateSlice<'_>> {
+        Some(CertificateSlice::from(p))
+    }
+}
+
+/* Ser/De ******************************************************************* */
+
+impl property::Serialize for VoteTally {
+    type Error = std::io::Error;
+    fn serialize<W: std::io::Write>(&self, mut writer: W) -> Result<(), Self::Error> {
+        writer.write_all(self.serialize().as_slice())?;
+        Ok(())
+    }
+}
+
+impl Readable for TallyProof {
+    fn read<'a>(buf: &mut ReadBuf<'a>) -> Result<Self, ReadError> {
+        match buf.peek_u8()? {
+            0 => {
+                let _ = buf.get_u8()?;
+                let id = CommitteeId::read(buf)?;
+                let signature = SingleAccountBindingSignature::read(buf)?;
+                Ok(Self::Public { id, signature })
+            }
+            _ => Err(ReadError::StructureInvalid(
+                "Unknown Tally proof type".to_owned(),
+            )),
+        }
+    }
+}
+
+impl Readable for VoteTally {
+    fn read<'a>(buf: &mut ReadBuf<'a>) -> Result<Self, ReadError> {
+        use std::convert::TryInto as _;
+
+        let id = <[u8; 32]>::read(buf)?.into();
+        let payload_type = buf
+            .get_u8()?
+            .try_into()
+            .map_err(|e: TryFromIntError| ReadError::StructureInvalid(e.to_string()))?;
+
+        let payload = match payload_type {
+            PayloadType::Public => VoteTallyPayload::Public,
+        };
+
+        Ok(Self { id, payload })
+    }
+}

--- a/chain-impl-mockchain/src/certificate/vote_tally.rs
+++ b/chain-impl-mockchain/src/certificate/vote_tally.rs
@@ -24,6 +24,7 @@ pub enum VoteTallyPayload {
     Public,
 }
 
+#[derive(Debug, Clone)]
 pub enum TallyProof {
     Public {
         id: CommitteeId,

--- a/chain-impl-mockchain/src/fragment/mod.rs
+++ b/chain-impl-mockchain/src/fragment/mod.rs
@@ -41,6 +41,7 @@ pub enum Fragment {
     UpdateVote(SignedUpdateVote),
     VotePlan(Transaction<certificate::VotePlan>),
     VoteCast(Transaction<certificate::VoteCast>),
+    VoteTally(Transaction<certificate::VoteTally>),
 }
 
 impl PartialEq for Fragment {
@@ -65,6 +66,7 @@ pub(super) enum FragmentTag {
     UpdateVote = 9,
     VotePlan = 10,
     VoteCast = 11,
+    VoteTally = 12,
 }
 
 impl FragmentTag {
@@ -82,6 +84,7 @@ impl FragmentTag {
             9 => Some(FragmentTag::UpdateVote),
             10 => Some(FragmentTag::VotePlan),
             11 => Some(FragmentTag::VoteCast),
+            12 => Some(FragmentTag::VoteTally),
             _ => None,
         }
     }
@@ -103,6 +106,7 @@ impl Fragment {
             Fragment::UpdateVote(_) => FragmentTag::UpdateVote,
             Fragment::VotePlan(_) => FragmentTag::VotePlan,
             Fragment::VoteCast(_) => FragmentTag::VoteCast,
+            Fragment::VoteTally(_) => FragmentTag::VoteTally,
         }
     }
 
@@ -127,6 +131,7 @@ impl Fragment {
             Fragment::UpdateVote(vote) => vote.serialize(&mut codec).unwrap(),
             Fragment::VotePlan(vote_plan) => vote_plan.serialize(&mut codec).unwrap(),
             Fragment::VoteCast(vote_plan) => vote_plan.serialize(&mut codec).unwrap(),
+            Fragment::VoteTally(vote_tally) => vote_tally.serialize(&mut codec).unwrap(),
         }
         FragmentRaw(codec.into_inner())
     }
@@ -178,6 +183,7 @@ impl Readable for Fragment {
             Some(FragmentTag::UpdateVote) => SignedUpdateVote::read(buf).map(Fragment::UpdateVote),
             Some(FragmentTag::VotePlan) => Transaction::read(buf).map(Fragment::VotePlan),
             Some(FragmentTag::VoteCast) => Transaction::read(buf).map(Fragment::VoteCast),
+            Some(FragmentTag::VoteTally) => Transaction::read(buf).map(Fragment::VoteTally),
             None => Err(ReadError::UnknownTag(tag as u32)),
         }
     }

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -18,7 +18,7 @@ use crate::stake::{PercentStake, PoolError, PoolStakeInformation, PoolsState, St
 use crate::transaction::*;
 use crate::treasury::Treasury;
 use crate::value::*;
-use crate::vote::{CommitteeId, VotePlanLedger, VotePlanLedgerError};
+use crate::vote::{CommitteeId, VotePlanLedger, VotePlanLedgerError, VotePlanStatus};
 use crate::{account, certificate, legacy, multisig, setting, stake, update, utxo};
 use chain_addr::{Address, Discrimination, Kind};
 use chain_crypto::Verification;
@@ -1012,12 +1012,11 @@ impl Ledger {
         Ok((self, fee))
     }
 
-    pub fn active_vote_plans(&self) -> Vec<VotePlan> {
+    pub fn active_vote_plans(&self) -> Vec<VotePlanStatus> {
         self.votes
             .plans
             .iter()
-            .map(|(_, (plan, _))| plan.plan())
-            .cloned()
+            .map(|(_, (plan, _))| plan.statuses())
             .collect()
     }
 

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -1768,9 +1768,7 @@ mod tests {
     fn account_ledger_with_initials(initials: &[(Identifier, Value)]) -> account::Ledger {
         let mut account_ledger = account::Ledger::new();
         for (id, initial_value) in initials {
-            account_ledger = account_ledger
-                .add_account(&id, initial_value.clone(), ())
-                .unwrap();
+            account_ledger = account_ledger.add_account(&id, *initial_value, ()).unwrap();
         }
         account_ledger
     }

--- a/chain-impl-mockchain/src/testing/builders/initial_builder.rs
+++ b/chain-impl-mockchain/src/testing/builders/initial_builder.rs
@@ -1,14 +1,14 @@
 use crate::{
-    ledger::ledger::OutputAddress,
-    certificate::{Certificate, PoolUpdate, VotePlan, VoteCast},
+    certificate::{Certificate, PoolUpdate, VoteCast, VotePlan},
     fragment::Fragment,
     key::EitherEd25519SecretKey,
+    ledger::ledger::OutputAddress,
     testing::{
         builders::*,
         data::{StakePool, Wallet},
     },
-    value::Value,
     transaction::*,
+    value::Value,
 };
 use std::vec::Vec;
 
@@ -39,10 +39,7 @@ pub fn create_initial_stake_pool_registration(
     fragment(cert, keys, &[], &[])
 }
 
-pub fn create_initial_vote_plan(
-    vote_plan: &VotePlan,
-    owners: &[Wallet],
-) -> Fragment {
+pub fn create_initial_vote_plan(vote_plan: &VotePlan, owners: &[Wallet]) -> Fragment {
     let cert: Certificate = vote_plan.clone().into();
     let keys: Vec<EitherEd25519SecretKey> = owners
         .iter()
@@ -52,10 +49,7 @@ pub fn create_initial_vote_plan(
     fragment(cert, keys, &[], &[])
 }
 
-pub fn create_initial_vote_cast(
-    vote_cast: &VoteCast,
-    owners: &[Wallet],
-) -> Fragment {
+pub fn create_initial_vote_cast(vote_cast: &VoteCast, owners: &[Wallet]) -> Fragment {
     let cert: Certificate = vote_cast.clone().into();
     let keys: Vec<EitherEd25519SecretKey> = owners
         .iter()
@@ -82,16 +76,21 @@ pub fn create_initial_stake_pool_delegation(stake_pool: &StakePool, wallet: &Wal
 
 fn set_initial_ios<P: Payload>(
     builder: TxBuilderState<SetIOs<P>>,
-    inputs: &[Input], 
-    outputs: &[OutputAddress]
+    inputs: &[Input],
+    outputs: &[OutputAddress],
 ) -> TxBuilderState<SetAuthData<P>> {
     builder.set_ios(inputs, outputs).set_witnesses(&[])
 }
 
-fn fragment(cert: Certificate, keys: Vec<EitherEd25519SecretKey>, inputs: &[Input], outputs: &[OutputAddress]) -> Fragment {
+fn fragment(
+    cert: Certificate,
+    keys: Vec<EitherEd25519SecretKey>,
+    inputs: &[Input],
+    outputs: &[OutputAddress],
+) -> Fragment {
     match cert {
         Certificate::StakeDelegation(s) => {
-            let builder = set_initial_ios(TxBuilder::new().set_payload(&s),inputs,outputs);
+            let builder = set_initial_ios(TxBuilder::new().set_payload(&s), inputs, outputs);
             let signature = AccountBindingSignature::new_single(&builder.get_auth_data(), |d| {
                 keys[0].sign_slice(&d.0)
             });
@@ -99,24 +98,24 @@ fn fragment(cert: Certificate, keys: Vec<EitherEd25519SecretKey>, inputs: &[Inpu
             Fragment::StakeDelegation(tx)
         }
         Certificate::PoolRegistration(s) => {
-            let builder = set_initial_ios(TxBuilder::new().set_payload(&s),inputs,outputs);
+            let builder = set_initial_ios(TxBuilder::new().set_payload(&s), inputs, outputs);
             let signature = pool_owner_sign(&keys, &builder);
             let tx = builder.set_payload_auth(&signature);
             Fragment::PoolRegistration(tx)
         }
         Certificate::PoolUpdate(s) => {
-            let builder = set_initial_ios(TxBuilder::new().set_payload(&s),inputs,outputs);
+            let builder = set_initial_ios(TxBuilder::new().set_payload(&s), inputs, outputs);
             let signature = pool_owner_sign(&keys, &builder);
             let tx = builder.set_payload_auth(&signature);
             Fragment::PoolUpdate(tx)
-        },
+        }
         Certificate::VotePlan(s) => {
-            let builder = set_initial_ios(TxBuilder::new().set_payload(&s),inputs,outputs);
+            let builder = set_initial_ios(TxBuilder::new().set_payload(&s), inputs, outputs);
             let tx = builder.set_payload_auth(&());
             Fragment::VotePlan(tx)
         }
         Certificate::VoteCast(s) => {
-            let builder = set_initial_ios(TxBuilder::new().set_payload(&s),inputs,outputs);
+            let builder = set_initial_ios(TxBuilder::new().set_payload(&s), inputs, outputs);
             let tx = builder.set_payload_auth(&());
             Fragment::VoteCast(tx)
         }
@@ -124,37 +123,33 @@ fn fragment(cert: Certificate, keys: Vec<EitherEd25519SecretKey>, inputs: &[Inpu
     }
 }
 
-pub struct InitialFaultTolerantTxCertBuilder{
-    cert: Certificate, 
-    funder: Wallet
+pub struct InitialFaultTolerantTxCertBuilder {
+    cert: Certificate,
+    funder: Wallet,
 }
 
 impl InitialFaultTolerantTxCertBuilder {
-
     pub fn new(cert: Certificate, funder: Wallet) -> Self {
-        Self { 
+        Self {
             cert: cert,
-            funder: funder
+            funder: funder,
         }
     }
 
-    pub fn transaction_with_input_output(&self) -> Fragment
-    {
+    pub fn transaction_with_input_output(&self) -> Fragment {
         let keys = vec![self.funder.private_key()];
         let input = self.funder.make_input_with_value(Value(1));
         let output = self.funder.make_output_with_value(Value(1));
         fragment(self.cert.clone(), keys, &[input], &[output])
     }
 
-    pub fn transaction_with_output_only(&self) -> Fragment
-    {
+    pub fn transaction_with_output_only(&self) -> Fragment {
         let keys = vec![self.funder.private_key()];
         let output = self.funder.make_output_with_value(Value(1));
         fragment(self.cert.clone(), keys, &[], &[output])
     }
-    
-    pub fn transaction_with_input_only(&self) -> Fragment
-    {
+
+    pub fn transaction_with_input_only(&self) -> Fragment {
         let keys = vec![self.funder.private_key()];
         let input = self.funder.make_input_with_value(Value(1));
         fragment(self.cert.clone(), keys, &[input], &[])

--- a/chain-impl-mockchain/src/testing/gen/vote.rs
+++ b/chain-impl-mockchain/src/testing/gen/vote.rs
@@ -1,10 +1,7 @@
 use super::TestGen;
 use crate::{
     block::BlockDate,
-    certificate::{
-        ExternalProposalId, Proposal, Proposals, PushProposal,
-        VotePlan, VoteCast
-    },
+    certificate::{ExternalProposalId, Proposal, Proposals, PushProposal, VoteCast, VotePlan},
     vote,
 };
 use chain_core::property::BlockDate as BlockDateProp;
@@ -48,7 +45,7 @@ impl VoteTestGen {
             BlockDate::from_epoch_slot_id(2, 0),
             BlockDate::from_epoch_slot_id(3, 0),
             VoteTestGen::proposals(3),
-            vote::PayloadType::Public
+            vote::PayloadType::Public,
         )
     }
 
@@ -58,7 +55,7 @@ impl VoteTestGen {
             BlockDate::from_epoch_slot_id(2, 0),
             BlockDate::from_epoch_slot_id(3, 0),
             VoteTestGen::proposals(count),
-            vote::PayloadType::Public
+            vote::PayloadType::Public,
         )
     }
 

--- a/chain-impl-mockchain/src/testing/scenario/controller.rs
+++ b/chain-impl-mockchain/src/testing/scenario/controller.rs
@@ -8,10 +8,9 @@ use crate::{
     },
 };
 
-use super::FragmentFactory;
 #[cfg(test)]
-use super::
-    scenario_builder::{prepare_scenario, stake_pool, wallet};
+use super::scenario_builder::{prepare_scenario, stake_pool, wallet};
+use super::FragmentFactory;
 #[cfg(test)]
 use chain_addr::Discrimination;
 

--- a/chain-impl-mockchain/src/testing/scenario/fragment_factory.rs
+++ b/chain-impl-mockchain/src/testing/scenario/fragment_factory.rs
@@ -1,6 +1,6 @@
 use crate::{
     accounting::account::{DelegationRatio, DelegationType},
-    certificate::{Certificate, PoolId, PoolUpdate, VotePlan, VoteCast},
+    certificate::{Certificate, PoolId, PoolUpdate, VoteCast, VotePlan},
     fee::LinearFee,
     fragment::Fragment,
     key::Hash,

--- a/chain-impl-mockchain/src/vote/committee.rs
+++ b/chain-impl-mockchain/src/vote/committee.rs
@@ -2,6 +2,7 @@ use chain_core::{
     mempack::{ReadBuf, ReadError, Readable},
     property,
 };
+use chain_crypto::{Ed25519, PublicKey};
 use std::{
     convert::TryFrom,
     fmt::{self, Debug, Display},
@@ -31,6 +32,10 @@ impl CommitteeId {
         hex::decode_to_slice(s, &mut bytes)?;
         Ok(CommitteeId(bytes))
     }
+
+    pub fn public_key(&self) -> PublicKey<Ed25519> {
+        self.clone().into()
+    }
 }
 
 /* Conversion ************************************************************** */
@@ -44,6 +49,13 @@ impl From<[u8; Self::COMMITTEE_ID_SIZE]> for CommitteeId {
 impl From<CommitteeId> for [u8; CommitteeId::COMMITTEE_ID_SIZE] {
     fn from(id: CommitteeId) -> Self {
         id.0
+    }
+}
+
+impl From<CommitteeId> for PublicKey<Ed25519> {
+    fn from(id: CommitteeId) -> Self {
+        PublicKey::from_binary(id.0.as_ref())
+            .expect("CommitteeId should be a valid Ed25519 public key")
     }
 }
 

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -85,6 +85,10 @@ impl ProposalManager {
         }
     }
 
+    pub fn tally(&self) -> Option<&Tally> {
+        self.tally.as_ref()
+    }
+
     /// apply the given vote cast to the proposal
     ///
     /// if there is already a vote present for this proposal it will

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -1,6 +1,6 @@
 use crate::{
     account,
-    certificate::{ExternalProposalId, Proposal, VoteCast, VotePlan, VotePlanId},
+    certificate::{Proposal, VoteCast, VotePlan, VotePlanId},
     date::BlockDate,
     transaction::UnspecifiedAccountIdentifier,
     vote::{self, Options, Tally, TallyResult, VotePlanStatus, VoteProposalStatus},
@@ -222,6 +222,7 @@ impl VotePlanManager {
                 proposal_id: proposal.external_id().clone(),
                 options: proposal.options().clone(),
                 tally: manager.tally.clone(),
+                votes: manager.votes_by_voters.clone(),
             })
             .collect();
 

--- a/chain-impl-mockchain/src/vote/mod.rs
+++ b/chain-impl-mockchain/src/vote/mod.rs
@@ -8,6 +8,7 @@ mod committee;
 mod ledger;
 mod manager;
 mod payload;
+mod status;
 mod tally;
 
 pub use self::{
@@ -16,5 +17,6 @@ pub use self::{
     ledger::{VotePlanLedger, VotePlanLedgerError},
     manager::{VoteError, VotePlanManager},
     payload::{Payload, PayloadType, TryFromIntError},
+    status::{VotePlanStatus, VoteProposalStatus},
     tally::{Tally, TallyError, TallyResult, Weight},
 };

--- a/chain-impl-mockchain/src/vote/mod.rs
+++ b/chain-impl-mockchain/src/vote/mod.rs
@@ -8,6 +8,7 @@ mod committee;
 mod ledger;
 mod manager;
 mod payload;
+mod tally;
 
 pub use self::{
     choice::{Choice, Options},
@@ -15,4 +16,5 @@ pub use self::{
     ledger::{VotePlanLedger, VotePlanLedgerError},
     manager::{VoteError, VotePlanManager},
     payload::{Payload, PayloadType, TryFromIntError},
+    tally::{Tally, TallyError, TallyResult, Weight},
 };

--- a/chain-impl-mockchain/src/vote/status.rs
+++ b/chain-impl-mockchain/src/vote/status.rs
@@ -1,8 +1,11 @@
 use crate::{
     certificate::{ExternalProposalId, VotePlanId},
     date::BlockDate,
-    vote::{Options, PayloadType, Tally},
+    transaction::UnspecifiedAccountIdentifier,
+    vote::{Options, Payload, PayloadType, Tally},
 };
+use imhamt::Hamt;
+use std::collections::hash_map::DefaultHasher;
 
 pub struct VotePlanStatus {
     pub id: VotePlanId,
@@ -18,4 +21,5 @@ pub struct VoteProposalStatus {
     pub proposal_id: ExternalProposalId,
     pub options: Options,
     pub tally: Option<Tally>,
+    pub votes: Hamt<DefaultHasher, UnspecifiedAccountIdentifier, Payload>,
 }

--- a/chain-impl-mockchain/src/vote/status.rs
+++ b/chain-impl-mockchain/src/vote/status.rs
@@ -1,0 +1,21 @@
+use crate::{
+    certificate::{ExternalProposalId, VotePlanId},
+    date::BlockDate,
+    vote::{Options, PayloadType, Tally},
+};
+
+pub struct VotePlanStatus {
+    pub id: VotePlanId,
+    pub payload: PayloadType,
+    pub vote_start: BlockDate,
+    pub vote_end: BlockDate,
+    pub committee_end: BlockDate,
+    pub proposals: Vec<VoteProposalStatus>,
+}
+
+pub struct VoteProposalStatus {
+    pub index: u8,
+    pub proposal_id: ExternalProposalId,
+    pub options: Options,
+    pub tally: Option<Tally>,
+}

--- a/chain-impl-mockchain/src/vote/tally.rs
+++ b/chain-impl-mockchain/src/vote/tally.rs
@@ -1,0 +1,131 @@
+use crate::{
+    stake::Stake,
+    value::Value,
+    vote::{Choice, Options},
+};
+use thiserror::Error;
+
+/// weight of a vote
+///
+/// it is often associated to the `stake`. when the tally is counted,
+/// each vote will have the associated weight encoded in.
+#[derive(Debug, Default, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct Weight(u64);
+
+/// the tally results
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TallyResult {
+    results: Box<[Weight]>,
+
+    options: Options,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Tally {
+    Public { result: TallyResult },
+}
+
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
+pub enum TallyError {
+    #[error("Invalid option choice")]
+    InvalidChoice { options: Options, choice: Choice },
+}
+
+impl Weight {
+    fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+
+    fn saturating_add(self, other: Self) -> Self {
+        Self(self.0.saturating_add(other.0))
+    }
+}
+
+impl Tally {
+    pub fn new_public(result: TallyResult) -> Self {
+        Self::Public { result }
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.public().is_some()
+    }
+
+    pub fn public(&self) -> Option<&TallyResult> {
+        match self {
+            Self::Public { result } => Some(result),
+        }
+    }
+}
+
+impl TallyResult {
+    pub fn new(options: Options) -> Self {
+        let results = Vec::with_capacity(options.choice_range().len()).into();
+        Self { results, options }
+    }
+
+    pub fn results(&self) -> &[Weight] {
+        &self.results
+    }
+
+    pub fn options(&self) -> &Options {
+        &self.options
+    }
+
+    /// add a vote and its weight on the tally
+    ///
+    /// if the vote's weight is null (`0`), nothing will be changed.
+    ///
+    /// # Errors
+    ///
+    /// The function will fail if the `choice` is not a valid `Option`
+    pub fn add_vote<W>(&mut self, choice: Choice, weight: W) -> Result<(), TallyError>
+    where
+        W: Into<Weight>,
+    {
+        let weight = weight.into();
+
+        if !self.options.validate(choice) {
+            Err(TallyError::InvalidChoice {
+                options: self.options.clone(),
+                choice,
+            })
+        } else if weight.is_zero() {
+            // we simply ignore the case where the `weight` is nul
+            //
+            // this may have been just as good as to not do the check as we would have
+            // add `0` to the results. However just so we know this is handled
+            // properly we know that adding a weight of `0` is ignored
+            Ok(())
+        } else {
+            let index = choice.as_byte() as usize;
+
+            self.results[index].saturating_add(weight);
+
+            Ok(())
+        }
+    }
+}
+
+impl From<Stake> for Weight {
+    fn from(stake: Stake) -> Self {
+        Self(stake.into())
+    }
+}
+
+impl From<Value> for Weight {
+    fn from(value: Value) -> Self {
+        Self(value.0)
+    }
+}
+
+impl From<u64> for Weight {
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl From<Weight> for u64 {
+    fn from(w: Weight) -> Self {
+        w.0
+    }
+}


### PR DESCRIPTION
We are still requiring a VoteTally certificate to be sent from the committee members.

This PR break APIs with Jörmungandr's as it changes the data exposed for the current votes. This new object is more consistent with what is being expected and provide more useful information regarding the votes (results, the different votes already submitted) etc...