### PR TITLE
Remove tests on nightly Rust from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,12 +66,6 @@ jobs:
       - test:
           mode: --release --all-targets
 
-  test_nightly:
-    executor: rust-nightly
-    steps:
-      - test:
-          mode: --all-targets
-
   test_no_default_features:
     executor: rust-stable
     environment:
@@ -127,10 +121,6 @@ workflows:
       - test_release:
           requires:
             - cargo_fetch
-      # Temporarily disabled due to https://github.com/rust-lang/cargo/issues/8351
-      #- test_nightly:
-      #    requires:
-      #      - cargo_fetch
       - test_no_default_features:
           requires:
             - cargo_fetch


### PR DESCRIPTION
GitHub actions have better support for the nightly toolchain and non-fatal test runs.