### PR TITLE
Reserve a branch for CI testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - ci/test
   pull_request:
 
 jobs:


### PR DESCRIPTION
Pushes to this branch will cause the CI workflow to run without creating a PR.