### PR TITLE
Add verification of computed private tally; make tallying fallible

### DIFF
--- a/chain-impl-mockchain/src/vote/ledger.rs
+++ b/chain-impl-mockchain/src/vote/ledger.rs
@@ -161,7 +161,7 @@ impl VotePlanLedger {
                 .map(Some),
             TallyProof::Private { .. } => {
                 let shares = tally.decrypt_shares().unwrap();
-                v.private_tally_finish(&shares, governance, f).map(Some)
+                v.finalize_private_tally(&shares, governance, f).map(Some)
             }
         });
 
@@ -190,7 +190,7 @@ impl VotePlanLedger {
         let id = encrypted_tally.id().clone();
 
         let r = self.plans.update(&id, move |v| {
-            v.private_tally_start(block_date, stake, sig.id).map(Some)
+            v.start_private_tally(block_date, stake, sig.id).map(Some)
         });
 
         match r {

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -438,7 +438,7 @@ impl ProposalManagers {
         }
     }
 
-    pub fn private_tally_start(&self, stake: &StakeControl) -> Result<Self, VoteError> {
+    pub fn start_private_tally(&self, stake: &StakeControl) -> Result<Self, VoteError> {
         let mut proposals = Vec::with_capacity(self.0.len());
         for proposal in self.0.iter() {
             proposals.push(proposal.private_tally(stake)?);
@@ -447,7 +447,7 @@ impl ProposalManagers {
         Ok(Self(proposals))
     }
 
-    pub fn private_tally_finalize<F>(
+    pub fn finalize_private_tally<F>(
         &self,
         shares: &TallyDecryptShares,
         governance: &Governance,
@@ -640,7 +640,7 @@ impl VotePlanManager {
         })
     }
 
-    pub fn private_tally_start(
+    pub fn start_private_tally(
         &self,
         block_date: BlockDate,
         stake: &StakeControl,
@@ -661,7 +661,7 @@ impl VotePlanManager {
             return Err(TallyError::InvalidPrivacy.into());
         }
 
-        let proposal_managers = self.proposal_managers.private_tally_start(stake)?;
+        let proposal_managers = self.proposal_managers.start_private_tally(stake)?;
 
         Ok(Self {
             proposal_managers,
@@ -671,7 +671,7 @@ impl VotePlanManager {
         })
     }
 
-    pub fn private_tally_finish<F>(
+    pub fn finalize_private_tally<F>(
         &self,
         shares: &TallyDecryptShares,
         governance: &Governance,
@@ -682,7 +682,7 @@ impl VotePlanManager {
     {
         let proposal_managers = self
             .proposal_managers
-            .private_tally_finalize(shares, governance, f)?;
+            .finalize_private_tally(shares, governance, f)?;
         Ok(Self {
             proposal_managers,
             plan: Arc::clone(&self.plan),

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -246,14 +246,10 @@ impl ProposalManager {
             &state,
             shares,
             &chain_vote::PrivateTallyTable::generate(total_stake.0),
-        );
+        )
+        .map_err(|_| TallyError::BadDecryptShares)?;
         let mut result = TallyResult::new(self.options.clone());
-        for (choice, weight) in private_result
-            .votes
-            .iter()
-            .map(|maybe_vote| maybe_vote.unwrap_or_default())
-            .enumerate()
-        {
+        for (choice, &weight) in private_result.votes.iter().enumerate() {
             result.add_vote(
                 Choice::new(choice.try_into().map_err(|_| {
                     TallyError::InvalidPrivateChoiceSize {

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -240,11 +240,11 @@ impl ProposalManager {
         let tally = self.tally.as_ref().ok_or(TallyError::NoEncryptedTally)?;
         let (encrypted_tally, total_stake) = tally.private_encrypted()?;
         let state = encrypted_tally.state();
-        let private_result = chain_vote::tally_result(
+        let private_result = chain_vote::tally(
             total_stake.0,
             &state,
             shares,
-            &chain_vote::PrivateTallyTable::generate(total_stake.0),
+            &chain_vote::TallyOptimizationTable::generate(total_stake.0),
         )
         .map_err(|_| TallyError::BadDecryptShares)?;
         let mut result = TallyResult::new(self.options.clone());

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -264,8 +264,6 @@ impl ProposalManager {
             )?;
         }
 
-        dbg!(&result);
-
         if self.check(*total_stake, governance, &result) {
             f(&self.action);
         }

--- a/chain-impl-mockchain/src/vote/tally.rs
+++ b/chain-impl-mockchain/src/vote/tally.rs
@@ -45,8 +45,6 @@ pub enum TallyError {
     InvalidChoice { options: Options, choice: Choice },
     #[error("Invalid privacy")]
     InvalidPrivacy,
-    #[error("Choice number {choice} in private vote was too high. Maximum of 255 is allowed.")]
-    InvalidPrivateChoiceSize { choice: u64 },
     #[error("this private tally is already decryptred")]
     TallyAlreadyDecrypted,
     #[error("the encrypted tally was not provided yet")]

--- a/chain-impl-mockchain/src/vote/tally.rs
+++ b/chain-impl-mockchain/src/vote/tally.rs
@@ -51,6 +51,8 @@ pub enum TallyError {
     TallyAlreadyDecrypted,
     #[error("the encrypted tally was not provided yet")]
     NoEncryptedTally,
+    #[error("bad decryption share data")]
+    BadDecryptShares,
 }
 
 impl Weight {

--- a/chain-vote/Cargo.toml
+++ b/chain-vote/Cargo.toml
@@ -4,15 +4,13 @@ version = "0.1.0"
 authors = ["Vincent Hanquez <vincent.hanquez@iohk.io>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 rand_core = "0.5"
 rayon = "1.5"
+thiserror = "1.0"
 cryptoxide = "0.2"
 eccoxide = { version = "0.3", optional = true }
 zerocaf = { version = "0.2", optional = true }
-
 criterion = { version = "0.3", optional = true }
 rand_chacha = { version = "0.2", optional = true }
 

--- a/chain-vote/src/lib.rs
+++ b/chain-vote/src/lib.rs
@@ -254,6 +254,26 @@ pub fn tally_result(
     Ok(DecryptedTally { votes })
 }
 
+/// Verifies that the decrypted tally was correctly obtained from the given
+/// `TallyState` and `TallyDecryptShare` parts.
+///
+/// This can be used for quick online validation for the tallying
+/// performed offline.
+pub fn verify_tally(
+    tally_state: &TallyState,
+    decrypt_shares: &[TallyDecryptShare],
+    result: &DecryptedTally,
+) -> bool {
+    let r_results = result_vector(tally_state, decrypt_shares);
+    let gen = gang::GroupElement::generator();
+    for (i, &w) in result.votes.iter().enumerate() {
+        if &gen * gang::Scalar::from_u64(w) != r_results[i] {
+            return false;
+        }
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/chain-vote/src/lib.rs
+++ b/chain-vote/src/lib.rs
@@ -324,6 +324,9 @@ mod tests {
         assert_eq!(tr.votes.len(), vote_options);
         assert_eq!(tr.votes[0], 10, "vote for option 0");
         assert_eq!(tr.votes[1], 5, "vote for option 1");
+
+        println!("verifying");
+        assert!(verify_tally(&ts, &shares, &tr));
     }
 
     #[test]
@@ -377,5 +380,8 @@ mod tests {
         assert_eq!(tr.votes.len(), vote_options);
         assert_eq!(tr.votes[0], 5, "vote for option 0");
         assert_eq!(tr.votes[1], 3, "vote for option 1");
+
+        println!("verifying");
+        assert!(verify_tally(&ts, &shares, &tr));
     }
 }


### PR DESCRIPTION
Add a `verify` function to enable quick online verification of a tally that is computed offline and submitted to the ledger along with the decrypt shares certified by the committee.

Resolve the problem of dealing with `None` holes in `TallyResult` by not having holes, but returning an error. The assumption is that any cases where such a result can occur raise from either a programming error with the total vote count, or bad input data.

Resolves #515.