### PR TITLE
Add tests for baby-step giant-step

### DIFF
--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -244,7 +244,7 @@ impl ProposalManager {
             total_stake.0,
             &state,
             shares,
-            &chain_vote::TallyOptimizationTable::generate(total_stake.0),
+            &chain_vote::TallyOptimizationTable::generate_with_balance(total_stake.0, 1),
         )
         .map_err(|_| TallyError::BadDecryptShares)?;
         let mut result = TallyResult::new(self.options.clone());


### PR DESCRIPTION
New tests are ignored by default because `HashMap`s are very slow in unoptimized builds.