### PR TITLE
Expose serialization API for ProofOfCorrectVote

### DIFF
--- a/chain-impl-mockchain/src/testing/scenario/controller.rs
+++ b/chain-impl-mockchain/src/testing/scenario/controller.rs
@@ -11,7 +11,7 @@ use crate::{
         ledger::TestLedger,
         scenario::template::VotePlanDef,
     },
-    vote::{Choice, Payload, PayloadType},
+    vote::{Choice, Payload, PayloadType, ProofOfCorrectVote},
 };
 
 #[cfg(test)]
@@ -253,7 +253,7 @@ impl Controller {
 
                     Payload::Private {
                         encrypted_vote,
-                        proof,
+                        proof: ProofOfCorrectVote::from_inner(proof),
                     }
                 }
             },

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -543,7 +543,7 @@ impl VotePlanManager {
                 let pk = chain_vote::EncryptingVoteKey::from_participants(
                     self.plan.committee_public_keys(),
                 );
-                if !chain_vote::verify_vote(&pk, encrypted_vote, proof) {
+                if !chain_vote::verify_vote(&pk, encrypted_vote, proof.as_inner()) {
                     Err(VoteError::VoteVerificationError)
                 } else {
                     Ok(())

--- a/chain-impl-mockchain/src/vote/mod.rs
+++ b/chain-impl-mockchain/src/vote/mod.rs
@@ -16,7 +16,7 @@ pub use self::{
     committee::CommitteeId,
     ledger::{VotePlanLedger, VotePlanLedgerError},
     manager::{VoteError, VotePlanManager},
-    payload::{Payload, PayloadType, TryFromIntError},
+    payload::{Payload, PayloadType, ProofOfCorrectVote, TryFromIntError},
     status::{VotePlanStatus, VoteProposalStatus},
     tally::{PrivateTallyState, Tally, TallyError, TallyResult, Weight},
 };

--- a/typed-bytes/src/lib.rs
+++ b/typed-bytes/src/lib.rs
@@ -54,6 +54,12 @@ impl<T> From<Vec<u8>> for ByteArray<T> {
     }
 }
 
+impl<T> From<ByteArray<T>> for Vec<u8> {
+    fn from(a: ByteArray<T>) -> Self {
+        a.array.into()
+    }
+}
+
 impl<'a, T> ByteSlice<'a, T> {
     pub fn as_slice(&self) -> &[u8] {
         self.slice


### PR DESCRIPTION
No need to implement it another time in jormungandr.
Also make the serialization of proof self-contained by including the length.
As the number of options in mockchain can never exceed 255, control for this
and use an `u8` for the length field.