### PR TITLE
Multiverse GC improvements + permanent store flush fix

### DIFF
--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -117,14 +117,6 @@ impl<State> Multiverse<State> {
             .insert(k, GcEntry::Retained(state.clone()));
         Ref::new(k, state)
     }
-}
-
-impl Multiverse<Ledger> {
-    /// Add a state to the multiverse. Return a `Ref` object that
-    /// pins the state into memory.
-    pub fn add(&mut self, k: HeaderId, st: Ledger) -> Ref<Ledger> {
-        self.insert(st.chain_length(), k, st)
-    }
 
     /// Once the state are old in the timeline, they are less and less likely to
     /// be used anymore, so we leave a gap between different version that gets
@@ -183,6 +175,14 @@ impl Multiverse<Ledger> {
                 scan_length = chain_length.increase();
             }
         }
+    }
+}
+
+impl Multiverse<Ledger> {
+    /// Add a state to the multiverse. Return a `Ref` object that
+    /// pins the state into memory.
+    pub fn add(&mut self, k: HeaderId, st: Ledger) -> Ref<Ledger> {
+        self.insert(st.chain_length(), k, st)
     }
 }
 

--- a/chain-storage/src/block_store.rs
+++ b/chain-storage/src/block_store.rs
@@ -474,13 +474,13 @@ impl BlockStore {
 
         let mut current_block_id = to_block;
 
-        while let Some(block_info) =
-            self.get_block_info(current_block_id)
-                .map(Some)
-                .or_else(|err| match err {
-                    Error::BlockNotFound => Ok(None),
-                    e => Err(e),
-                })?
+        while let Some(block_info) = self
+            .get_block_info_volatile(current_block_id)
+            .map(Some)
+            .or_else(|err| match err {
+                Error::BlockNotFound => Ok(None),
+                e => Err(e),
+            })?
         {
             block_infos.push(block_info);
             current_block_id = block_infos.last().unwrap().parent_id().as_ref();

--- a/chain-storage/src/block_store.rs
+++ b/chain-storage/src/block_store.rs
@@ -469,10 +469,67 @@ impl BlockStore {
 
     /// Move all blocks up to the provided block ID to the permanent block
     /// storage.
-    pub fn flush_to_permanent_store(&self, to_block: &[u8]) -> Result<(), Error> {
-        let mut block_infos = Vec::new();
+    ///
+    /// # Arguments
+    ///
+    /// * `to_block` - the ID of the block until which we want to flush blocks
+    ///   to the permanent storage.
+    /// * `min_number` - the minimum number of blocks to be flushed. If less
+    ///   than this number of blocks is available for flushing the function will
+    ///   not trigger.
+    ///
+    /// # Panics
+    ///
+    /// If `min_number` is less than 1.
+    ///
+    /// # Returns
+    ///
+    /// The number of blocks that were flushed.
+    pub fn flush_to_permanent_store(
+        &self,
+        to_block: &[u8],
+        min_number: usize,
+    ) -> Result<usize, Error> {
+        use std::convert::TryInto;
 
-        let mut current_block_id = to_block;
+        assert!(min_number > 0);
+
+        // We get the first block and check if we can go deep enough into the
+        // volatile storage.
+        let maybe_block_info = self
+            .get_block_info_volatile(to_block)
+            .map(Some)
+            .or_else(|err| match err {
+                Error::BlockNotFound => Ok(None),
+                e => Err(e),
+            })?;
+
+        let block_info = match maybe_block_info {
+            Some(block_info) => block_info,
+            None => return Ok(0),
+        };
+
+        let chain_length_prefix = match block_info
+            .chain_length()
+            .checked_sub(min_number.try_into().unwrap())
+        {
+            Some(length) => build_chain_length_index_prefix(length),
+            None => return Ok(0),
+        };
+
+        match self
+            .chain_length_index_tree
+            .scan_prefix(chain_length_prefix)
+            .next()
+        {
+            Some(Ok(_)) => {}
+            Some(Err(err)) => return Err(err.into()),
+            None => return Ok(0),
+        }
+
+        let mut block_infos = Vec::new();
+        block_infos.push(block_info);
+        let mut current_block_id = block_infos.last().unwrap().parent_id().as_ref();
 
         while let Some(block_info) = self
             .get_block_info_volatile(current_block_id)
@@ -486,8 +543,8 @@ impl BlockStore {
             current_block_id = block_infos.last().unwrap().parent_id().as_ref();
         }
 
-        if block_infos.is_empty() {
-            return Ok(());
+        if block_infos.len() < min_number {
+            return Ok(0);
         }
 
         let blocks = block_infos
@@ -516,7 +573,7 @@ impl BlockStore {
                 .remove(build_chain_length_index(chain_length, key))?;
         }
 
-        Ok(())
+        Ok(block_infos.len())
     }
 
     /// Iterate to the given block starting from the block at the given

--- a/chain-storage/src/tests.rs
+++ b/chain-storage/src/tests.rs
@@ -8,6 +8,7 @@ use std::{collections::HashSet, iter::FromIterator};
 const SIMULTANEOUS_READ_WRITE_ITERS: usize = 50;
 const BLOCK_NUM_PERMANENT_TEST: usize = 1024;
 const FLUSH_TO_BLOCK: usize = 512;
+const FLUSH_TO_BLOCK_2: usize = 768;
 
 pub fn pick_from_vector<'a, A, R: RngCore>(rng: &mut R, v: &'a [A]) -> &'a A {
     let s = rng.next_u32() as usize;
@@ -628,6 +629,27 @@ fn permanent_store_read() {
 
         let actual_block = store.get_block(&block_id).unwrap();
         assert_eq!(block.serialize_as_value().as_ref(), actual_block.as_ref());
+    }
+}
+
+#[test]
+fn permanent_store_flush_twice() {
+    let (_file, store, blocks) = prepare_permament_store();
+
+    store
+        .flush_to_permanent_store(&blocks[FLUSH_TO_BLOCK_2].id.serialize_as_vec())
+        .unwrap();
+
+    for (i, block) in store
+        .iter(
+            &blocks[BLOCK_NUM_PERMANENT_TEST - 1].id.serialize_as_vec(),
+            BLOCK_NUM_PERMANENT_TEST as u32,
+        )
+        .unwrap()
+        .map(|result| result.unwrap())
+        .enumerate()
+    {
+        assert_eq!(blocks[i].serialize_as_value(), block);
     }
 }
 

--- a/chain-storage/src/tests.rs
+++ b/chain-storage/src/tests.rs
@@ -519,6 +519,7 @@ fn is_ancestor_permanent_volatile() {
             &main_branch_blocks[PERMANENT_STORAGE_START]
                 .id
                 .serialize_as_vec(),
+            1,
         )
         .unwrap();
 
@@ -545,6 +546,7 @@ fn is_ancestor_only_permanent() {
             &main_branch_blocks[PERMANENT_STORAGE_START]
                 .id
                 .serialize_as_vec(),
+            1,
         )
         .unwrap();
 
@@ -606,7 +608,7 @@ fn prepare_permament_store() -> (tempfile::TempDir, BlockStore, Vec<Block>) {
     let (file, store, blocks) = prepare_and_fill_store(BLOCK_NUM_PERMANENT_TEST);
 
     store
-        .flush_to_permanent_store(&blocks[FLUSH_TO_BLOCK].id.serialize_as_vec())
+        .flush_to_permanent_store(&blocks[FLUSH_TO_BLOCK].id.serialize_as_vec(), 1)
         .unwrap();
 
     (file, store, blocks)
@@ -637,7 +639,7 @@ fn permanent_store_flush_twice() {
     let (_file, store, blocks) = prepare_permament_store();
 
     store
-        .flush_to_permanent_store(&blocks[FLUSH_TO_BLOCK_2].id.serialize_as_vec())
+        .flush_to_permanent_store(&blocks[FLUSH_TO_BLOCK_2].id.serialize_as_vec(), 1)
         .unwrap();
 
     for (i, block) in store
@@ -727,7 +729,7 @@ fn iterator_volatile_and_permanent_storage() {
     let (_file, store, blocks) = prepare_and_fill_store(TEST_BLOCK_NUM);
 
     store
-        .flush_to_permanent_store(&blocks[FLUSH_AT].id.serialize_as_vec()[..])
+        .flush_to_permanent_store(&blocks[FLUSH_AT].id.serialize_as_vec()[..], 1)
         .unwrap();
 
     for (i, block) in store
@@ -749,7 +751,7 @@ fn iterator_only_permanent_storage() {
     let (_file, store, blocks) = prepare_and_fill_store(TEST_BLOCK_NUM);
 
     store
-        .flush_to_permanent_store(&blocks[blocks.len() - 1].id.serialize_as_vec()[..])
+        .flush_to_permanent_store(&blocks[blocks.len() - 1].id.serialize_as_vec()[..], 1)
         .unwrap();
 
     for (i, block) in store


### PR DESCRIPTION
- Make `Multiverse::gc` available for any `State`.
- Allow to configure it with the desired depth (to be used with epoch stability depth).