### PR TITLE
use baby-step giant-step to speed up tallying

### DIFF
--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -241,8 +241,12 @@ impl ProposalManager {
         let tally = self.tally.as_ref().ok_or(TallyError::NoEncryptedTally)?;
         let (encrypted_tally, total_stake) = tally.private_encrypted()?;
         let state = encrypted_tally.state();
-        let table_size = total_stake.0 as usize / self.options.choice_range().len();
-        let private_result = chain_vote::result(total_stake.0, table_size, &state, shares);
+        let private_result = chain_vote::tally_result(
+            total_stake.0,
+            &state,
+            shares,
+            &chain_vote::PrivateTallyTable::generate(total_stake.0),
+        );
         let mut result = TallyResult::new(self.options.clone());
         for (choice, weight) in private_result
             .votes

--- a/chain-vote/Cargo.toml
+++ b/chain-vote/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 rand_core = "0.5"
+rayon = "1.5"
 cryptoxide = "0.2"
 eccoxide = { version = "0.3", optional = true }
 zerocaf = { version = "0.2", optional = true }

--- a/chain-vote/src/gang/babystep.rs
+++ b/chain-vote/src/gang/babystep.rs
@@ -4,26 +4,32 @@ use super::p256k1::*;
 use super::zerocaf::*;
 use lazy_static::*;
 use std::collections::HashMap;
+use std::convert::TryFrom;
 
+// make steps asymmetric, in order to better use caching of baby steps.
+// balance of 2 means that baby steps are 2 time more than sqrt(MAX_VOTES_BSGS)
+const BALANCE: u64 = 2;
 // change this to adjust precomputed range, given this number it is possible to
 // find mupltiples up to SQRT_STEP_SIZE ^ 2 - 1
 lazy_static! {
-    pub(crate) static ref SQRT_STEP_SIZE: u64 = {
+    static ref SQRT_STEP_SIZE: u64 = {
         let max_votes = option_env!("MAX_VOTES_BSGS")
-            .unwrap_or("9999999999") // 1e10 -1
+            .unwrap_or("31999999999") // 1e10 -1
             .parse::<u64>()
             .expect("Invalid MAX_VOTES_BSGS: expected a integer");
         ((max_votes as f64).sqrt() + 1.0) as u64
     };
+    static ref BABY_STEPS_SIZE: u64 = *SQRT_STEP_SIZE * BALANCE;
 }
 
 lazy_static! {
-    static ref BS: HashMap<GroupElement, u64> = {
+    static ref BS: HashMap<[u8; 32], u64> = {
         let mut bs = HashMap::new();
         let gen = GroupElement::generator();
         let mut e = GroupElement::zero();
-        for i in 0..*SQRT_STEP_SIZE {
-            bs.insert(e.clone(), i);
+        // use negation trick and store only the x coordinate
+        for i in 0..*BABY_STEPS_SIZE / 2 {
+            bs.insert(<[u8; 32]>::try_from(&e.to_bytes()[1..33]).unwrap(), i);
             e = &e + &gen;
         }
         bs
@@ -32,14 +38,14 @@ lazy_static! {
 
 #[cfg(not(feature = "zerocaf"))]
 lazy_static! {
-    static ref SQRT_STEP: GroupElement =
-        GroupElement::generator() * Scalar::from_u64(*SQRT_STEP_SIZE).negate();
+    static ref GIANT_STEP: GroupElement =
+        GroupElement::generator() * Scalar::from_u64(*BABY_STEPS_SIZE).negate();
 }
 
 #[cfg(feature = "zerocaf")]
 lazy_static! {
-    static ref SQRT_STEP: GroupElement =
-        GroupElement::generator() * FieldElement::from_u64(*SQRT_STEP_SIZE).negate();
+    static ref GIANT_STEP: GroupElement =
+        GroupElement::generator() * FieldElement::from_u64(*BABY_STEPS_SIZE).negate();
 }
 
 // Solve the discrete log on ECC using baby step giant step algorithm
@@ -49,16 +55,19 @@ pub fn baby_step_giant_step(points: Vec<GroupElement>, max_votes: u64) -> Vec<Op
         .map(|mut p| {
             let mut a = 0;
             loop {
-                if let Some(x) = BS.get(&p) {
-                    return Some(x + a * *SQRT_STEP_SIZE);
+                if let Some(x) = BS.get(&p.to_bytes()[1..33]) {
+                    if Scalar::from_u64(*x) * GroupElement::generator() == p {
+                        return Some(a * (*BABY_STEPS_SIZE) + x);
+                    } else {
+                        return Some(a * (*BABY_STEPS_SIZE) - x);
+                    }
                 }
                 // This should not happen if the precomputed range is correctly
                 // sized, set MAX_VOTES_BSGS at compile time for best performances
-                if a * (*SQRT_STEP_SIZE) + *SQRT_STEP_SIZE - 1 > max_votes {
+                if a * (*BABY_STEPS_SIZE) + *BABY_STEPS_SIZE - 1 > max_votes {
                     break;
                 }
-
-                p = p + &*SQRT_STEP;
+                p = p + &*GIANT_STEP;
                 a += 1;
             }
 

--- a/chain-vote/src/gang/babystep.rs
+++ b/chain-vote/src/gang/babystep.rs
@@ -3,6 +3,7 @@ use super::p256k1::*;
 #[cfg(feature = "zerocaf")]
 use super::zerocaf::*;
 use lazy_static::*;
+use rayon::prelude::*;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
@@ -51,7 +52,7 @@ lazy_static! {
 // Solve the discrete log on ECC using baby step giant step algorithm
 pub fn baby_step_giant_step(points: Vec<GroupElement>, max_votes: u64) -> Vec<Option<u64>> {
     points
-        .into_iter()
+        .into_par_iter()
         .map(|mut p| {
             let mut a = 0;
             loop {

--- a/chain-vote/src/gang/babystep.rs
+++ b/chain-vote/src/gang/babystep.rs
@@ -1,74 +1,80 @@
-#[cfg(not(feature = "zerocaf"))]
 use super::p256k1::*;
-#[cfg(feature = "zerocaf")]
-use super::zerocaf::*;
-use lazy_static::*;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
 // make steps asymmetric, in order to better use caching of baby steps.
 // balance of 2 means that baby steps are 2 time more than sqrt(MAX_VOTES_BSGS)
-const BALANCE: u64 = 2;
-// change this to adjust precomputed range, given this number it is possible to
-// find mupltiples up to SQRT_STEP_SIZE ^ 2 - 1
-lazy_static! {
-    static ref SQRT_STEP_SIZE: u64 = {
-        let max_votes = option_env!("MAX_VOTES_BSGS")
-            .unwrap_or("31999999999") // 1e10 -1
-            .parse::<u64>()
-            .expect("Invalid MAX_VOTES_BSGS: expected a integer");
-        ((max_votes as f64).sqrt() + 1.0) as u64
-    };
-    static ref BABY_STEPS_SIZE: u64 = *SQRT_STEP_SIZE * BALANCE;
+const DEFAULT_BALANCE: u64 = 2;
+
+/// Holds precomputed baby steps for the baby-stap giant-step algorithm
+/// for solving discrete log on ECC and tally private votes
+pub struct PrivateTallyTable {
+    table: HashMap<[u8; 32], u64>,
+    baby_step_size: u64,
+    giant_step: GroupElement,
 }
 
-lazy_static! {
-    static ref BS: HashMap<[u8; 32], u64> = {
+impl PrivateTallyTable {
+    /// Generate the table with asymmetrical steps,
+    /// optimized for multiple reuse of the same table.
+    pub fn generate(max_voting_power: u64) -> Self {
+        Self::generate_with_balance(max_voting_power, DEFAULT_BALANCE)
+    }
+
+    /// Generate the table with the given balance. Balance is used to make
+    /// steps asymmetrical. If the table is reused multiple times with the same
+    /// max_voting_power it is recommended to set a balance > 1, since this will
+    /// allow to cache more results, at the expense of a higher memory footprint.
+    ///
+    /// For example, a balance of 2 means that the table will precompute 2 times more
+    /// baby steps than the standard O(sqrt(n)), 1 means symmetrical steps.
+    pub fn generate_with_balance(max_voting_power: u64, balance: u64) -> Self {
+        let sqrt_step_size = (max_voting_power as f64).sqrt().ceil() as u64;
+        let baby_step_size = sqrt_step_size * balance;
         let mut bs = HashMap::new();
         let gen = GroupElement::generator();
         let mut e = GroupElement::zero();
         // use negation trick and store only the x coordinate
-        for i in 0..*BABY_STEPS_SIZE / 2 {
+        for i in 0..=baby_step_size / 2 {
             bs.insert(<[u8; 32]>::try_from(&e.to_bytes()[1..33]).unwrap(), i);
             e = &e + &gen;
         }
-        bs
-    };
-}
-
-#[cfg(not(feature = "zerocaf"))]
-lazy_static! {
-    static ref GIANT_STEP: GroupElement =
-        GroupElement::generator() * Scalar::from_u64(*BABY_STEPS_SIZE).negate();
-}
-
-#[cfg(feature = "zerocaf")]
-lazy_static! {
-    static ref GIANT_STEP: GroupElement =
-        GroupElement::generator() * FieldElement::from_u64(*BABY_STEPS_SIZE).negate();
+        Self {
+            table: bs,
+            baby_step_size: baby_step_size,
+            giant_step: GroupElement::generator() * Scalar::from_u64(baby_step_size).negate(),
+        }
+    }
 }
 
 // Solve the discrete log on ECC using baby step giant step algorithm
-pub fn baby_step_giant_step(points: Vec<GroupElement>, max_votes: u64) -> Vec<Option<u64>> {
+pub fn baby_step_giant_step(
+    points: Vec<GroupElement>,
+    max_votes: u64,
+    table: &PrivateTallyTable,
+) -> Vec<Option<u64>> {
+    let baby_step_size = table.baby_step_size;
+    let giant_step = &table.giant_step;
+    let table = &table.table;
     points
         .into_par_iter()
         .map(|mut p| {
             let mut a = 0;
             loop {
-                if let Some(x) = BS.get(&p.to_bytes()[1..33]) {
+                if let Some(x) = table.get(&p.to_bytes()[1..33]) {
                     if Scalar::from_u64(*x) * GroupElement::generator() == p {
-                        return Some(a * (*BABY_STEPS_SIZE) + x);
+                        return Some(a * baby_step_size + x);
                     } else {
-                        return Some(a * (*BABY_STEPS_SIZE) - x);
+                        return Some(a * baby_step_size - x);
                     }
                 }
                 // This should not happen if the precomputed range is correctly
                 // sized, set MAX_VOTES_BSGS at compile time for best performances
-                if a * (*BABY_STEPS_SIZE) + *BABY_STEPS_SIZE - 1 > max_votes {
+                if a * baby_step_size > max_votes {
                     break;
                 }
-                p = p + &*GIANT_STEP;
+                p = p + giant_step;
                 a += 1;
             }
 
@@ -83,12 +89,9 @@ mod tests {
 
     #[test]
     fn bsgs() {
+        let table = PrivateTallyTable::generate_with_balance(25, 1);
         let p = GroupElement::generator();
-        let votes = [
-            (*SQRT_STEP_SIZE).pow(2) - 1,
-            (*SQRT_STEP_SIZE).pow(2),
-            (*SQRT_STEP_SIZE).pow(2) * 2 - 1,
-        ];
+        let votes = (0..100).collect::<Vec<_>>();
         let points = votes
             .iter()
             .map(|k| {
@@ -101,7 +104,7 @@ mod tests {
             .collect();
         assert_eq!(
             votes.iter().map(|v| Some(*v)).collect::<Vec<_>>(),
-            baby_step_giant_step(points, (*SQRT_STEP_SIZE).pow(2) * 2 - 1)[..]
+            baby_step_giant_step(points, 100, &table)[..]
         );
     }
 }

--- a/chain-vote/src/gang/babystep.rs
+++ b/chain-vote/src/gang/babystep.rs
@@ -1,0 +1,97 @@
+#[cfg(not(feature = "zerocaf"))]
+use super::p256k1::*;
+#[cfg(feature = "zerocaf")]
+use super::zerocaf::*;
+use lazy_static::*;
+use std::collections::HashMap;
+
+// change this to adjust precomputed range, given this number it is possible to
+// find mupltiples up to SQRT_STEP_SIZE ^ 2 - 1
+lazy_static! {
+    pub(crate) static ref SQRT_STEP_SIZE: u64 = {
+        let max_votes = option_env!("MAX_VOTES_BSGS")
+            .unwrap_or("9999999999") // 1e10 -1
+            .parse::<u64>()
+            .expect("Invalid MAX_VOTES_BSGS: expected a integer");
+        ((max_votes as f64).sqrt() + 1.0) as u64
+    };
+}
+
+lazy_static! {
+    static ref BS: HashMap<GroupElement, u64> = {
+        let mut bs = HashMap::new();
+        let gen = GroupElement::generator();
+        let mut e = GroupElement::zero();
+        for i in 0..*SQRT_STEP_SIZE {
+            bs.insert(e.clone(), i);
+            e = &e + &gen;
+        }
+        bs
+    };
+}
+
+#[cfg(not(feature = "zerocaf"))]
+lazy_static! {
+    static ref SQRT_STEP: GroupElement =
+        GroupElement::generator() * Scalar::from_u64(*SQRT_STEP_SIZE).negate();
+}
+
+#[cfg(feature = "zerocaf")]
+lazy_static! {
+    static ref SQRT_STEP: GroupElement =
+        GroupElement::generator() * FieldElement::from_u64(*SQRT_STEP_SIZE).negate();
+}
+
+// Solve the discrete log on ECC using baby step giant step algorithm
+pub fn baby_step_giant_step(points: Vec<GroupElement>, max_votes: u64) -> Vec<Option<u64>> {
+    points
+        .into_iter()
+        .map(|mut p| {
+            let mut a = 0;
+            loop {
+                if let Some(x) = BS.get(&p) {
+                    return Some(x + a * *SQRT_STEP_SIZE);
+                }
+                // This should not happen if the precomputed range is correctly
+                // sized, set MAX_VOTES_BSGS at compile time for best performances
+                if a * (*SQRT_STEP_SIZE) + *SQRT_STEP_SIZE - 1 > max_votes {
+                    break;
+                }
+
+                p = p + &*SQRT_STEP;
+                a += 1;
+            }
+
+            None
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bsgs() {
+        let p = GroupElement::generator();
+        let votes = [
+            (*SQRT_STEP_SIZE).pow(2) - 1,
+            (*SQRT_STEP_SIZE).pow(2),
+            (*SQRT_STEP_SIZE).pow(2) * 2 - 1,
+        ];
+        let points = votes
+            .iter()
+            .map(|k| {
+                #[cfg(not(feature = "zerocaf"))]
+                let ks = Scalar::from_u64(*k);
+                #[cfg(feature = "zerocaf")]
+                let ks = FieldElement::from_u64(*k);
+                &p * ks
+            })
+            .collect();
+        assert_eq!(
+            votes.iter().map(|v| Some(*v)).collect::<Vec<_>>(),
+            baby_step_giant_step(points, (*SQRT_STEP_SIZE).pow(2) * 2 - 1)[..]
+        );
+    }
+}

--- a/chain-vote/src/gang/mod.rs
+++ b/chain-vote/src/gang/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod babystep;
 #[cfg(not(feature = "zerocaf"))]
 mod p256k1;
 #[cfg(feature = "zerocaf")]
@@ -7,6 +8,7 @@ mod zerocaf;
 pub use self::p256k1::*;
 #[cfg(feature = "zerocaf")]
 pub use self::zerocaf::*;
+pub use babystep::baby_step_giant_step;
 
 #[cfg(test)]
 mod tests {

--- a/chain-vote/src/gang/mod.rs
+++ b/chain-vote/src/gang/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(not(feature = "zerocaf"))]
 mod babystep;
 #[cfg(not(feature = "zerocaf"))]
 mod p256k1;
@@ -9,8 +8,7 @@ mod zerocaf;
 pub use self::p256k1::*;
 #[cfg(feature = "zerocaf")]
 pub use self::zerocaf::*;
-#[cfg(not(feature = "zerocaf"))]
-pub use babystep::{baby_step_giant_step, PrivateTallyTable};
+pub use babystep::{baby_step_giant_step, BabyStepsTable};
 
 #[cfg(test)]
 mod tests {

--- a/chain-vote/src/gang/mod.rs
+++ b/chain-vote/src/gang/mod.rs
@@ -1,4 +1,5 @@
-pub(crate) mod babystep;
+#[cfg(not(feature = "zerocaf"))]
+mod babystep;
 #[cfg(not(feature = "zerocaf"))]
 mod p256k1;
 #[cfg(feature = "zerocaf")]
@@ -8,7 +9,8 @@ mod zerocaf;
 pub use self::p256k1::*;
 #[cfg(feature = "zerocaf")]
 pub use self::zerocaf::*;
-pub use babystep::baby_step_giant_step;
+#[cfg(not(feature = "zerocaf"))]
+pub use babystep::{baby_step_giant_step, PrivateTallyTable};
 
 #[cfg(test)]
 mod tests {

--- a/chain-vote/src/gang/p256k1.rs
+++ b/chain-vote/src/gang/p256k1.rs
@@ -85,21 +85,6 @@ impl GroupElement {
         }
         sum
     }
-
-    pub fn table(table_size: usize) -> Vec<Self> {
-        let mut table = Vec::with_capacity(table_size);
-
-        let gen = GroupElement::generator();
-        let mut r = &gen * Scalar::one();
-
-        for _ in 0..table_size {
-            r.normalize();
-            let r2 = &r + &gen;
-            table.push(r);
-            r = r2;
-        }
-        table
-    }
 }
 
 impl Scalar {

--- a/chain-vote/src/gang/p256k1.rs
+++ b/chain-vote/src/gang/p256k1.rs
@@ -1,4 +1,5 @@
 use eccoxide::curve::sec2::p256k1::{FieldElement, Point, PointAffine, Scalar as IScalar};
+use eccoxide::curve::Sign as ISign;
 use rand_core::{CryptoRng, RngCore};
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, Mul, Sub};
@@ -8,6 +9,12 @@ pub struct Scalar(IScalar);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GroupElement(Point);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Coordinate(FieldElement);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sign(ISign);
 
 #[allow(clippy::derive_hash_xor_eq)]
 impl Hash for GroupElement {
@@ -20,6 +27,14 @@ impl Hash for GroupElement {
 impl Hash for Scalar {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(&self.to_bytes())
+    }
+}
+
+impl Coordinate {
+    pub const BYTES_LEN: usize = FieldElement::SIZE_BYTES;
+
+    pub fn to_bytes(&self) -> [u8; Self::BYTES_LEN] {
+        self.0.to_bytes()
     }
 }
 
@@ -48,6 +63,13 @@ impl GroupElement {
 
     pub fn normalize(&mut self) {
         self.0.normalize()
+    }
+
+    pub(super) fn compress(&self) -> Option<(Coordinate, Sign)> {
+        self.0.to_affine().map(|p| {
+            let (x, sign) = p.compress();
+            (Coordinate(x.clone()), Sign(sign))
+        })
     }
 
     pub fn to_bytes(&self) -> [u8; Self::BYTES_LEN] {

--- a/chain-vote/src/lib.rs
+++ b/chain-vote/src/lib.rs
@@ -26,7 +26,7 @@ pub use committee::{
 };
 pub use encrypted::EncryptingVote;
 use gang::GroupElement;
-pub use gang::Scalar;
+pub use gang::{BabyStepsTable as PrivateTallyTable, Scalar};
 pub use gargamel::Ciphertext;
 use rand_core::{CryptoRng, RngCore};
 pub use unit_vector::UnitVector;
@@ -223,7 +223,7 @@ pub fn tally_result(
     max_votes: u64,
     tally_state: &TallyState,
     decrypt_shares: &[TallyDecryptShare],
-    table: &gang::PrivateTallyTable,
+    table: &PrivateTallyTable,
 ) -> TallyResult {
     let ris = (0..tally_state.r2s.len())
         .map(|i| gang::GroupElement::sum(decrypt_shares.iter().map(|ds| &ds.r1s[i])));
@@ -286,7 +286,7 @@ mod tests {
         let shares = vec![tds1];
 
         println!("resulting");
-        let table = gang::PrivateTallyTable::generate_with_balance(max_votes, 1);
+        let table = crate::PrivateTallyTable::generate_with_balance(max_votes, 1);
         let tr = tally_result(max_votes, &ts, &shares, &table);
 
         println!("{:?}", tr);
@@ -339,7 +339,7 @@ mod tests {
         let shares = vec![tds1, tds2, tds3];
 
         println!("resulting");
-        let table = gang::PrivateTallyTable::generate_with_balance(max_votes, 1);
+        let table = crate::PrivateTallyTable::generate_with_balance(max_votes, 1);
         let tr = tally_result(max_votes, &ts, &shares, &table);
 
         println!("{:?}", tr);

--- a/chain-vote/src/lib.rs
+++ b/chain-vote/src/lib.rs
@@ -219,10 +219,11 @@ fn group_elements_from_bytes(bytes: &[u8]) -> Option<Vec<gang::GroupElement>> {
     Some(elements)
 }
 
-pub fn result(
+pub fn tally_result(
     max_votes: u64,
     tally_state: &TallyState,
     decrypt_shares: &[TallyDecryptShare],
+    table: &gang::PrivateTallyTable,
 ) -> TallyResult {
     let ris = (0..tally_state.r2s.len())
         .map(|i| gang::GroupElement::sum(decrypt_shares.iter().map(|ds| &ds.r1s[i])));
@@ -238,7 +239,7 @@ pub fn result(
     }
 
     TallyResult {
-        votes: gang::baby_step_giant_step(r_results, max_votes),
+        votes: gang::baby_step_giant_step(r_results, max_votes, table),
     }
 }
 
@@ -285,7 +286,8 @@ mod tests {
         let shares = vec![tds1];
 
         println!("resulting");
-        let tr = result(max_votes, &ts, &shares);
+        let table = gang::PrivateTallyTable::generate_with_balance(max_votes, 1);
+        let tr = tally_result(max_votes, &ts, &shares, &table);
 
         println!("{:?}", tr);
         assert_eq!(tr.votes.len(), vote_options);
@@ -337,7 +339,8 @@ mod tests {
         let shares = vec![tds1, tds2, tds3];
 
         println!("resulting");
-        let tr = result(max_votes, &ts, &shares);
+        let table = gang::PrivateTallyTable::generate_with_balance(max_votes, 1);
+        let tr = tally_result(max_votes, &ts, &shares, &table);
 
         println!("{:?}", tr);
         assert_eq!(tr.votes.len(), vote_options);


### PR DESCRIPTION
Use baby-step giant-step algorithm (https://en.wikipedia.org/wiki/Baby-step_giant-step) to speed up the tallying, memory and time O(sqrt(MAX_VOTES)). With this change we can tally a fund2-like vote plan in 3s.

To utilize this efficiently we should add a command in jcli to do the tallying for all the proposals in a vote plan.
