### PR TITLE
Add node ID authentication to protocol handshake

### DIFF
--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -66,7 +66,7 @@ impl<A: AsymmetricKey> KeyPair<A> {
     pub fn into_keys(self) -> (SecretKey<A>, PublicKey<A::PubAlg>) {
         (self.0, self.1)
     }
-    pub fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    pub fn generate<R: RngCore + CryptoRng>(rng: R) -> Self {
         let sk = A::generate(rng);
         let pk = A::compute_public(&sk);
         KeyPair(SecretKey(sk), PublicKey(pk))

--- a/chain-network/Cargo.toml
+++ b/chain-network/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+chain-crypto = { path = "../chain-crypto" }
 async-trait = "0.1"
 futures = "0.3"
 pin-project = "0.4"
 prost = "0.6"
-rand_core = { version = "0.5", optional = true }
+rand_core = { version = "0.5" }
 thiserror = "1.0"
 
 [dependencies.tonic]
@@ -29,5 +30,5 @@ features = ["prost"]
 [features]
 default = ["transport", "legacy"]
 transport = ["tonic/transport", "tonic-build/transport"]
-legacy = ["rand_core"]
+legacy = []
 codegen-rustfmt = ["tonic-build/rustfmt"]

--- a/chain-network/proto/node.proto
+++ b/chain-network/proto/node.proto
@@ -5,10 +5,8 @@ package iohk.chain.node;
 
 // Request message for method Handshake.
 message HandshakeRequest {
-  // Node ID of the client, the public key of a key pair.
-  bytes node_id = 3;
   // Nonce for the server to authenticate its node ID with.
-  bytes nonce = 4;
+  bytes nonce = 1;
 }
 
 // Response message for method Handshake.
@@ -23,7 +21,21 @@ message HandshakeResponse {
   // Signature of the client's nonce using the private key in the server's
   // key pair.
   bytes signature = 4;
+  // Nonce for the client to authenticate its node ID with.
+  bytes nonce = 5;
 }
+
+// Request message for method ClientAuth.
+message ClientAuthRequest {
+  // Node ID of the client, the public key of a key pair.
+  bytes node_id = 1;
+  // Signature of the server's nonce sent in HandshakeResponse,
+  // using the private key in the client's key pair.
+  bytes signature = 2;
+}
+
+// Response message for method ClientAuth.
+message ClientAuthResponse {}
 
 // Request message for method Tip.
 message TipRequest {}
@@ -138,7 +150,13 @@ message BlockEvent {
 }
 
 service Node {
+  // Initial handshake and authentication of the server node.
   rpc Handshake(HandshakeRequest) returns (HandshakeResponse);
+
+  // Optional authentication of the client node.
+  // Called after Handshake.
+  rpc ClientAuth(ClientAuthRequest) returns (ClientAuthResponse);
+
   rpc Tip(TipRequest) returns (TipResponse);
 
   // Requests for some peers

--- a/chain-network/proto/node.proto
+++ b/chain-network/proto/node.proto
@@ -4,7 +4,12 @@ syntax = "proto3";
 package iohk.chain.node;
 
 // Request message for method Handshake.
-message HandshakeRequest {}
+message HandshakeRequest {
+  // Node ID of the client, the public key of a key pair.
+  bytes node_id = 3;
+  // Nonce for the server to authenticate its node ID with.
+  bytes nonce = 4;
+}
 
 // Response message for method Handshake.
 message HandshakeResponse {
@@ -13,6 +18,11 @@ message HandshakeResponse {
   // The identifier of the genesis block. This can be used by the client
   // to determine if the server node runs the expected blockchain.
   bytes block0 = 2;
+  // Node ID of the server, the public key of a key pair.
+  bytes node_id = 3;
+  // Signature of the client's nonce using the private key in the server's
+  // key pair.
+  bytes signature = 4;
 }
 
 // Request message for method Tip.

--- a/chain-network/src/core/server/block.rs
+++ b/chain-network/src/core/server/block.rs
@@ -8,9 +8,6 @@ use futures::prelude::*;
 /// providing access to block data.
 #[async_trait]
 pub trait BlockService {
-    /// Returns the ID of the genesis block of the chain served by this node.
-    fn block0(&self) -> BlockId;
-
     /// Serves a request for the current blockchain tip.
     /// Resolves to the tip of the blockchain
     /// accepted by this node.

--- a/chain-network/src/core/server/node.rs
+++ b/chain-network/src/core/server/node.rs
@@ -1,4 +1,7 @@
 use super::{BlockService, FragmentService, GossipService};
+use crate::data::p2p::{NodeId, SignedNodeId};
+use crate::data::BlockId;
+use crate::error::Error;
 
 /// Interface to application logic of the blockchain node server.
 ///
@@ -14,6 +17,11 @@ pub trait Node: Send + Sync + 'static {
 
     /// The implementation of the gossip service.
     type GossipService: GossipService + Send + Sync;
+
+    /// Implements node handshake. Remote node ID is passed in `peer_id`,
+    /// as well as bytes of `nonce`. The server returns the
+    /// ID of the genesis block and its own node ID, signed using the nonce.
+    fn handshake(&self, peer_id: NodeId, nonce: &[u8]) -> Result<(BlockId, SignedNodeId), Error>;
 
     /// Instantiates the block service,
     /// if supported by this node.

--- a/chain-network/src/core/server/node.rs
+++ b/chain-network/src/core/server/node.rs
@@ -18,9 +18,12 @@ pub trait Node: Send + Sync + 'static {
     /// The implementation of the gossip service.
     type GossipService: GossipService + Send + Sync;
 
+    /// Implements node handshake. A remote node ID, if available, is passed in
+    /// `peer_id`. The server returns the ID of the genesis block and its own
+    /// node ID, authenticated with the signature of `nonce`.
     fn handshake(
         &self,
-        peer_id: NodeId,
+        peer_id: Option<NodeId>,
         nonce: &[u8],
     ) -> Result<(BlockId, AuthenticatedNodeId), Error>;
 

--- a/chain-network/src/core/server/node.rs
+++ b/chain-network/src/core/server/node.rs
@@ -1,13 +1,15 @@
 use super::{BlockService, FragmentService, GossipService};
-use crate::data::p2p::AuthenticatedNodeId;
+use crate::data::p2p::{AuthenticatedNodeId, Peer};
 use crate::data::HandshakeResponse;
 use crate::error::Error;
+use async_trait::async_trait;
 
 /// Interface to application logic of the blockchain node server.
 ///
 /// An implementation of a blockchain node implements this trait to
 /// serve the network protocols using node's subsystems such as
 /// block storage and fragment processor.
+#[async_trait]
 pub trait Node: Send + Sync + 'static {
     /// The implementation of the block service.
     type BlockService: BlockService + Send + Sync;
@@ -20,10 +22,10 @@ pub trait Node: Send + Sync + 'static {
 
     /// Implements node handshake. The server returns the ID of the genesis
     /// block and its own node ID, authenticated with the signature of `nonce`.
-    fn handshake(&self, nonce: &[u8]) -> Result<HandshakeResponse, Error>;
+    async fn handshake(&self, peer: Peer, nonce: &[u8]) -> Result<HandshakeResponse, Error>;
 
     /// Handles client ID authentication.
-    fn client_auth(&self, auth: AuthenticatedNodeId) -> Result<(), Error>;
+    async fn client_auth(&self, peer: Peer, auth: AuthenticatedNodeId) -> Result<(), Error>;
 
     /// Instantiates the block service,
     /// if supported by this node.

--- a/chain-network/src/core/server/node.rs
+++ b/chain-network/src/core/server/node.rs
@@ -1,6 +1,6 @@
 use super::{BlockService, FragmentService, GossipService};
-use crate::data::p2p::{AuthenticatedNodeId, NodeId};
-use crate::data::BlockId;
+use crate::data::p2p::AuthenticatedNodeId;
+use crate::data::HandshakeResponse;
 use crate::error::Error;
 
 /// Interface to application logic of the blockchain node server.
@@ -18,14 +18,12 @@ pub trait Node: Send + Sync + 'static {
     /// The implementation of the gossip service.
     type GossipService: GossipService + Send + Sync;
 
-    /// Implements node handshake. A remote node ID, if available, is passed in
-    /// `peer_id`. The server returns the ID of the genesis block and its own
-    /// node ID, authenticated with the signature of `nonce`.
-    fn handshake(
-        &self,
-        peer_id: Option<NodeId>,
-        nonce: &[u8],
-    ) -> Result<(BlockId, AuthenticatedNodeId), Error>;
+    /// Implements node handshake. The server returns the ID of the genesis
+    /// block and its own node ID, authenticated with the signature of `nonce`.
+    fn handshake(&self, nonce: &[u8]) -> Result<HandshakeResponse, Error>;
+
+    /// Handles client ID authentication.
+    fn client_auth(&self, auth: AuthenticatedNodeId) -> Result<(), Error>;
 
     /// Instantiates the block service,
     /// if supported by this node.

--- a/chain-network/src/core/server/node.rs
+++ b/chain-network/src/core/server/node.rs
@@ -1,5 +1,5 @@
 use super::{BlockService, FragmentService, GossipService};
-use crate::data::p2p::{NodeId, SignedNodeId};
+use crate::data::p2p::{AuthenticatedNodeId, NodeId};
 use crate::data::BlockId;
 use crate::error::Error;
 
@@ -18,10 +18,11 @@ pub trait Node: Send + Sync + 'static {
     /// The implementation of the gossip service.
     type GossipService: GossipService + Send + Sync;
 
-    /// Implements node handshake. Remote node ID is passed in `peer_id`,
-    /// as well as bytes of `nonce`. The server returns the
-    /// ID of the genesis block and its own node ID, signed using the nonce.
-    fn handshake(&self, peer_id: NodeId, nonce: &[u8]) -> Result<(BlockId, SignedNodeId), Error>;
+    fn handshake(
+        &self,
+        peer_id: NodeId,
+        nonce: &[u8],
+    ) -> Result<(BlockId, AuthenticatedNodeId), Error>;
 
     /// Instantiates the block service,
     /// if supported by this node.

--- a/chain-network/src/data/handshake.rs
+++ b/chain-network/src/data/handshake.rs
@@ -1,0 +1,8 @@
+use super::block::BlockId;
+use super::p2p::AuthenticatedNodeId;
+
+pub struct HandshakeResponse {
+    pub block0_id: BlockId,
+    pub auth: AuthenticatedNodeId,
+    pub nonce: Box<[u8]>,
+}

--- a/chain-network/src/data/mod.rs
+++ b/chain-network/src/data/mod.rs
@@ -8,4 +8,4 @@ pub use block::{Block, BlockEvent, BlockId, BlockIds, Header};
 pub use fragment::{Fragment, FragmentId, FragmentIds};
 pub use gossip::Gossip;
 pub use handshake::HandshakeResponse;
-pub use p2p::{Peer, Peers};
+pub use p2p::{AuthenticatedNodeId, NodeId, Peer, Peers};

--- a/chain-network/src/data/mod.rs
+++ b/chain-network/src/data/mod.rs
@@ -8,4 +8,4 @@ pub use block::{Block, BlockEvent, BlockId, BlockIds, Header};
 pub use fragment::{Fragment, FragmentId, FragmentIds};
 pub use gossip::Gossip;
 pub use handshake::HandshakeResponse;
-pub use p2p::{AuthenticatedNodeId, NodeId, Peer, Peers};
+pub use p2p::{AuthenticatedNodeId, NodeId, NodeKeyPair, Peer, Peers};

--- a/chain-network/src/data/mod.rs
+++ b/chain-network/src/data/mod.rs
@@ -1,9 +1,11 @@
 pub mod block;
 pub mod fragment;
 pub mod gossip;
+mod handshake;
 pub mod p2p;
 
 pub use block::{Block, BlockEvent, BlockId, BlockIds, Header};
 pub use fragment::{Fragment, FragmentId, FragmentIds};
 pub use gossip::Gossip;
+pub use handshake::HandshakeResponse;
 pub use p2p::{Peer, Peers};

--- a/chain-network/src/data/p2p.rs
+++ b/chain-network/src/data/p2p.rs
@@ -98,3 +98,9 @@ impl AuthenticatedNodeId {
         &self.signature
     }
 }
+
+impl From<AuthenticatedNodeId> for NodeId {
+    fn from(auth: AuthenticatedNodeId) -> Self {
+        auth.id
+    }
+}

--- a/chain-network/src/data/p2p.rs
+++ b/chain-network/src/data/p2p.rs
@@ -52,14 +52,14 @@ impl NodeId {
         &self.0
     }
 
-    pub fn signed(self, signature: &[u8]) -> Result<SignedNodeId, Error> {
+    pub fn authenticated(self, signature: &[u8]) -> Result<AuthenticatedNodeId, Error> {
         if signature.len() != NODE_SIGNATURE_LEN {
             return Err(Error::new(
                 Code::InvalidArgument,
                 format!("node signature must be {} bytes long", NODE_SIGNATURE_LEN),
             ));
         }
-        let mut res = SignedNodeId {
+        let mut res = AuthenticatedNodeId {
             id: self,
             signature: [0; NODE_SIGNATURE_LEN],
         };
@@ -84,12 +84,12 @@ impl TryFrom<&[u8]> for NodeId {
 
 const NODE_SIGNATURE_LEN: usize = 64;
 
-pub struct SignedNodeId {
+pub struct AuthenticatedNodeId {
     id: NodeId,
     signature: [u8; NODE_SIGNATURE_LEN],
 }
 
-impl SignedNodeId {
+impl AuthenticatedNodeId {
     pub fn id(&self) -> &NodeId {
         &self.id
     }

--- a/chain-network/src/data/p2p.rs
+++ b/chain-network/src/data/p2p.rs
@@ -35,6 +35,7 @@ impl fmt::Display for Peer {
 
 /// The key pair used to authenticate a network node,
 /// including the secret key.
+#[derive(Clone, Debug)]
 pub struct NodeKeyPair(KeyPair<Ed25519>);
 
 impl NodeKeyPair {

--- a/chain-network/src/data/p2p.rs
+++ b/chain-network/src/data/p2p.rs
@@ -1,3 +1,6 @@
+use crate::error::{Code, Error};
+
+use std::convert::TryFrom;
 use std::fmt;
 use std::net::SocketAddr;
 
@@ -25,5 +28,73 @@ impl From<SocketAddr> for Peer {
 impl fmt::Display for Peer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.addr)
+    }
+}
+
+const NODE_ID_LEN: usize = 32;
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct NodeId([u8; NODE_ID_LEN]);
+
+impl fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("NodeId(0x")?;
+        for byte in self.0.iter() {
+            write!(f, "{:02x}", byte)?;
+        }
+        f.write_str(")")
+    }
+}
+
+impl NodeId {
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn signed(self, signature: &[u8]) -> Result<SignedNodeId, Error> {
+        if signature.len() != NODE_SIGNATURE_LEN {
+            return Err(Error::new(
+                Code::InvalidArgument,
+                format!("node signature must be {} bytes long", NODE_SIGNATURE_LEN),
+            ));
+        }
+        let mut res = SignedNodeId {
+            id: self,
+            signature: [0; NODE_SIGNATURE_LEN],
+        };
+        res.signature.copy_from_slice(&signature);
+        Ok(res)
+    }
+}
+
+impl TryFrom<&[u8]> for NodeId {
+    type Error = Error;
+
+    fn try_from(src: &[u8]) -> Result<Self, Error> {
+        match TryFrom::try_from(src) {
+            Ok(data) => Ok(NodeId(data)),
+            Err(_) => Err(Error::new(
+                Code::InvalidArgument,
+                format!("block identifier must be {} bytes long", NODE_ID_LEN),
+            )),
+        }
+    }
+}
+
+const NODE_SIGNATURE_LEN: usize = 64;
+
+pub struct SignedNodeId {
+    id: NodeId,
+    signature: [u8; NODE_SIGNATURE_LEN],
+}
+
+impl SignedNodeId {
+    pub fn id(&self) -> &NodeId {
+        &self.id
+    }
+
+    pub fn signature(&self) -> &[u8] {
+        &self.signature
     }
 }

--- a/chain-network/src/error.rs
+++ b/chain-network/src/error.rs
@@ -80,4 +80,8 @@ pub enum HandshakeError {
     UnsupportedVersion(Box<str>),
     #[error("invalid genesis block payload")]
     InvalidBlock0(#[source] Error),
+    #[error("invalid node ID")]
+    InvalidNodeId(#[source] Error),
+    #[error("invalid node signature format")]
+    MalformedSignature(#[source] Error),
 }

--- a/chain-network/src/grpc/client.rs
+++ b/chain-network/src/grpc/client.rs
@@ -7,7 +7,7 @@ use super::legacy;
 
 use crate::data::block::{Block, BlockEvent, BlockId, BlockIds, Header};
 use crate::data::fragment::{Fragment, FragmentIds};
-use crate::data::p2p::{NodeId, SignedNodeId};
+use crate::data::p2p::{AuthenticatedNodeId, NodeId};
 use crate::data::{Gossip, Peers};
 use crate::error::{Error, HandshakeError};
 use crate::PROTOCOL_VERSION;
@@ -159,7 +159,7 @@ where
     pub async fn handshake(
         &mut self,
         nonce: Vec<u8>,
-    ) -> Result<(BlockId, SignedNodeId), HandshakeError> {
+    ) -> Result<(BlockId, AuthenticatedNodeId), HandshakeError> {
         let node_id = self.node_id.as_bytes().into();
         let req = proto::HandshakeRequest { node_id, nonce };
         let res = self
@@ -176,7 +176,7 @@ where
         let block_id = BlockId::try_from(&res.block0[..]).map_err(HandshakeError::InvalidBlock0)?;
         let node_id = NodeId::try_from(&res.node_id[..]).map_err(HandshakeError::InvalidNodeId)?;
         let node_auth = node_id
-            .signed(&res.signature)
+            .authenticated(&res.signature)
             .map_err(HandshakeError::MalformedSignature)?;
         Ok((block_id, node_auth))
     }

--- a/chain-network/src/grpc/client.rs
+++ b/chain-network/src/grpc/client.rs
@@ -67,7 +67,7 @@ impl Builder {
     {
         Client {
             inner: proto::node_client::NodeClient::new(service),
-            node_id: self.node_id.expect("node ID must be set"),
+            node_id: self.node_id,
             #[cfg(feature = "legacy")]
             legacy_node_id: self.legacy_node_id,
         }
@@ -82,7 +82,7 @@ impl Builder {
         let inner = proto::node_client::NodeClient::connect(dst).await?;
         Ok(Client {
             inner,
-            node_id: self.node_id.expect("node ID must be set"),
+            node_id: self.node_id,
             #[cfg(feature = "legacy")]
             legacy_node_id: self.legacy_node_id,
         })
@@ -92,7 +92,7 @@ impl Builder {
 #[derive(Clone)]
 pub struct Client<T> {
     inner: proto::node_client::NodeClient<T>,
-    node_id: NodeId,
+    node_id: Option<NodeId>,
     #[cfg(feature = "legacy")]
     legacy_node_id: Option<legacy::NodeId>,
 }
@@ -160,7 +160,10 @@ where
         &mut self,
         nonce: Vec<u8>,
     ) -> Result<(BlockId, AuthenticatedNodeId), HandshakeError> {
-        let node_id = self.node_id.as_bytes().into();
+        let node_id = match self.node_id {
+            Some(id) => id.as_bytes().into(),
+            None => Default::default(),
+        };
         let req = proto::HandshakeRequest { node_id, nonce };
         let res = self
             .inner

--- a/chain-network/src/grpc/client.rs
+++ b/chain-network/src/grpc/client.rs
@@ -146,8 +146,10 @@ where
     ///
     /// This method should be called first after establishing the client
     /// connection.
-    pub async fn handshake(&mut self, nonce: Vec<u8>) -> Result<HandshakeResponse, HandshakeError> {
-        let req = proto::HandshakeRequest { nonce };
+    pub async fn handshake(&mut self, nonce: &[u8]) -> Result<HandshakeResponse, HandshakeError> {
+        let req = proto::HandshakeRequest {
+            nonce: nonce.into(),
+        };
         let res = self
             .inner
             .handshake(req)

--- a/chain-network/src/grpc/server.rs
+++ b/chain-network/src/grpc/server.rs
@@ -122,7 +122,11 @@ where
         req: tonic::Request<proto::HandshakeRequest>,
     ) -> Result<tonic::Response<proto::HandshakeResponse>, tonic::Status> {
         let req = req.into_inner();
-        let peer_id = NodeId::try_from(&req.node_id[..])?;
+        let peer_id = if req.node_id.is_empty() {
+            None
+        } else {
+            Some(NodeId::try_from(&req.node_id[..])?)
+        };
         let nonce = &req.nonce;
         let (block0, node_auth) = self.inner.handshake(peer_id, nonce)?;
         let res = proto::HandshakeResponse {


### PR DESCRIPTION
Modify the `Handshake` request and response to add server node ID authentication.
Add a `ClientAuth` RPC method to authenticate the client's node ID using the server-side nonce returned in the `Handshake` response.