### PR TITLE
GitHub CI: Work around special caching on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,8 @@ jobs:
         with:
           path: ~/.cargo/registry/index
           key: cargo-index-v2-${{ needs.update_deps.outputs.crates-io-index-head }}
+          # Windows needs fallback: https://github.com/actions/cache/issues/330
+          restore-keys: cargo-index-v2-
 
       - name: Restore dependency crates
         uses: actions/cache@v2


### PR DESCRIPTION
The cache action on the Windows runner won't find the same cache key that was saved on Linux, because issues. Let it find some proximate registry index state saved by a previous Windows run, rather than have a full miss and resync.