### PR TITLE
Update crypto dependencies

### DIFF
--- a/chain-crypto/Cargo.toml
+++ b/chain-crypto/Cargo.toml
@@ -9,9 +9,9 @@ keywords = [ "Crypto", "VRF", "Ed25519", "MMM" ]
 [dependencies]
 bech32 = "0.7"
 cryptoxide = "0.2"
-curve25519-dalek = "2"
-ed25519-dalek = "1.0.0-pre.4"
-sha2 = "^0.8"
+curve25519-dalek = "3.0"
+ed25519-dalek = "1.0"
+sha2 = "0.9"
 digest = "^0.9"
 generic-array = "^0.14"
 rand_core = "0.5"

--- a/chain-crypto/src/algorithms/sumed25519/common.rs
+++ b/chain-crypto/src/algorithms/sumed25519/common.rs
@@ -62,14 +62,14 @@ pub fn split_seed(r: &Seed) -> (Seed, Seed) {
     let mut hleft = sha2::Sha256::default();
     let mut hright = sha2::Sha256::default();
 
-    hleft.input(&[1]);
-    hleft.input(&r.0);
+    hleft.update(&[1]);
+    hleft.update(&r.0);
 
-    hright.input(&[2]);
-    hright.input(&r.0);
+    hright.update(&[2]);
+    hright.update(&r.0);
 
-    let o1 = hleft.result();
-    let o2 = hright.result();
+    let o1 = hleft.finalize();
+    let o2 = hright.finalize();
     let s1 = Seed::from_slice(&o1);
     let s2 = Seed::from_slice(&o2);
     (s1, s2)

--- a/chain-crypto/src/algorithms/sumed25519/sum.rs
+++ b/chain-crypto/src/algorithms/sumed25519/sum.rs
@@ -490,10 +490,10 @@ pub fn hash(pk1: &PublicKey, pk2: &PublicKey) -> PublicKey {
     use sha2::Digest as _;
     let mut out = [0u8; 32];
     let mut h = sha2::Sha256::default();
-    h.input(&pk1.0);
-    h.input(&pk2.0);
+    h.update(&pk1.0);
+    h.update(&pk2.0);
 
-    let o = h.result();
+    let o = h.finalize();
     out.copy_from_slice(&o);
     PublicKey(out)
 }

--- a/chain-crypto/src/algorithms/sumed25519/sumrec.rs
+++ b/chain-crypto/src/algorithms/sumed25519/sumrec.rs
@@ -35,10 +35,10 @@ pub fn hash(pk1: &PublicKey, pk2: &PublicKey) -> [u8; 32] {
     use sha2::Digest;
     let mut out = [0u8; 32];
     let mut h = sha2::Sha256::default();
-    h.input(pk1.as_bytes());
-    h.input(pk2.as_bytes());
+    h.update(pk1.as_bytes());
+    h.update(pk2.as_bytes());
 
-    let o = h.result();
+    let o = h.finalize();
     out.copy_from_slice(&o);
     out
 }

--- a/chain-crypto/src/algorithms/vrf/dleq.rs
+++ b/chain-crypto/src/algorithms/vrf/dleq.rs
@@ -50,10 +50,10 @@ struct Challenge(Scalar);
 
 fn challenge(h1: &Point, h2: &Point, a1: &Point, a2: &Point) -> Challenge {
     let mut d = Sha512::new();
-    d.input(h1.compress().as_bytes());
-    d.input(h2.compress().as_bytes());
-    d.input(a1.compress().as_bytes());
-    d.input(a2.compress().as_bytes());
+    d.update(h1.compress().as_bytes());
+    d.update(h2.compress().as_bytes());
+    d.update(a1.compress().as_bytes());
+    d.update(a2.compress().as_bytes());
     Challenge(Scalar::from_hash(d))
 }
 

--- a/chain-crypto/src/algorithms/vrf/vrf.rs
+++ b/chain-crypto/src/algorithms/vrf/vrf.rs
@@ -254,7 +254,7 @@ impl OutputSeed {
 fn make_message_hash_point(data: &[u8]) -> Point {
     let m_hash = {
         let mut c = Sha512::new();
-        c.input(data);
+        c.update(data);
         c
     };
     Point::from_hash(m_hash)


### PR DESCRIPTION
Bump `curve25519-dalek`, `ed25519-dalek`, and `sha2` to latest stable versions and update to the API changes.