### PR TITLE
store iterator vs sequential get with different permanent store utilization

### DIFF
--- a/chain-storage/benches/storage.rs
+++ b/chain-storage/benches/storage.rs
@@ -7,8 +7,10 @@ use chain_storage::{
 };
 
 const BLOCK_DATA_LENGTH: usize = 1024;
+const SEQ_BENCH_N_BLOCKS: u32 = 5210;
+const SEQ_BENCH_FLUSH_POINT: u32 = 4096;
 
-fn criterion_benchmark(c: &mut Criterion) {
+fn basic_benchmark(c: &mut Criterion) {
     let mut rng = OsRng;
     let mut block_data = [0; BLOCK_DATA_LENGTH];
 
@@ -71,5 +73,116 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
+fn seq_read_benchmark(c: &mut Criterion) {
+    let mut rng = OsRng;
+    let mut block_data = [0; BLOCK_DATA_LENGTH];
+
+    rng.fill_bytes(&mut block_data);
+    let genesis_block = Block::genesis(Some(Box::new(block_data)));
+
+    let tempdir = tempfile::TempDir::new().unwrap();
+    let path = {
+        let mut path = tempdir.path().to_path_buf();
+        path.push("test");
+        path
+    };
+    let store = BlockStore::file(path, BlockId(0).serialize_as_vec()).unwrap();
+    let genesis_block_info = BlockInfo::new(
+        genesis_block.id.serialize_as_vec(),
+        genesis_block.parent.serialize_as_vec(),
+        genesis_block.chain_length,
+    );
+    store
+        .put_block(&genesis_block.serialize_as_vec(), genesis_block_info)
+        .unwrap();
+
+    let mut blocks = vec![genesis_block];
+
+    for _i in 0..SEQ_BENCH_N_BLOCKS {
+        let last_block = blocks.last().unwrap();
+        rng.fill_bytes(&mut block_data);
+        let block = last_block.make_child(Some(Box::new(block_data)));
+        let block_info = BlockInfo::new(
+            block.id.serialize_as_vec(),
+            block.parent.serialize_as_vec(),
+            block.chain_length,
+        );
+        store
+            .put_block(&block.serialize_as_vec(), block_info)
+            .unwrap();
+        blocks.push(block);
+    }
+
+    let block_ids: Vec<_> = blocks
+        .iter()
+        .map(|block| block.id.serialize_as_vec())
+        .collect();
+
+    c.bench_function("seq_volatile_get_block", |b| {
+        b.iter(|| {
+            for block_id in block_ids.iter() {
+                store.get_block(&block_id).unwrap();
+            }
+        })
+    });
+
+    c.bench_function("seq_volatile_iter", |b| {
+        b.iter(|| {
+            for block_res in store
+                .iter(block_ids.last().unwrap().as_ref(), SEQ_BENCH_N_BLOCKS)
+                .unwrap()
+            {
+                let _block = block_res.unwrap();
+            }
+        })
+    });
+
+    store
+        .flush_to_permanent_store(&block_ids[SEQ_BENCH_FLUSH_POINT as usize], 1)
+        .unwrap();
+
+    c.bench_function("seq_mixed_get_block", |b| {
+        b.iter(|| {
+            for block_id in block_ids.iter() {
+                store.get_block(&block_id).unwrap();
+            }
+        })
+    });
+
+    c.bench_function("seq_mixed_iter", |b| {
+        b.iter(|| {
+            for block_res in store
+                .iter(block_ids.last().unwrap().as_ref(), SEQ_BENCH_N_BLOCKS)
+                .unwrap()
+            {
+                let _block = block_res.unwrap();
+            }
+        })
+    });
+
+    store
+        .flush_to_permanent_store(&block_ids[SEQ_BENCH_N_BLOCKS as usize - 1], 1)
+        .unwrap();
+
+    c.bench_function("seq_permanent_get_block", |b| {
+        b.iter(|| {
+            for block_id in block_ids.iter() {
+                store.get_block(&block_id).unwrap();
+            }
+        })
+    });
+
+    c.bench_function("seq_permanent_iter", |b| {
+        b.iter(|| {
+            for block_res in store
+                .iter(block_ids.last().unwrap().as_ref(), SEQ_BENCH_N_BLOCKS)
+                .unwrap()
+            {
+                let _block = block_res.unwrap();
+            }
+        })
+    });
+}
+
+criterion_group!(benches, basic_benchmark, seq_read_benchmark);
 criterion_main!(benches);


### PR DESCRIPTION
## Goal

Evaluate the performance of sequential `get` queries vs iterators for large range queries, that will occur in the implementation of parallel block download.

## Benchmark method

5120 blocks used for each test.

* `seq_volatile_*` utilize only volatile storage.
* `seq_mixed_*` use 4096 block in the permanent storage and 1024 in the volatile storage (one of practical scenarios)
* `seq_permanent_*` all blocks are in the permanent storage. Can occur when fetching older blocks.

## Benchmark results

<details>
<summary>Benchmark logs</summary>

```
seq_volatile_get_block  time:   [7.0471 ms 7.2519 ms 7.4972 ms]
                        change: [+5.1207% +8.2813% +11.923%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 22 outliers among 100 measurements (22.00%)
  10 (10.00%) low mild
  1 (1.00%) high mild
  11 (11.00%) high severe

seq_volatile_iter       time:   [11.739 ms 11.951 ms 12.195 ms]
                        change: [-0.1929% +2.2513% +4.7618%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

seq_mixed_get_block     time:   [5.8660 ms 6.0023 ms 6.1551 ms]
                        change: [-5.1074% -1.8891% +1.4452%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe

seq_mixed_iter          time:   [2.8681 ms 2.9018 ms 2.9455 ms]
                        change: [-6.3589% -3.8481% -1.3788%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  13 (13.00%) low mild
  1 (1.00%) high mild
  5 (5.00%) high severe

seq_permanent_get_block time:   [4.8416 ms 4.9432 ms 5.0646 ms]
                        change: [-3.4350% -0.6106% +2.3846%] (p = 0.70 > 0.05)
                        No change in performance detected.
Found 22 outliers among 100 measurements (22.00%)
  11 (11.00%) low mild
  1 (1.00%) high mild
  10 (10.00%) high severe

seq_permanent_iter      time:   [780.22 us 787.84 us 797.16 us]
                        change: [-7.0052% -4.8957% -3.1764%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe
```

</details>

## Evaluation

On scenarios with a big number of blocks in the volatile storage this iterator shows worse performance than a simple sequence of `get` queries. This happens due to the fact that the iterator needs to build a list of blocks to iterate over it first.

On the other hand, iteration through the permanent storage (the most common in the production environment) is significantly (by several orders of magnitude, 4.9 ms vs 787.8 us) faster than sequential `get` queries due to only one access to the index per one construction of a new iterator.

Given that the use of the permanent storage is the most common and the iterator performance on it is much better, I would advise to use iterators for large range queries.