### PR TITLE
add secret key to_inner

### DIFF
--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -167,6 +167,9 @@ impl<A: AsymmetricKey> SecretKey<A> {
     pub fn from_binary(data: &[u8]) -> Result<Self, SecretKeyError> {
         Ok(SecretKey(<A as AsymmetricKey>::secret_from_binary(data)?))
     }
+    pub fn inner(self) -> A::Secret {
+        self.0
+    }
 }
 
 impl<A: AsymmetricPublicKey> PublicKey<A> {

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -167,7 +167,10 @@ impl<A: AsymmetricKey> SecretKey<A> {
     pub fn from_binary(data: &[u8]) -> Result<Self, SecretKeyError> {
         Ok(SecretKey(<A as AsymmetricKey>::secret_from_binary(data)?))
     }
-    pub fn security_leak(self) -> A::Secret {
+    // get ownership of the secret key, allowing to get its byte representation.
+    // On the other hand, this may allow unintentionally logging keys through
+    // AsRef
+    pub fn leak_secret(self) -> A::Secret {
         self.0
     }
 }

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -167,7 +167,7 @@ impl<A: AsymmetricKey> SecretKey<A> {
     pub fn from_binary(data: &[u8]) -> Result<Self, SecretKeyError> {
         Ok(SecretKey(<A as AsymmetricKey>::secret_from_binary(data)?))
     }
-    pub fn inner(self) -> A::Secret {
+    pub fn security_leak(self) -> A::Secret {
         self.0
     }
 }


### PR DESCRIPTION
Context: For the QR code generation for the voting app, we need to generate private keys and be able to write them. But currently the only way I find of getting the key out is as bech32. I'm not sure if there are any security concerns with doing it this way?