### PR TITLE
Implemented EncryptedVote for mock-chain

### DIFF
--- a/chain-impl-mockchain/src/testing/scenario/controller.rs
+++ b/chain-impl-mockchain/src/testing/scenario/controller.rs
@@ -20,6 +20,7 @@ use super::FragmentFactory;
 #[cfg(test)]
 use chain_addr::Discrimination;
 
+use crate::vote::EncryptedVote;
 use rand_core::{CryptoRng, RngCore};
 use thiserror::Error;
 
@@ -252,7 +253,7 @@ impl Controller {
                     );
 
                     Payload::Private {
-                        encrypted_vote,
+                        encrypted_vote: EncryptedVote::from_inner(encrypted_vote),
                         proof: ProofOfCorrectVote::from_inner(proof),
                     }
                 }

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -190,7 +190,7 @@ impl ProposalManager {
                             encrypted_vote,
                             proof: _,
                         } => {
-                            tally.add(encrypted_vote, stake.0);
+                            tally.add(encrypted_vote.as_inner(), stake.0);
                         }
                     }
                 }
@@ -543,7 +543,7 @@ impl VotePlanManager {
                 let pk = chain_vote::EncryptingVoteKey::from_participants(
                     self.plan.committee_public_keys(),
                 );
-                if !chain_vote::verify_vote(&pk, encrypted_vote, proof.as_inner()) {
+                if !chain_vote::verify_vote(&pk, encrypted_vote.as_inner(), proof.as_inner()) {
                     Err(VoteError::VoteVerificationError)
                 } else {
                     Ok(())

--- a/chain-impl-mockchain/src/vote/mod.rs
+++ b/chain-impl-mockchain/src/vote/mod.rs
@@ -12,14 +12,12 @@ mod privacy;
 mod status;
 mod tally;
 
-pub use chain_vote::EncryptedVote;
-
 pub use self::{
     choice::{Choice, Options},
     committee::CommitteeId,
     ledger::{VotePlanLedger, VotePlanLedgerError},
     manager::{VoteError, VotePlanManager},
-    payload::{Payload, PayloadType, ProofOfCorrectVote, TryFromIntError},
+    payload::{EncryptedVote, Payload, PayloadType, ProofOfCorrectVote, TryFromIntError},
     privacy::encrypt_vote,
     status::{VotePlanStatus, VoteProposalStatus},
     tally::{PrivateTallyState, Tally, TallyError, TallyResult, Weight},

--- a/chain-impl-mockchain/src/vote/privacy.rs
+++ b/chain-impl-mockchain/src/vote/privacy.rs
@@ -1,5 +1,5 @@
-use crate::vote::ProofOfCorrectVote;
-use chain_vote::{EncryptedVote, EncryptingVoteKey, Vote};
+use crate::vote::{EncryptedVote, ProofOfCorrectVote};
+use chain_vote::{EncryptingVoteKey, Vote};
 use rand_core::{CryptoRng, RngCore};
 
 #[allow(dead_code)]
@@ -9,5 +9,8 @@ pub fn encrypt_vote<R: RngCore + CryptoRng>(
     vote: Vote,
 ) -> (EncryptedVote, ProofOfCorrectVote) {
     let (ev, proof) = chain_vote::encrypt_vote(rng, public_key, vote);
-    (ev, ProofOfCorrectVote::from_inner(proof))
+    (
+        EncryptedVote::from_inner(ev),
+        ProofOfCorrectVote::from_inner(proof),
+    )
 }


### PR DESCRIPTION
Added a layer in mock-chain for EncryptedVote handling.
Part of https://github.com/input-output-hk/jormungandr/issues/2623