### PR TITLE
Outer build warnings cleaning

### DIFF
--- a/chain-impl-mockchain/src/block/test.rs
+++ b/chain-impl-mockchain/src/block/test.rs
@@ -1,14 +1,14 @@
 #[cfg(test)]
 use crate::block::Header;
+#[cfg(test)]
+use crate::header::HeaderDesc;
 use crate::{
     block::{Block, BlockVersion, HeaderRaw},
     fragment::{Contents, ContentsBuilder, Fragment},
-    header::{BftProof, GenesisPraosProof, HeaderBuilderNew, HeaderDesc},
+    header::{BftProof, GenesisPraosProof, HeaderBuilderNew},
 };
-
 #[cfg(test)]
 use chain_core::property::{Block as _, Deserialize, HasHeader as _, Serialize};
-
 #[cfg(test)]
 use chain_test_utils::property;
 #[cfg(test)]

--- a/chain-impl-mockchain/src/block/test.rs
+++ b/chain-impl-mockchain/src/block/test.rs
@@ -5,7 +5,10 @@ use crate::{
     fragment::{Contents, ContentsBuilder, Fragment},
     header::{BftProof, GenesisPraosProof, HeaderBuilderNew, HeaderDesc},
 };
+
+#[cfg(test)]
 use chain_core::property::{Block as _, Deserialize, HasHeader as _, Serialize};
+
 #[cfg(test)]
 use chain_test_utils::property;
 #[cfg(test)]
@@ -66,6 +69,7 @@ quickcheck! {
     }
 }
 
+#[cfg(test)]
 fn are_desc_equal(left: HeaderDesc, right: HeaderDesc) -> bool {
     left.id == right.id
 }


### PR DESCRIPTION
Added missing `cfg(test)` showing warning in outer builds