### PR TITLE
More informative message for volatile store errors

### DIFF
--- a/chain-storage/src/error.rs
+++ b/chain-storage/src/error.rs
@@ -6,7 +6,7 @@ pub enum Error {
     Open(#[source] std::io::Error),
     #[error("block not found")]
     BlockNotFound,
-    #[error("database backend error")]
+    #[error("volatile store error")]
     VolatileBackendError(#[from] sled::Error),
     #[error("permanent store error")]
     PermanentBackendError(#[from] data_pile::Error),


### PR DESCRIPTION
The storage error variant for volatile store errors had the same message as the higher level error. Make it more informative.