### PR TITLE
use SmallRng instead of ChaCha for generating test keys

### DIFF
--- a/chain-crypto/Cargo.toml
+++ b/chain-crypto/Cargo.toml
@@ -15,7 +15,7 @@ sha2 = "0.9"
 digest = "^0.9"
 generic-array = "^0.14"
 rand_core = "0.5"
-rand_chacha = { version = "0.2", optional = true }
+rand = { version = "0.7", features = [ "small_rng" ], optional = true }
 quickcheck = { version = "0.9", optional = true }
 ed25519-bip32 = "0.3"
 cfg-if = "1.0"
@@ -27,11 +27,11 @@ criterion = { version = "0.3.0", optional = true }
 [dev-dependencies]
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
-rand_chacha = "0.2"
+rand = { version = "0.7", features = ["small_rng"] }
 
 [features]
 with-bench = ["criterion"]
-property-test-api = [ "quickcheck", "rand_chacha" ]
+property-test-api = [ "quickcheck", "rand" ]
 
 [[bench]]
 harness = false


### PR DESCRIPTION
Use a faster non-cryptographic generators for generating `Arbitrary` keys.