### PR TITLE
Cow versioned tree

### DIFF
--- a/btree/benches/benchmark.rs
+++ b/btree/benches/benchmark.rs
@@ -5,7 +5,6 @@ use crate::rand::rngs::StdRng;
 use crate::rand::Rng as _;
 use crate::rand::SeedableRng;
 use byteorder::{ByteOrder, LittleEndian};
-use std::convert::TryInto;
 
 static SEED: u64 = 11;
 
@@ -41,11 +40,10 @@ fn random_blob(rng: &mut impl rand::Rng) -> Box<[u8]> {
 fn single_key_insertion(c: &mut Criterion) {
     // TODO: Maybe create a temp file somehow?
     let dir_path = "benchmark_single_key_insertion";
-    let key_size = std::mem::size_of::<U64Key>();
     let page_size = 4096;
 
     let tree: BTreeStore<U64Key> =
-        BTreeStore::new(dir_path, key_size.try_into().unwrap(), page_size).unwrap();
+        BTreeStore::new(dir_path, page_size).unwrap();
 
     let n: u64 = 200_000;
 
@@ -78,11 +76,10 @@ fn single_key_insertion(c: &mut Criterion) {
 
 fn single_key_search(c: &mut Criterion) {
     let dir_path = "benchmark_single_key_search";
-    let key_size = std::mem::size_of::<U64Key>();
     let page_size = 4096;
 
     let tree: BTreeStore<U64Key> =
-        BTreeStore::new(dir_path, key_size.try_into().unwrap(), page_size).unwrap();
+        BTreeStore::new(dir_path, page_size).unwrap();
 
     let n: u64 = 200_000;
 

--- a/btree/examples/blockindex.rs
+++ b/btree/examples/blockindex.rs
@@ -8,7 +8,7 @@ struct Key([u8; 32]);
 
 fn main() -> io::Result<()> {
     let db: BTreeStore<Key> = BTreeStore::open("blocksdb")
-        .or_else(|_| BTreeStore::new("blocksdb", 32, 4096))
+        .or_else(|_| BTreeStore::new("blocksdb", 4096))
         .unwrap();
 
     for line in io::stdin().lock().lines() {

--- a/btree/src/arrayview.rs
+++ b/btree/src/arrayview.rs
@@ -54,14 +54,14 @@ where
         len: usize,
         element_size: usize,
     ) -> ArrayView<'elements, T, E> {
-        assert_eq!(
-            if element_size < 8 {
-                data.as_ref().as_ptr().align_offset(element_size)
-            } else {
-                0
-            },
-            0
-        );
+        // assert_eq!(
+        //     if element_size < 8 {
+        //         data.as_ref().as_ptr().align_offset(element_size)
+        //     } else {
+        //         0
+        //     },
+        //     0
+        // );
 
         ArrayView {
             data,
@@ -164,7 +164,14 @@ where
     T: AsRef<[u8]> + AsMut<[u8]> + 'elements,
 {
     pub(crate) fn insert(&mut self, pos: usize, element: &E) -> Result<(), ()> {
-        if self.len() < self.data.as_ref().len() / usize::from(&self.element_size) {
+        let stride = usize::from(&self.element_size);
+
+        if stride == 0 {
+            self.len += 1;
+            return Ok(());
+        }
+
+        if self.len() < self.data.as_ref().len() / stride {
             unsafe {
                 let src: *mut u8 = self
                     .data
@@ -205,7 +212,13 @@ where
     }
 
     pub(crate) fn delete(&mut self, pos: usize) -> Result<(), ()> {
+        let stride = usize::from(&self.element_size);
         if pos < self.len() {
+            if stride == 0 {
+                self.len -= 1;
+                return Ok(());
+            }
+
             unsafe {
                 let src: *mut u8 = self
                     .data

--- a/btree/src/btreeindex/metadata.rs
+++ b/btree/src/btreeindex/metadata.rs
@@ -109,7 +109,7 @@ mod tests {
         let metadata = Metadata::read(&mut file).unwrap();
 
         let page_manager = metadata.page_manager;
-        assert_eq!(page_manager.next_page(), FIRST_PAGE_ID);
+        assert_eq!(page_manager.next_page, FIRST_PAGE_ID);
         assert_eq!(page_manager.free_pages(), &vec![]);
 
         std::fs::remove_file("metadata_test").unwrap();

--- a/btree/src/btreeindex/mod.rs
+++ b/btree/src/btreeindex/mod.rs
@@ -244,7 +244,10 @@ where
 
     /// perform a range query. The returned iterator holds a read-only transaction for it's entire lifetime.
     /// This avoids pages to be collected, so it may better for it to not be long-lived.
-    pub fn range<R, Q>(&self, range: R) -> BTreeIterator<std::sync::Arc<Version>, R, Q, K, V>
+    pub fn range<R, Q>(
+        &self,
+        range: R,
+    ) -> BTreeIterator<std::sync::Arc<Version>, R, Q, K, V, &Pages>
     where
         K: Borrow<Q>,
         R: RangeBounds<Q>,

--- a/btree/src/btreeindex/multitree/mod.rs
+++ b/btree/src/btreeindex/multitree/mod.rs
@@ -1,0 +1,568 @@
+use super::page_manager::PageIdGenerator;
+use super::transaction::{ReadTransaction, WriteTransaction};
+use super::version_management::TreeIdentifier;
+use super::{ tree_algorithm, NODES_PER_PAGE, Node, PageId, Pages, PagesInitializationParams, StaticSettings };
+use crate::btreeindex::node::NodeRef;
+use crate::btreeindex::BTree;
+use crate::{BTreeStoreError, FixedSize};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use std::borrow::Borrow;
+use std::convert::{TryFrom, TryInto};
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::marker::PhantomData;
+use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use thiserror::Error;
+
+const STATIC_SETTINGS_FILE: &str = "static_settings";
+const TREE_FILE: &str = "tree_file";
+
+const ROOTS_FILE_PATH: &str = "roots_meta";
+
+const NEXT_PAGE_FILE: &str = "next_page";
+const FREE_PAGES_DIR_PATH: &str = "free_pages_meta";
+
+#[derive(Error, Debug)]
+pub enum TaggedTreeError {
+    #[error("source tag not found")]
+    SrcTagNotFound,
+    #[error("destination tag is already used")]
+    DstTagAlreadyExists,
+}
+
+pub struct TaggedTree<Tag, K, V>
+where
+    K: FixedSize,
+    V: FixedSize,
+    Tag: FixedSize,
+{
+    roots: BTree<Tag, PageId>,
+    page_manager: SharedPageGenerator,
+    static_settings: StaticSettings,
+    pages: Arc<Pages>,
+    phantom: PhantomData<(Tag, K, V)>,
+}
+
+struct PageGenerator {
+    free_pages: BTree<PageId, ()>,
+    next_page: AtomicU32,
+    next_page_file: File,
+}
+
+#[derive(Clone)]
+struct SharedPageGenerator(pub Arc<PageGenerator>);
+
+impl<Tag, K, V> TaggedTree<Tag, K, V>
+where
+    Tag: FixedSize,
+    K: FixedSize,
+    V: FixedSize,
+{
+    pub fn new(
+        dir_path: impl AsRef<Path>,
+        page_size: u16,
+        initial_tag: Tag,
+    ) -> Result<TaggedTree<Tag, K, V>, BTreeStoreError> {
+        std::fs::create_dir_all(dir_path.as_ref())?;
+
+        let mut static_settings_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(dir_path.as_ref().join(STATIC_SETTINGS_FILE))?;
+
+        let tree_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(dir_path.as_ref().join(TREE_FILE))?;
+
+        let pages_storage =
+            crate::storage::MmapStorage::new(tree_file, page_size as u64 * NODES_PER_PAGE)?;
+
+        let pages = Pages::new(PagesInitializationParams {
+            storage: pages_storage,
+            page_size: page_size.try_into().unwrap(),
+        });
+
+        let page_manager = Arc::new(PageGenerator::new(dir_path.as_ref())?);
+        let roots = BTree::new(dir_path.as_ref().join(ROOTS_FILE_PATH), 4096)?;
+
+        let first_page_id = page_manager.new_id();
+
+        roots.insert_one(initial_tag, first_page_id)?;
+
+        let mut root_page = pages.mut_page(first_page_id)?;
+
+        root_page.as_slice(|page| {
+            Node::<K, &mut [u8]>::new_leaf::<V>(page);
+        });
+
+        let static_settings = StaticSettings {
+            page_size,
+            key_buffer_size: K::max_size().try_into().unwrap(),
+        };
+
+        static_settings.write(&mut static_settings_file)?;
+
+        Ok(TaggedTree {
+            roots,
+            page_manager: SharedPageGenerator(page_manager),
+            static_settings,
+            pages: Arc::new(pages),
+            phantom: PhantomData,
+        })
+    }
+
+    pub fn open(dir_path: impl AsRef<Path>) -> Result<TaggedTree<Tag, K, V>, BTreeStoreError> {
+        let mut static_settings_file = OpenOptions::new()
+            .read(true)
+            .write(false)
+            .open(dir_path.as_ref().join(STATIC_SETTINGS_FILE))?;
+
+        let tree_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(dir_path.as_ref().join(TREE_FILE))?;
+
+        let static_settings = StaticSettings::read(&mut static_settings_file)?;
+
+        let pages_storage = crate::storage::MmapStorage::new(
+            tree_file,
+            static_settings.page_size as u64 * NODES_PER_PAGE,
+        )?;
+
+        let pages = Pages::new(PagesInitializationParams {
+            storage: pages_storage,
+            page_size: static_settings.page_size.try_into().unwrap(),
+        });
+
+        let roots = BTree::open(dir_path.as_ref().join(ROOTS_FILE_PATH))?;
+
+        let page_manager = Arc::new(PageGenerator::open(dir_path.as_ref())?);
+
+        Ok(TaggedTree {
+            roots,
+            page_manager: SharedPageGenerator(page_manager),
+            static_settings,
+            pages: Arc::new(pages),
+            phantom: PhantomData,
+        })
+    }
+
+    pub fn write(&self, from: Tag, to: Tag) -> Result<WriteTx<Tag, K, V>, BTreeStoreError> {
+        let root = self
+            .roots
+            .get(&from, |page_id| page_id.cloned())
+            .clone()
+            .ok_or(TaggedTreeError::SrcTagNotFound)?;
+
+        let page_size = usize::try_from(self.static_settings.page_size).unwrap();
+
+        Ok(WriteTx {
+            tx: WriteTransaction::new(root, &self.pages, self.page_manager.clone()),
+            roots: &self.roots,
+            page_size,
+            to,
+            pages: Arc::clone(&self.pages),
+            phantom: PhantomData,
+        })
+    }
+
+    pub fn read(&self, tag: Tag) -> Result<Option<ReadTx<K>>, BTreeStoreError> {
+        self.roots
+            .get(&tag, |root| {
+                root.map(|root| {
+                    Ok(ReadTx {
+                        tx: ReadTransaction::new(*root, Arc::clone(&self.pages)),
+                        phantom_keys: PhantomData,
+                    })
+                })
+            })
+            .transpose()
+    }
+
+    pub fn sync(&self) -> Result<(), BTreeStoreError> {
+        self.pages.sync_file()?;
+        self.roots.checkpoint()?;
+        self.page_manager.0.save()
+    }
+}
+
+pub struct WriteTx<'a, 'b, Tag: FixedSize, K: FixedSize, V: FixedSize> {
+    tx: WriteTransaction<'a, SharedPageGenerator>,
+    page_size: usize,
+    roots: &'b BTree<Tag, PageId>,
+    to: Tag,
+    pages: Arc<Pages>,
+    phantom: PhantomData<(K, V)>,
+}
+
+pub struct ReadTx<K: FixedSize> {
+    tx: ReadTransaction<PageId, Arc<Pages>>,
+    phantom_keys: PhantomData<K>,
+}
+
+impl<'a, 'b, Tag: FixedSize, K: FixedSize, V: FixedSize> WriteTx<'a, 'b, Tag, K, V> {
+    pub fn insert(&mut self, key: K, value: V) -> Result<(), BTreeStoreError> {
+        tree_algorithm::insert(&mut self.tx, key, value, self.page_size)?;
+
+        Ok(())
+    }
+
+    pub fn update(&mut self, key: &K, f: impl Fn(&V) -> V) -> Result<(), BTreeStoreError> {
+        super::backtrack::UpdateBacktrack::new_search_for(&mut self.tx, key).update(f)?;
+
+        Ok(())
+    }
+
+    pub fn update_or_default(
+        &mut self,
+        key: &K,
+        default: V,
+        update_with: impl Fn(&V) -> V,
+    ) -> Result<(), BTreeStoreError> {
+        let updated = self.update(key, update_with);
+        if let Err(BTreeStoreError::KeyNotFound) = updated {
+            self.insert(key.clone(), default)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn commit(self) -> Result<ReadTx<K>, BTreeStoreError> {
+        let delta = self.tx.commit::<K>();
+
+        self.roots
+            .insert_one(self.to, delta.new_root)
+            .map_err(|err| match err {
+                BTreeStoreError::DuplicatedKey => {
+                    BTreeStoreError::TaggedTree(TaggedTreeError::DstTagAlreadyExists)
+                }
+                err => err,
+            })?;
+
+        Ok(ReadTx {
+            tx: ReadTransaction::new(delta.new_root, self.pages),
+            phantom_keys: PhantomData,
+        })
+    }
+}
+
+impl<K: FixedSize> ReadTx<K> {
+    pub fn get<V, Q, F, R>(&self, key: &Q, f: F) -> R
+    where
+        Q: Ord,
+        K: Borrow<Q>,
+        V: FixedSize,
+        F: FnOnce(Option<&V>) -> R,
+    {
+        let page_ref = tree_algorithm::search::<PageId, K, Q, Arc<Pages>>(&self.tx, key);
+
+        page_ref.as_node(|node: Node<K, &[u8]>| {
+            match node.as_leaf::<V>().keys().binary_search::<Q>(key) {
+                Ok(pos) => f(Some(node.as_leaf::<V>().values().get(pos).borrow())),
+                Err(_) => f(None),
+            }
+        })
+    }
+}
+
+impl PageIdGenerator for SharedPageGenerator {
+    fn next_id(&self) -> PageId {
+        PageGenerator::next_id(&self.0)
+    }
+
+    fn new_id(&mut self) -> PageId {
+        PageGenerator::new_id(&self.0)
+    }
+}
+
+impl PageGenerator {
+    fn new(dir_path: impl AsRef<Path>) -> Result<PageGenerator, BTreeStoreError> {
+        let free_pages = BTree::new(dir_path.as_ref().join(FREE_PAGES_DIR_PATH), 4096)?;
+        let next_page = AtomicU32::new(1);
+
+        let mut next_page_file = OpenOptions::new()
+            .read(true)
+            .create(true)
+            .write(true)
+            .open(dir_path.as_ref().join(NEXT_PAGE_FILE))?;
+
+        next_page_file.write_u32::<LittleEndian>(1)?;
+
+        Ok(PageGenerator {
+            free_pages,
+            next_page,
+            next_page_file,
+        })
+    }
+
+    fn open(dir_path: impl AsRef<Path>) -> Result<PageGenerator, BTreeStoreError> {
+        let free_pages = BTree::open(dir_path.as_ref().join(FREE_PAGES_DIR_PATH))?;
+
+        let mut next_page_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(dir_path.as_ref().join(NEXT_PAGE_FILE))?;
+
+        let next_page = next_page_file
+            .read_u32::<LittleEndian>()
+            .expect("Couldn't read next page id");
+
+        Ok(PageGenerator {
+            free_pages,
+            next_page: AtomicU32::new(next_page),
+            next_page_file,
+        })
+    }
+
+    fn next_id(&self) -> PageId {
+        self.next_page.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    fn new_id(&self) -> PageId {
+        let next = self.free_pages.pop_max().expect("pop max shouldn't error");
+
+        next
+            .map(|(key, _)| key)
+            .unwrap_or_else(|| self.next_page.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn return_page(&self, page_id: PageId) -> Result<(), BTreeStoreError> {
+        self.free_pages.insert_one(page_id, ())?;
+
+        Ok(())
+    }
+
+    fn save(&self) -> Result<(), BTreeStoreError> {
+        let next_page = self.next_page.load(Ordering::SeqCst);
+
+        self.next_page_file
+            .try_clone()
+            .unwrap()
+            .write_all(&next_page.to_le_bytes())
+            .expect("Can't save next_page");
+
+        self.free_pages.checkpoint()?;
+
+        Ok(())
+    }
+}
+
+impl TreeIdentifier for PageId {
+    fn root(&self) -> PageId {
+        *self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::U64Key;
+    use tempfile::tempdir;
+
+    extern crate rand;
+    extern crate tempfile;
+
+    const INITIAL_TAG: u64 = 0;
+
+    fn new_tree() -> TaggedTree<U64Key, U64Key, U64Key> {
+        let dir_path = tempdir().unwrap();
+
+        let page_size = 88;
+
+        let tree: TaggedTree<U64Key, U64Key, U64Key> =
+            TaggedTree::new(dir_path.path(), page_size, U64Key(INITIAL_TAG)).unwrap();
+
+        tree
+    }
+
+    use model::*;
+    #[quickcheck]
+    fn test_scalar_add(ops: Vec<Op>) -> bool {
+        let db = new_tree();
+        let mut reference = Reference::default();
+
+        for op in ops {
+            match op {
+                Op::Write { from, to, op } => {
+                    let ref_result = reference.write(from, to, |old| {
+                        let mut new = old.clone();
+                        match op {
+                            WriteOp::InsertOrAdd { key, default, add } => {
+                                if let Some(value) = new.get_mut(&key) {
+                                    *value += add;
+                                } else {
+                                    new.insert(key, default);
+                                }
+                            }
+                        }
+
+                        new
+                    });
+
+                    let wtx = db.write(from.into(), to.into());
+
+                    let mut wtx = if let Err(TaggedTreeError::SrcTagNotFound) = ref_result {
+                        assert!(wtx.is_err());
+                        continue;
+                    } else {
+                        wtx.unwrap()
+                    };
+
+                    match op {
+                        WriteOp::InsertOrAdd { key, default, add } => {
+                            wtx.update_or_default(&U64Key(key), default.into(), |old| {
+                                U64Key::from(old.0 + add)
+                            })
+                            .unwrap();
+                        }
+                    }
+                    let commit = wtx.commit();
+
+                    if let Err(TaggedTreeError::DstTagAlreadyExists) = ref_result {
+                        assert!(commit.is_err());
+                        continue;
+                    } else {
+                        assert!(commit.is_ok());
+                    };
+
+                }
+                Op::Read { from, keys } => {
+                    let rtx = db.read(from.into()).unwrap();
+                    let pair = reference.read(from).map(|from| (from, rtx.unwrap()));
+
+                    if let Some((refversion, dbversion)) = pair {
+                        for k in keys {
+                            assert_eq!(
+                                refversion.get(&k).cloned(),
+                                dbversion.get(&U64Key(k), |iv| iv.map(|n: &U64Key| n.0))
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        true
+    }
+
+    #[test]
+    fn is_send() {
+        fn is_send<T: Send>() {
+        }
+
+        is_send::<TaggedTree<U64Key, U64Key, u64>>();
+    }
+
+    #[test]
+    fn is_sync() {
+        fn is_sync<T: Sync>() {
+        }
+
+        is_sync::<TaggedTree<U64Key, U64Key, u64>>();
+    }
+    
+    mod model {
+        use super::super::TaggedTreeError;
+        use quickcheck::{Arbitrary, Gen};
+        use rand::Rng;
+        use std::collections::BTreeMap;
+
+        pub struct Reference {
+            versions: BTreeMap<u64, BTreeMap<u64, u64>>,
+        }
+
+        impl Reference {
+            pub fn write<F>(
+                &mut self,
+                from: u64,
+                to: u64,
+                f: F,
+            ) -> Result<&BTreeMap<u64, u64>, TaggedTreeError>
+            where
+                F: Fn(&BTreeMap<u64, u64>) -> BTreeMap<u64, u64>,
+            {
+                let base = &self
+                    .versions
+                    .get(&from)
+                    .ok_or(TaggedTreeError::SrcTagNotFound)?;
+
+                if self.versions.get(&to).is_some() {
+                    return Err(TaggedTreeError::DstTagAlreadyExists);
+                }
+
+                let new = f(&base);
+                self.versions.insert(to, new);
+
+                Ok(&self.versions[&to])
+            }
+
+            pub fn read(&mut self, tag: u64) -> Option<&BTreeMap<u64, u64>> {
+                self.versions.get(&tag)
+            }
+        }
+
+        impl Default for Reference {
+            fn default() -> Reference {
+                let mut versions = <BTreeMap<u64, BTreeMap<u64, u64>>>::new();
+
+                versions.insert(super::INITIAL_TAG, <BTreeMap<u64, u64>>::new());
+
+                Reference { versions }
+            }
+        }
+
+        const MAX_TAG: u64 = 25;
+        const MAX_DEFAULT: u64 = 5;
+        const MAX_ADD: u64 = 10;
+        const MAX_KEY: u64 = 25;
+
+        #[derive(Clone, Debug)]
+        pub enum Op {
+            Write { from: u64, to: u64, op: WriteOp },
+            Read { from: u64, keys: Vec<u64> },
+        }
+
+        #[derive(Clone, Debug)]
+        pub enum WriteOp {
+            InsertOrAdd { key: u64, default: u64, add: u64 },
+        }
+
+        impl Arbitrary for Op {
+            fn arbitrary<G: Gen>(g: &mut G) -> Op {
+                match g.gen_range(0, 2) {
+                    0 => {
+                        let from = g.gen_range(0, MAX_TAG);
+                        let to = g.gen_range(0, MAX_TAG);
+
+                        let op = <WriteOp as Arbitrary>::arbitrary(g);
+
+                        Op::Write { from, to, op }
+                    }
+
+                    1 => {
+                        let from = g.gen_range(0, MAX_TAG);
+                        let keys = Vec::<u64>::arbitrary(g);
+
+                        Op::Read { from, keys }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        impl Arbitrary for WriteOp {
+            fn arbitrary<G: Gen>(g: &mut G) -> WriteOp {
+                let key = g.gen_range(0, MAX_KEY);
+                let default = g.gen_range(0, MAX_DEFAULT);
+                let add = g.gen_range(0, MAX_ADD);
+
+                WriteOp::InsertOrAdd { key, default, add }
+            }
+        }
+    }
+}

--- a/btree/src/btreeindex/node/internal_node.rs
+++ b/btree/src/btreeindex/node/internal_node.rs
@@ -33,6 +33,7 @@ pub(crate) enum InternalInsertStatus<K> {
 pub(crate) enum InternalDeleteStatus {
     Ok,
     NeedsRebalance,
+    LastValue(PageId),
 }
 
 impl<'b, K, T> InternalNode<'b, K, T>
@@ -273,12 +274,17 @@ where
         self.children_mut()
             .delete(pos + 1)
             .expect("Couldn't delete last child");
-        self.set_len(current_len - 1);
 
-        if self.children().len() < self.lower_bound() {
-            InternalDeleteStatus::NeedsRebalance
+        if dbg!(current_len) == 1 {
+            InternalDeleteStatus::LastValue(self.children().get(0))
         } else {
-            InternalDeleteStatus::Ok
+            self.set_len(current_len - 1);
+
+            if self.children().len() < self.lower_bound() {
+                InternalDeleteStatus::NeedsRebalance
+            } else {
+                InternalDeleteStatus::Ok
+            }
         }
     }
 

--- a/btree/src/btreeindex/node/internal_node.rs
+++ b/btree/src/btreeindex/node/internal_node.rs
@@ -275,7 +275,7 @@ where
             .delete(pos + 1)
             .expect("Couldn't delete last child");
 
-        if dbg!(current_len) == 1 {
+        if current_len == 1 {
             InternalDeleteStatus::LastValue(self.children().get(0))
         } else {
             self.set_len(current_len - 1);

--- a/btree/src/btreeindex/node/leaf_node.rs
+++ b/btree/src/btreeindex/node/leaf_node.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use super::{Node, NodeRef, NodeRefMut, RebalanceResult, RebalanceSiblingArg, SiblingsArg};
 use crate::btreeindex::{Keys, KeysMut, PageId, Values, ValuesMut};
 use crate::BTreeStoreError;
@@ -8,6 +6,7 @@ use crate::MemPage;
 use byteorder::ByteOrder as _;
 use byteorder::LittleEndian;
 use std::borrow::Borrow;
+use std::marker::PhantomData;
 
 use std::convert::{TryFrom, TryInto};
 use std::mem::size_of;
@@ -569,7 +568,6 @@ mod tests {
     use crate::btreeindex::node::tests::{internal_page, internal_page_mut, pages};
     use crate::btreeindex::pages::borrow::{Immutable, Mutable};
     use crate::btreeindex::pages::{PageHandle, Pages};
-    use crate::btreeindex::*;
     use crate::tests::U64Key;
     use std::mem::size_of;
 

--- a/btree/src/btreeindex/node/leaf_node.rs
+++ b/btree/src/btreeindex/node/leaf_node.rs
@@ -56,7 +56,7 @@ where
     pub(crate) unsafe fn from_raw(data: T) -> LeafNode<'b, K, V, T> {
         assert_eq!(data.as_ref().as_ptr().align_offset(size_of::<PageId>()), 0);
         assert_eq!(data.as_ref().as_ptr().align_offset(size_of::<u64>()), 0);
-        assert!(K::max_size() % 8 == 0);
+        // assert!(K::max_size() % 8 == 0);
 
         // let size_per_key = K::max_size() + size_of::<V>();
         let size_per_key = K::max_size() + V::max_size();

--- a/btree/src/btreeindex/pages.rs
+++ b/btree/src/btreeindex/pages.rs
@@ -5,10 +5,8 @@ use crate::FixedSize;
 use std::marker::PhantomData;
 use std::sync::Mutex;
 
-/// An abstraction over a paged file, Pages is kind of an array but backed from disk. Page represents at the moment
-/// a heap allocated read/write page, while PageRef is a wrapper to share a read only page in an Arc
-/// when we move to mmap, this things may change to take advantage of zero copy.
-
+/// An abstraction over a paged file, Pages is kind of an array but backed from disk.
+///
 pub struct Pages {
     storage: MmapStorage,
     page_size: u16,

--- a/btree/src/btreeindex/tree_algorithm.rs
+++ b/btree/src/btreeindex/tree_algorithm.rs
@@ -1,12 +1,13 @@
-use super::version_management::transaction::{
-    PageRef, PageRefMut, ReadTransaction, WriteTransaction,
-};
-
 use super::node::internal_node::InternalDeleteStatus;
 use super::node::leaf_node::LeafDeleteStatus;
 use super::node::{
     InternalInsertStatus, LeafInsertStatus, Node, NodeRef, NodeRefMut, RebalanceResult, SiblingsArg,
 };
+use super::pages::Pages;
+use super::version_management::transaction::{
+    PageRef, PageRefMut, ReadTransaction, WriteTransaction,
+};
+use super::version_management::TreeIdentifier;
 use crate::mem_page::MemPage;
 use crate::BTreeStoreError;
 use std::borrow::Borrow;
@@ -137,10 +138,12 @@ fn create_internal_node<K: FixedSize>(
     node
 }
 
-pub(crate) fn search<'a, K, Q>(tx: &'a ReadTransaction, key: &Q) -> PageRef<'a>
+pub(crate) fn search<'a, T, K, Q, P>(tx: &'a ReadTransaction<T, P>, key: &Q) -> PageRef<'a>
 where
     Q: Ord,
     K: FixedSize + Borrow<Q>,
+    P: Borrow<Pages>,
+    T: TreeIdentifier,
 {
     let mut current = tx.get_page(tx.root()).unwrap();
 

--- a/btree/src/btreeindex/tree_algorithm.rs
+++ b/btree/src/btreeindex/tree_algorithm.rs
@@ -1,0 +1,357 @@
+use super::version_management::transaction::{
+    PageRef, PageRefMut, ReadTransaction, WriteTransaction,
+};
+
+use super::node::internal_node::InternalDeleteStatus;
+use super::node::leaf_node::LeafDeleteStatus;
+use super::node::{
+    InternalInsertStatus, LeafInsertStatus, Node, NodeRef, NodeRefMut, RebalanceResult, SiblingsArg,
+};
+use crate::mem_page::MemPage;
+use crate::BTreeStoreError;
+use std::borrow::Borrow;
+
+use crate::FixedSize;
+
+use super::backtrack::{DeleteBacktrack, InsertBacktrack};
+use super::page_manager::PageIdGenerator;
+use super::PageId;
+
+type SplitKeyNodePair<K> = (K, Node<K, MemPage>);
+
+pub(crate) fn insert<K: FixedSize, V: FixedSize, G: PageIdGenerator>(
+    tx: &mut WriteTransaction<'_, G>,
+    key: K,
+    value: V,
+    page_size: usize,
+) -> Result<(), BTreeStoreError> {
+    let mut backtrack = InsertBacktrack::new_search_for(tx, &key);
+
+    let needs_recurse = {
+        let leaf = backtrack.get_next()?.unwrap();
+        let leaf_id = leaf.id();
+        insert_in_leaf(leaf, key, value, page_size)?
+            .map(|(split_key, new_node)| (leaf_id, split_key, new_node))
+    };
+
+    if let Some((leaf_id, split_key, new_node)) = needs_recurse {
+        let id = backtrack.add_new_node(new_node.into_page())?;
+
+        if backtrack.has_next() {
+            insert_in_internals(split_key, id, &mut backtrack, page_size)?;
+        } else {
+            let new_root = create_internal_node(leaf_id, id, split_key, page_size);
+            backtrack.new_root(new_root.into_page())?;
+        }
+    }
+
+    Ok(())
+}
+
+fn insert_in_leaf<K: FixedSize, V: FixedSize>(
+    mut leaf: PageRefMut,
+    key: K,
+    value: V,
+    page_size: usize,
+) -> Result<Option<SplitKeyNodePair<K>>, BTreeStoreError> {
+    let update = {
+        let mut allocate = || {
+            let uninit = MemPage::new(page_size);
+            Node::<K, MemPage>::new_leaf::<V>(uninit)
+        };
+
+        let insert_status = leaf.as_node_mut(move |mut node: Node<K, &mut [u8]>| {
+            node.as_leaf_mut().insert(key, value, &mut allocate)
+        });
+
+        match insert_status {
+            LeafInsertStatus::Ok => None,
+            LeafInsertStatus::DuplicatedKey(_k) => {
+                return Err(crate::BTreeStoreError::DuplicatedKey)
+            }
+            LeafInsertStatus::Split(split_key, node) => Some((split_key, node)),
+        }
+    };
+
+    Ok(update)
+}
+
+// this function recurses on the backtrack splitting internal nodes as needed
+fn insert_in_internals<'a, K: FixedSize, G: PageIdGenerator>(
+    key: K,
+    to_insert: PageId,
+    backtrack: &'a mut InsertBacktrack<K, G>,
+    page_size: usize,
+) -> Result<(), BTreeStoreError> {
+    let mut split_key = key;
+    let mut right_id = to_insert;
+    loop {
+        let (current_id, new_split_key, new_node) = {
+            let mut node = backtrack.get_next()?.unwrap();
+            let node_id = node.id();
+            let mut allocate = || {
+                let uninit = MemPage::new(page_size);
+                Node::new_internal(uninit)
+            };
+
+            match node.as_node_mut(|mut node| {
+                node.as_internal_mut()
+                    .insert(split_key, right_id, &mut allocate)
+            }) {
+                InternalInsertStatus::Ok => return Ok(()),
+                InternalInsertStatus::Split(split_key, new_node) => (node_id, split_key, new_node),
+                _ => unreachable!(),
+            }
+        };
+
+        let new_id = backtrack.add_new_node(new_node.into_page())?;
+
+        if backtrack.has_next() {
+            // set values to insert in next iteration (recurse on parent)
+            split_key = new_split_key;
+            right_id = new_id;
+        } else {
+            let left_id = current_id;
+            let right_id = new_id;
+            let new_root = create_internal_node(left_id, right_id, new_split_key, page_size);
+
+            backtrack.new_root(new_root.into_page())?;
+            return Ok(());
+        }
+    }
+}
+
+// Used when the current root needs a split
+fn create_internal_node<K: FixedSize>(
+    left_child: PageId,
+    right_child: PageId,
+    key: K,
+    page_size: usize,
+) -> Node<K, MemPage> {
+    let page = MemPage::new(page_size);
+    let mut node = Node::new_internal(page);
+
+    node.as_internal_mut()
+        .insert_first(key, left_child, right_child);
+
+    node
+}
+
+pub(crate) fn search<'a, K, Q>(tx: &'a ReadTransaction, key: &Q) -> PageRef<'a>
+where
+    Q: Ord,
+    K: FixedSize + Borrow<Q>,
+{
+    let mut current = tx.get_page(tx.root()).unwrap();
+
+    loop {
+        let new_current = current.as_node(|node: Node<K, &[u8]>| {
+            node.try_as_internal().map(|inode| {
+                let upper_pivot = match inode.keys().binary_search(key) {
+                    Ok(pos) => Some(pos + 1),
+                    Err(pos) => Some(pos),
+                }
+                .filter(|pos| pos < &inode.children().len());
+
+                let new_current_id = if let Some(upper_pivot) = upper_pivot {
+                    inode.children().get(upper_pivot)
+                } else {
+                    let last = inode.children().len().checked_sub(1).unwrap();
+                    inode.children().get(last)
+                };
+
+                tx.get_page(new_current_id).unwrap()
+            })
+        });
+
+        if let Some(new_current) = new_current {
+            current = new_current;
+        } else {
+            // found leaf
+            break;
+        }
+    }
+
+    current
+}
+
+pub(crate) fn delete<K: FixedSize, V: FixedSize, G: PageIdGenerator>(
+    key: &K,
+    tx: &mut WriteTransaction<G>,
+) -> Result<(), BTreeStoreError> {
+    let mut backtrack = DeleteBacktrack::new_search_for(tx, key);
+
+    // we can unwrap safely because there is always a leaf in the path
+    // delete will return Ok if the key is not in the given leaf
+    use super::backtrack::DeleteNextElement;
+    let DeleteNextElement {
+        mut next_element,
+        mut_context,
+    } = backtrack.get_next()?.unwrap();
+
+    let delete_result = next_element
+        .next
+        .as_node_mut(|mut node| node.as_leaf_mut::<V>().delete(key))?;
+
+    match delete_result {
+        LeafDeleteStatus::Ok => return Ok(()),
+        LeafDeleteStatus::NeedsRebalance => (),
+    };
+
+    // this allows us to get mutable references to out parent and siblings, we only need those when we need to rebalance
+    let mut mut_context = match mut_context {
+        super::backtrack::MutableContext::NonRoot(mut_context) => mut_context,
+        // this means we are processing the root node, it is not possible to do any rebalancing because we don't have siblings
+        // I think we don't need to do anything here, in theory, we could change the tree height to 0, but we are not tracking the height
+        super::backtrack::MutableContext::Root(_) => return Ok(()),
+    };
+
+    let next = &mut next_element.next;
+    let left = next_element.left.as_ref();
+    let right = next_element.right.as_ref();
+    // we need this to know which child we are (what position does this node have in the parent)
+    let anchor = next_element.anchor;
+
+    let should_recurse_on_parent: Option<usize> = next.as_node_mut(
+        |mut node: Node<K, &mut [u8]>| -> Result<Option<usize>, BTreeStoreError> {
+            let siblings = SiblingsArg::new_from_options(left, right);
+
+            match node.as_leaf_mut::<V>().rebalance(siblings)? {
+                RebalanceResult::TakeFromLeft(add_sibling) => {
+                    let (sibling, parent) = mut_context.mut_left_sibling();
+                    add_sibling.take_key_from_left(parent, anchor, sibling);
+                    Ok(None)
+                }
+                RebalanceResult::TakeFromRight(add_sibling) => {
+                    let (sibling, parent) = mut_context.mut_right_sibling();
+                    add_sibling.take_key_from_right(parent, anchor, sibling);
+                    Ok(None)
+                }
+                RebalanceResult::MergeIntoLeft(add_sibling) => {
+                    let (sibling, _) = mut_context.mut_left_sibling();
+                    add_sibling.merge_into_left(sibling);
+                    mut_context.delete_node();
+                    // the anchor is the the index of the key that splits the left sibling and the node, it's only None if the current node
+                    // it's the leftmost (and thus has no left sibling)
+                    Ok(Some(
+                        anchor.expect("merged into left sibling, but anchor is None"),
+                    ))
+                }
+                RebalanceResult::MergeIntoSelf(add_sibling) => {
+                    let (sibling, _) = mut_context.mut_right_sibling();
+                    add_sibling.merge_into_self(sibling);
+                    mut_context
+                        .delete_right_sibling()
+                        .expect("can't mutate right sibling");
+                    Ok(Some(anchor.map_or(0, |a| a + 1)))
+                }
+            }
+        },
+    )?;
+
+    // we need to do this because `mut_context` has a mutable borrow of the parent, which is the next node to process
+    // I don't think adding an additional scope and indentation level is worth it in that case. Geting rid of the closure above may be a better solution
+    drop(mut_context);
+
+    if let Some(anchor) = should_recurse_on_parent {
+        delete_internal(anchor, &mut backtrack)?;
+    }
+
+    Ok(())
+}
+
+fn delete_internal<'a, 'b: 'a, K: FixedSize, G: PageIdGenerator>(
+    anchor: usize,
+    tx: &'a mut DeleteBacktrack<'b, 'b, K, G>,
+) -> Result<(), BTreeStoreError> {
+    let mut anchor_to_delete = anchor;
+    while let Some(next_element) = tx.get_next()? {
+        let super::backtrack::DeleteNextElement {
+            mut next_element,
+            mut_context,
+        } = next_element;
+
+        let last_value = match next_element
+            .next
+            .as_node_mut(|mut node: Node<K, &mut [u8]>| {
+                let mut node = node.as_internal_mut();
+                node.delete_key_children(anchor_to_delete)
+            }) {
+            InternalDeleteStatus::Ok => return Ok(()),
+            InternalDeleteStatus::NeedsRebalance => None,
+            InternalDeleteStatus::LastValue(id) => Some(id),
+        };
+
+        match mut_context {
+            super::backtrack::MutableContext::Root(context) => {
+                // here we are dealing with the root
+                // the root is not rebalanced, but if it is empty then it can
+                // be deleted, and unlike the leaf case, we need to promote it's only remainining child as the new root
+                if let Some(new_root) = last_value {
+                    next_element.set_root(new_root);
+                }
+
+                context.delete_node()
+            }
+            super::backtrack::MutableContext::NonRoot(mut mut_context) => {
+                // non-root node
+                // let parent = next_element.parent.unwrap();
+                let anchor = next_element.anchor;
+                let left = next_element.left;
+                let right = next_element.right;
+
+                // as in the leaf case, the value in the Option is the 'anchor' (pointer) to the deleted node
+                let recurse_on_parent: Option<usize> = next_element.next.as_node_mut(
+                    |mut node: Node<K, &mut [u8]>| -> Result<Option<usize>, BTreeStoreError> {
+                        let siblings = SiblingsArg::new_from_options(left, right);
+
+                        match node.as_internal_mut().rebalance(siblings)? {
+                            RebalanceResult::TakeFromLeft(add_params) => {
+                                let (sibling, parent) = mut_context.mut_left_sibling();
+                                add_params.take_key_from_left(
+                                    parent,
+                                    anchor.expect("left sibling seems to exist but anchor is none"),
+                                    sibling,
+                                );
+                                Ok(None)
+                            }
+                            RebalanceResult::TakeFromRight(add_params) => {
+                                let (sibling, parent) = mut_context.mut_right_sibling();
+                                add_params.take_key_from_right(parent, anchor, sibling);
+                                Ok(None)
+                            }
+                            RebalanceResult::MergeIntoLeft(add_params) => {
+                                let (sibling, parent) = mut_context.mut_left_sibling();
+                                add_params.merge_into_left(parent, anchor, sibling)?;
+                                mut_context.delete_node();
+                                Ok(Some(
+                                    anchor
+                                        .clone()
+                                        .expect("merged into left sibling, but anchor is none"),
+                                ))
+                            }
+                            RebalanceResult::MergeIntoSelf(add_params) => {
+                                let (sibling, parent) = mut_context.mut_right_sibling();
+                                add_params.merge_into_self(parent, anchor, sibling)?;
+                                let new_anchor = anchor.map_or(0, |n| n + 1);
+                                mut_context
+                                    .delete_right_sibling()
+                                    .expect("right sibling doesn't exist");
+                                Ok(Some(new_anchor))
+                            }
+                        }
+                    },
+                )?;
+
+                // (there is no recursive call, we just go the next loop iteration)
+                if let Some(anchor) = recurse_on_parent {
+                    anchor_to_delete = anchor;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/btree/src/btreeindex/version_management/transaction.rs
+++ b/btree/src/btreeindex/version_management/transaction.rs
@@ -165,7 +165,6 @@ impl<'locks, 'storage: 'locks, G: PageIdGenerator> WriteTransaction<'storage, G>
             None => {
                 let old_id = id;
                 let new_id = state.page_manager.new_id();
-                // let new_id = new_id();
 
                 self.pages.make_shadow(old_id, new_id)?;
 

--- a/btree/src/lib.rs
+++ b/btree/src/lib.rs
@@ -7,20 +7,16 @@ pub mod btreeindex;
 pub mod flatfile;
 mod mem_page;
 pub mod storage;
-use flatfile::MmapedAppendOnlyFile;
-
-const APPENDER_FILE_PATH: &str = "flatfile";
-
-use mem_page::MemPage;
-
 use crate::btreeindex::BTree;
+use flatfile::MmapedAppendOnlyFile;
+use mem_page::MemPage;
 use std::borrow::Borrow;
 use std::convert::TryInto;
 use std::fmt::Debug;
-use std::fs::OpenOptions;
 use std::path::Path;
-
 use thiserror::Error;
+
+const APPENDER_FILE_PATH: &str = "flatfile";
 
 type Offset = u64;
 
@@ -54,10 +50,7 @@ impl<K> BTreeStore<K>
 where
     K: FixedSize,
 {
-    pub fn new(
-        path: impl AsRef<Path>,
-        page_size: u16,
-    ) -> Result<BTreeStore<K>, BTreeStoreError> {
+    pub fn new(path: impl AsRef<Path>, page_size: u16) -> Result<BTreeStore<K>, BTreeStoreError> {
         std::fs::create_dir_all(path.as_ref())?;
 
         let flatfile = MmapedAppendOnlyFile::new(path.as_ref().join(APPENDER_FILE_PATH))?;


### PR DESCRIPTION
# Some refactors to the btree algorithm to act as an append-only tree

Out of curiosity I refactored out the algorithms currently used by the BTreeIndex (which is a normal key-value store) into some kind of multiversioned key-value store. It's just a prototype/experiment, but I'll share it anyway in case someone finds it interesting (it works in general, but there are some important things missing, like garbage collection, maybe a multimap, and it's probably not completely crashproof).

As a background, the way the btree works right now is by keeping multiple versions but in a linear fashion (enforced by a writer lock), and only keeps old versions as long as someone is reading from them (MVCC, with reference counting in memory). The multiple versions are not full copies, of course, they use structural sharing (shadowing, with a root swap). Also, when a version is discarded the now unreachable pages are reused (so the file doesn't grow indefinitely), reusing pages is way simpler in a linear history, though, for a tree of versions I guess some kind of reference counting could be used (I think it's what filesystems do).

*Note*: the actual new code is in *src/multitree*, the rest is mostly moving things around and adding generics/traits for reusing the code.

## TaggedTree

Kind of: `BTreeMap<VersionTag, ImBTree<K, V>>`

Just adds names to those versions. It's essentially an append-only tree, because it doesn't have the gc/page re-use that the non-versioned version has. Although my idea was to reutilize non-reachable pages too.

As a reference, keeping the balance per address for **each one** of the first 300_000 blocks/versions of the ITN took about 900mb of disk space. (although there is no point in keeping that many versions stored, and not all of them have transactions, of course. And there may be bugs somewhere)