### PR TITLE
expose bft leaders

### DIFF
--- a/chain-impl-mockchain/src/leadership/bft.rs
+++ b/chain-impl-mockchain/src/leadership/bft.rs
@@ -32,6 +32,10 @@ impl LeadershipData {
         self.leaders.len()
     }
 
+    pub fn leaders(&self) -> &[BftLeaderId] {
+        self.leaders.as_ref()
+    }
+
     #[inline]
     fn offset(&self, block_number: u64) -> BftRoundRobinIndex {
         let max = self.number_of_leaders() as u64;


### PR DESCRIPTION
Leaders in a bft chain are public, but it is quite cumbersome to get their ids now. 
Also useful for https://github.com/input-output-hk/jormungandr/issues/2942 
