### PR TITLE
use sha2 version of Digest for Sha256 object

### DIFF
--- a/chain-crypto/src/algorithms/sumed25519/common.rs
+++ b/chain-crypto/src/algorithms/sumed25519/common.rs
@@ -58,7 +58,7 @@ impl Depth {
 }
 
 pub fn split_seed(r: &Seed) -> (Seed, Seed) {
-    use ed25519_dalek::Digest;
+    use sha2::Digest;
     let mut hleft = sha2::Sha256::default();
     let mut hright = sha2::Sha256::default();
 

--- a/chain-crypto/src/algorithms/sumed25519/sum.rs
+++ b/chain-crypto/src/algorithms/sumed25519/sum.rs
@@ -1,6 +1,6 @@
 use super::common::{self, Depth, Seed};
 use ed25519_dalek as ed25519;
-use ed25519_dalek::{Digest, Signer as _, Verifier as _};
+use ed25519_dalek::{Signer as _, Verifier as _};
 use std::convert::TryFrom as _;
 //use std::hash::Hash;
 
@@ -487,6 +487,7 @@ impl Signature {
 }
 
 pub fn hash(pk1: &PublicKey, pk2: &PublicKey) -> PublicKey {
+    use sha2::Digest as _;
     let mut out = [0u8; 32];
     let mut h = sha2::Sha256::default();
     h.input(&pk1.0);

--- a/chain-crypto/src/algorithms/sumed25519/sumrec.rs
+++ b/chain-crypto/src/algorithms/sumed25519/sumrec.rs
@@ -4,7 +4,7 @@
 // is sum. this module should never be used for anything but testing.
 use super::common::{self, Depth, Seed};
 use ed25519_dalek as ed25519;
-use ed25519_dalek::{Digest, Signer as _, Verifier as _};
+use ed25519_dalek::{Signer as _, Verifier as _};
 
 pub enum SecretKey {
     Leaf(ed25519::Keypair),
@@ -32,6 +32,7 @@ pub enum Signature {
 }
 
 pub fn hash(pk1: &PublicKey, pk2: &PublicKey) -> [u8; 32] {
+    use sha2::Digest;
     let mut out = [0u8; 32];
     let mut h = sha2::Sha256::default();
     h.input(pk1.as_bytes());


### PR DESCRIPTION
instead of the ed25519_dalek version, which can be incompatible

we could also upgrade sha2, but I think this is more consistent anyway.