### PR TITLE
Hash to group

### DIFF
--- a/chain-addr/src/testing.rs
+++ b/chain-addr/src/testing.rs
@@ -64,9 +64,7 @@ impl Arbitrary for Kind {
                 let h = arbitrary_32bytes(g);
                 Kind::Multisig(h)
             }
-            4 => {
-                Kind::Script(arbitrary_32bytes(g))
-            }
+            4 => Kind::Script(arbitrary_32bytes(g)),
             _ => unreachable!(),
         }
     }

--- a/chain-crypto/src/testing.rs
+++ b/chain-crypto/src/testing.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::digest;
 
 use quickcheck::{Arbitrary, Gen};
-use rand_core::{SeedableRng, RngCore, CryptoRng, Error as RngError};
 use rand::rngs::SmallRng;
+use rand_core::{CryptoRng, Error as RngError, RngCore, SeedableRng};
 
 /// an Arbitrary friendly cryptographic generator
 ///

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -57,6 +57,7 @@ rand_chacha = "0.3"
 lazy_static = "1.3.0"
 tempfile = "3.1.0"
 rand = "0.8"
+cryptoxide = "0.3"
 
 
 [[bench]]

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -57,8 +57,6 @@ rand_chacha = "0.3"
 lazy_static = "1.3.0"
 tempfile = "3.1.0"
 rand = "0.8"
-cryptoxide = "0.3"
-
 
 [[bench]]
 harness = false

--- a/chain-impl-mockchain/benches/tally.rs
+++ b/chain-impl-mockchain/benches/tally.rs
@@ -25,6 +25,7 @@ use rayon::prelude::*;
 
 const ALICE: &str = "Alice";
 const STAKE_POOL: &str = "stake_pool";
+const CRS_SEED: &[u8] = b"This should be a shared seed among the different committee members. Could be the id of the previous VotePlan";
 const VOTE_PLAN: &str = "fund1";
 const MEMBERS_NO: usize = 3;
 const THRESHOLD: usize = 2;
@@ -75,7 +76,7 @@ fn tally_benchmark(
     wallets.append(&mut voters_wallets.iter_mut().collect());
 
     // Prepare committee members keys
-    let members = CommitteeMembersManager::new(&mut rng, THRESHOLD, MEMBERS_NO);
+    let members = CommitteeMembersManager::new(&mut rng, CRS_SEED, THRESHOLD, MEMBERS_NO);
     let committee_keys: Vec<_> = members
         .members()
         .iter()

--- a/chain-impl-mockchain/src/certificate/test.rs
+++ b/chain-impl-mockchain/src/certificate/test.rs
@@ -13,9 +13,6 @@ use quickcheck::TestResult;
 use quickcheck::{Arbitrary, Gen};
 use quickcheck_macros::quickcheck;
 
-use cryptoxide::blake2b::Blake2b;
-use cryptoxide::digest::Digest;
-
 impl Arbitrary for PoolRetirement {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let retirement_time = DurationSeconds::from(u64::arbitrary(g)).into();
@@ -188,9 +185,7 @@ impl Arbitrary for VotePlan {
         let mut seed = [0u8; 32];
         g.fill_bytes(&mut seed);
         let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed);
-        let mut hash = Blake2b::new(32);
-        hash.input(&seed);
-        let h = chain_vote::CRS::from_hash(&mut hash).expect("Hash size should be correct");
+        let h = chain_vote::CRS::from_hash(&seed);
         for _i in 0..keys_n {
             let mc = chain_vote::MemberCommunicationKey::new(&mut rng);
             let threshold = 1;

--- a/chain-impl-mockchain/src/certificate/test.rs
+++ b/chain-impl-mockchain/src/certificate/test.rs
@@ -13,6 +13,9 @@ use quickcheck::TestResult;
 use quickcheck::{Arbitrary, Gen};
 use quickcheck_macros::quickcheck;
 
+use cryptoxide::blake2b::Blake2b;
+use cryptoxide::digest::Digest;
+
 impl Arbitrary for PoolRetirement {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let retirement_time = DurationSeconds::from(u64::arbitrary(g)).into();
@@ -185,7 +188,9 @@ impl Arbitrary for VotePlan {
         let mut seed = [0u8; 32];
         g.fill_bytes(&mut seed);
         let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed);
-        let h = chain_vote::CRS::random(&mut rng);
+        let mut hash = Blake2b::new(32);
+        hash.input(&seed);
+        let h = chain_vote::CRS::from_hash(&mut hash).expect("Hash size should be correct");
         for _i in 0..keys_n {
             let mc = chain_vote::MemberCommunicationKey::new(&mut rng);
             let threshold = 1;

--- a/chain-impl-mockchain/src/testing/data/vote.rs
+++ b/chain-impl-mockchain/src/testing/data/vote.rs
@@ -15,7 +15,12 @@ pub struct CommitteeMember {
 }
 
 impl CommitteeMembersManager {
-    pub fn new(rng: &mut (impl RngCore + CryptoRng), threshold: usize, members_no: usize) -> Self {
+    pub fn new(
+        rng: &mut (impl RngCore + CryptoRng),
+        crs_seed: &[u8],
+        threshold: usize,
+        members_no: usize,
+    ) -> Self {
         let mut public_keys = Vec::new();
         for _ in 0..members_no {
             let private_key = MemberCommunicationKey::new(rng);
@@ -23,7 +28,7 @@ impl CommitteeMembersManager {
             public_keys.push(public_key);
         }
 
-        let crs = CRS::random(rng);
+        let crs = CRS::from_hash(&crs_seed);
 
         let mut members = Vec::new();
         for i in 0..members_no {

--- a/chain-impl-mockchain/src/testing/e2e/vote_private.rs
+++ b/chain-impl-mockchain/src/testing/e2e/vote_private.rs
@@ -1,5 +1,5 @@
-use crate::testing::decrypt_tally;
 use crate::testing::data::CommitteeMembersManager;
+use crate::testing::decrypt_tally;
 use crate::testing::VoteTestGen;
 use crate::{
     certificate::VotePlan,
@@ -19,6 +19,7 @@ use rand_core::SeedableRng;
 const ALICE: &str = "Alice";
 const STAKE_POOL: &str = "stake_pool";
 const VOTE_PLAN: &str = "fund1";
+const CRS_SEED: &[u8] = b"This should be a shared seed among the different committee members. Could be the id of the previous VotePlan";
 
 #[test]
 pub fn private_vote_cast_action_transfer_to_rewards_all_shares() {
@@ -29,7 +30,7 @@ pub fn private_vote_cast_action_transfer_to_rewards_all_shares() {
 
     let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-    let members = CommitteeMembersManager::new(&mut rng, THRESHOLD, MEMBERS_NO);
+    let members = CommitteeMembersManager::new(&mut rng, CRS_SEED, THRESHOLD, MEMBERS_NO);
 
     let committee_keys = members
         .members()

--- a/chain-impl-mockchain/src/testing/gen/vote.rs
+++ b/chain-impl-mockchain/src/testing/gen/vote.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use chain_core::property::BlockDate as BlockDateProp;
 use chain_crypto::digest::DigestOf;
+use chain_vote::CRS;
 use rand_core::{CryptoRng, RngCore};
 use typed_bytes::ByteBuilder;
 
@@ -106,8 +107,10 @@ impl VoteTestGen {
         let encrypting_key =
             chain_vote::EncryptingVoteKey::from_participants(vote_plan.committee_public_keys());
 
+        let crs = CRS::from_hash(&vote_plan.to_id().as_ref());
         let (encrypted_vote, proof) = chain_vote::encrypt_vote(
             rng,
+            &crs,
             &encrypting_key,
             chain_vote::Vote::new(
                 proposal.options().choice_range().clone().max().unwrap() as usize + 1,

--- a/chain-impl-mockchain/src/vote/payload.rs
+++ b/chain-impl-mockchain/src/vote/payload.rs
@@ -221,8 +221,6 @@ impl Default for PayloadType {
 mod tests {
     use super::*;
     use quickcheck::{Arbitrary, Gen};
-    use cryptoxide::blake2b::Blake2b;
-    use cryptoxide::digest::Digest;
 
     impl Arbitrary for PayloadType {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
@@ -249,9 +247,7 @@ mod tests {
                     let mut gen = rand_chacha::ChaCha20Rng::from_seed(seed);
                     let mc = MemberCommunicationKey::new(&mut gen);
                     let threshold = 1;
-                    let mut hash_crs = Blake2b::new(32);
-                    hash_crs.input(&seed);
-                    let h = CRS::from_hash(&mut hash_crs).expect("Hash size is correct");
+                    let h = CRS::from_hash(&mut seed);
                     let m = MemberState::new(&mut gen, threshold, &h, &[mc.to_public()], 0);
                     let participants = vec![m.public_key()];
                     let ek = EncryptingVoteKey::from_participants(&participants);

--- a/chain-impl-mockchain/src/vote/payload.rs
+++ b/chain-impl-mockchain/src/vote/payload.rs
@@ -221,6 +221,8 @@ impl Default for PayloadType {
 mod tests {
     use super::*;
     use quickcheck::{Arbitrary, Gen};
+    use cryptoxide::blake2b::Blake2b;
+    use cryptoxide::digest::Digest;
 
     impl Arbitrary for PayloadType {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
@@ -247,7 +249,9 @@ mod tests {
                     let mut gen = rand_chacha::ChaCha20Rng::from_seed(seed);
                     let mc = MemberCommunicationKey::new(&mut gen);
                     let threshold = 1;
-                    let h = CRS::random(&mut gen);
+                    let mut hash_crs = Blake2b::new(32);
+                    hash_crs.input(&seed);
+                    let h = CRS::from_hash(&mut hash_crs).expect("Hash size is correct");
                     let m = MemberState::new(&mut gen, threshold, &h, &[mc.to_public()], 0);
                     let participants = vec![m.public_key()];
                     let ek = EncryptingVoteKey::from_participants(&participants);
@@ -255,6 +259,7 @@ mod tests {
                     let choice = g.next_u32() % vote_options;
                     let (vote, proof) = encrypt_vote(
                         &mut gen,
+                        &h,
                         &ek,
                         Vote::new(vote_options as usize, choice as usize),
                     );

--- a/chain-impl-mockchain/src/vote/privacy.rs
+++ b/chain-impl-mockchain/src/vote/privacy.rs
@@ -1,14 +1,15 @@
 use crate::vote::{EncryptedVote, ProofOfCorrectVote};
-use chain_vote::{EncryptingVoteKey, Vote};
+use chain_vote::{EncryptingVoteKey, Vote, CRS};
 use rand_core::{CryptoRng, RngCore};
 
 #[allow(dead_code)]
 pub fn encrypt_vote<R: RngCore + CryptoRng>(
     rng: &mut R,
+    crs: &CRS,
     public_key: &EncryptingVoteKey,
     vote: Vote,
 ) -> (EncryptedVote, ProofOfCorrectVote) {
-    let (ev, proof) = chain_vote::encrypt_vote(rng, public_key, vote);
+    let (ev, proof) = chain_vote::encrypt_vote(rng, crs, public_key, vote);
     (
         EncryptedVote::from_inner(ev),
         ProofOfCorrectVote::from_inner(proof),

--- a/chain-vote/benches/gmul.rs
+++ b/chain-vote/benches/gmul.rs
@@ -1,9 +1,8 @@
 use chain_vote::debug::gang;
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand_chacha::ChaCha20Rng;
 
 fn mul(c: &mut Criterion) {
-    let mut g = gang::GroupElement::generator() * gang::Scalar::from_u64(100);
+    let g = gang::GroupElement::generator() * gang::Scalar::from_u64(100);
     c.bench_function("mul", |b| b.iter(|| &g + &g));
 }
 

--- a/chain-vote/src/commitment.rs
+++ b/chain-vote/src/commitment.rs
@@ -1,5 +1,4 @@
 use crate::gang::{GroupElement, Scalar};
-use rand_core::{CryptoRng, RngCore};
 use std::ops::{Add, Mul};
 
 /// Pedersen commitment
@@ -17,17 +16,6 @@ impl CommitmentKey {
     pub fn generate_from_seed(buffer: &mut [u8]) -> Self {
         CommitmentKey {
             h: GroupElement::from_hash(buffer),
-        }
-    }
-
-    pub fn commit<R: RngCore + CryptoRng>(&self, rng: &mut R, message: &Scalar) -> Commitment {
-        let randomness = Scalar::random(rng);
-        self.commit_with_randomness(message, &randomness)
-    }
-
-    pub fn commit_with_randomness(&self, message: &Scalar, randomness: &Scalar) -> Commitment {
-        Commitment {
-            c: GroupElement::generator() * message + &self.h * randomness,
         }
     }
 }

--- a/chain-vote/src/commitment.rs
+++ b/chain-vote/src/commitment.rs
@@ -1,7 +1,6 @@
-use crate::gang::{GroupElement, Scalar, IncorrectHashLengthError};
+use crate::gang::{GroupElement, Scalar};
 use rand_core::{CryptoRng, RngCore};
 use std::ops::{Add, Mul};
-use cryptoxide::digest::Digest;
 
 /// Pedersen commitment
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -15,24 +14,20 @@ pub struct CommitmentKey {
 }
 
 impl CommitmentKey {
-    pub fn generate<D: Digest>(hash: &mut D) -> Result<Self, IncorrectHashLengthError> {
-        match GroupElement::from_hash(hash){
-            Ok(h) => Ok(CommitmentKey { h }),
-            Err(e) => Err(e)
+    pub fn generate_from_seed(buffer: &mut [u8]) -> Self {
+        CommitmentKey {
+            h: GroupElement::from_hash(buffer),
         }
-
     }
 
     pub fn commit<R: RngCore + CryptoRng>(&self, rng: &mut R, message: &Scalar) -> Commitment {
         let randomness = Scalar::random(rng);
-        Commitment {
-            c: GroupElement::generator() * message + &self.h * randomness
-        }
+        self.commit_with_randomness(message, &randomness)
     }
 
     pub fn commit_with_randomness(&self, message: &Scalar, randomness: &Scalar) -> Commitment {
         Commitment {
-            c: GroupElement::generator() * message + &self.h * randomness
+            c: GroupElement::generator() * message + &self.h * randomness,
         }
     }
 }

--- a/chain-vote/src/committee.rs
+++ b/chain-vote/src/committee.rs
@@ -82,7 +82,7 @@ impl MemberState {
                 let share_shek = pshek.evaluate(&idx);
 
                 let pk = &committee_pks[i];
-                let ck = CommitmentKey{h: h.clone()};
+                let ck = CommitmentKey { h: h.clone() };
 
                 let rcomm = Scalar::random(rng);
                 let rshek = Scalar::random(rng);

--- a/chain-vote/src/committee.rs
+++ b/chain-vote/src/committee.rs
@@ -1,7 +1,7 @@
-use crate::commitment::CommitmentKey;
 use crate::gang::{GroupElement, Scalar};
 use crate::gargamel::{PublicKey, SecretKey};
 use crate::hybrid;
+use crate::hybrid::SymmetricKey;
 use crate::math::Polynomial;
 use rand_core::{CryptoRng, RngCore};
 
@@ -38,7 +38,7 @@ pub struct MemberState {
     owner_index: usize,
     apubs: Vec<GroupElement>,
     es: Vec<GroupElement>,
-    encrypted: Vec<(hybrid::Encrypted, hybrid::Encrypted)>,
+    encrypted: Vec<(hybrid::HybridCiphertext, hybrid::HybridCiphertext)>,
 }
 
 pub type CRS = GroupElement;
@@ -82,12 +82,19 @@ impl MemberState {
                 let share_shek = pshek.evaluate(&idx);
 
                 let pk = &committee_pks[i];
-                let ck = CommitmentKey { h: h.clone() };
+                let sym_key_shares = SymmetricKey::new(rng);
+                let sym_key_blinders = SymmetricKey::new(rng);
 
                 let rcomm = Scalar::random(rng);
                 let rshek = Scalar::random(rng);
-                let ecomm = hybrid::encrypt(&pk.0, &ck, &share_comm.to_bytes(), &rcomm);
-                let eshek = hybrid::encrypt(&pk.0, &ck, &share_shek.to_bytes(), &rshek);
+                let ecomm =
+                    hybrid::hybrid_encrypt(&pk.0, &sym_key_shares, &share_comm.to_bytes(), &rcomm);
+                let eshek = hybrid::hybrid_encrypt(
+                    &pk.0,
+                    &sym_key_blinders,
+                    &share_shek.to_bytes(),
+                    &rshek,
+                );
 
                 encrypted.push((ecomm, eshek));
             }

--- a/chain-vote/src/committee.rs
+++ b/chain-vote/src/committee.rs
@@ -82,13 +82,12 @@ impl MemberState {
                 let share_shek = pshek.evaluate(&idx);
 
                 let pk = &committee_pks[i];
-                let ck_comm = CommitmentKey::generate(rng);
-                let ck_shek = CommitmentKey::generate(rng);
+                let ck = CommitmentKey{h: h.clone()};
 
                 let rcomm = Scalar::random(rng);
                 let rshek = Scalar::random(rng);
-                let ecomm = hybrid::encrypt(&pk.0, &ck_comm, &share_comm.to_bytes(), &rcomm);
-                let eshek = hybrid::encrypt(&pk.0, &ck_shek, &share_shek.to_bytes(), &rshek);
+                let ecomm = hybrid::encrypt(&pk.0, &ck, &share_comm.to_bytes(), &rcomm);
+                let eshek = hybrid::encrypt(&pk.0, &ck, &share_shek.to_bytes(), &rshek);
 
                 encrypted.push((ecomm, eshek));
             }

--- a/chain-vote/src/gang/p256k1.rs
+++ b/chain-vote/src/gang/p256k1.rs
@@ -99,17 +99,6 @@ impl GroupElement {
         GroupElement(Point::infinity())
     }
 
-    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        let mut r = [0u8; 32];
-        loop {
-            rng.fill_bytes(&mut r[..]);
-
-            if let Some(s) = GroupElement::from_x_bytes(&r) {
-                break s;
-            }
-        }
-    }
-
     pub fn normalize(&mut self) {
         self.0.normalize()
     }

--- a/chain-vote/src/hybrid.rs
+++ b/chain-vote/src/hybrid.rs
@@ -47,9 +47,7 @@ mod tests {
 
     #[test]
     fn encrypt_decrypt() {
-        let mut hash = Blake2b::new(32);
-        hash.input(&[0; 23]);
-        let ck = CommitmentKey::generate(&mut hash).expect("Hash size is correct");
+        let ck = CommitmentKey::generate_from_seed(&mut [0; 23]);
 
         let mut r = ChaCha20Rng::from_seed([0u8; 32]);
         let k = SecretKey::generate(&mut r);

--- a/chain-vote/src/hybrid.rs
+++ b/chain-vote/src/hybrid.rs
@@ -47,8 +47,11 @@ mod tests {
 
     #[test]
     fn encrypt_decrypt() {
+        let mut hash = Blake2b::new(32);
+        hash.input(&[0; 23]);
+        let ck = CommitmentKey::generate(&mut hash).expect("Hash size is correct");
+
         let mut r = ChaCha20Rng::from_seed([0u8; 32]);
-        let ck = CommitmentKey::generate(&mut r);
         let k = SecretKey::generate(&mut r);
         let k = Keypair::from_secretkey(k);
 

--- a/chain-vote/src/hybrid.rs
+++ b/chain-vote/src/hybrid.rs
@@ -1,41 +1,72 @@
-use crate::commitment::CommitmentKey;
 use crate::gang::{GroupElement, Scalar};
 use crate::gargamel::{self, PublicKey, SecretKey};
 use cryptoxide::blake2b::Blake2b;
 use cryptoxide::chacha20::ChaCha20;
 use cryptoxide::digest::Digest;
+use rand_core::{CryptoRng, RngCore};
 
 #[derive(Clone)]
-pub struct Encrypted {
+pub struct HybridCiphertext {
+    // ElGamal Ciphertext
     e1: gargamel::Ciphertext,
+    // Symmetric encrypted message
     e2: Box<[u8]>,
 }
 
-fn bc_key(ck: &GroupElement) -> ChaCha20 {
-    let mut out = [0u8; 44];
-    let mut h = Blake2b::new(44);
-    h.input(&ck.to_bytes());
-    h.result(&mut out);
-    ChaCha20::new(&out[0..32], &out[32..44])
+/// The hybrid encryption scheme uses a group element as a
+/// representation of the symmetric key. This facilitates
+/// its exchange using ElGamal encryption.
+pub struct SymmetricKey {
+    group_repr: GroupElement,
 }
 
-fn bc_process(ck: &GroupElement, m: &[u8]) -> Vec<u8> {
-    let mut key = bc_key(ck);
-    let mut dat = m.to_vec();
-    key.process_mut(&mut dat);
-    dat
+impl SymmetricKey {
+    /// Generate a new random symmetric key
+    pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        let exponent = Scalar::random(rng);
+        SymmetricKey {
+            group_repr: GroupElement::generator() * &exponent,
+        }
+    }
+
+    /// Initialise encryption, by hashing the group element
+    fn initialise_encryption(&self) -> ChaCha20 {
+        let mut out = [0u8; 44];
+        let mut h = Blake2b::new(44);
+        h.input(&self.group_repr.to_bytes());
+        h.result(&mut out);
+        ChaCha20::new(&out[0..32], &out[32..44])
+    }
+
+    /// Encrypt/decrypt a message using the symmetric key
+    fn process(&self, m: &[u8]) -> Vec<u8> {
+        let mut key = self.initialise_encryption();
+        let mut dat = m.to_vec();
+        key.process_mut(&mut dat);
+        dat
+    }
 }
 
-pub fn encrypt(pk: &PublicKey, ck: &CommitmentKey, m: &[u8], r: &Scalar) -> Encrypted {
-    let e1 = gargamel::encrypt_point(pk, &ck.h, r);
-    let e2 = bc_process(&ck.h, m).into_boxed_slice();
-    Encrypted { e1, e2 }
+/// Encrypt a message using hybrid encryption
+pub fn hybrid_encrypt(
+    pk: &PublicKey,
+    symmetric_key: &SymmetricKey,
+    m: &[u8],
+    r: &Scalar,
+) -> HybridCiphertext {
+    let e1 = gargamel::encrypt_point(pk, &symmetric_key.group_repr, r);
+    let e2 = symmetric_key.process(m).into_boxed_slice();
+    HybridCiphertext { e1, e2 }
 }
 
 #[allow(dead_code)]
-pub fn decrypt(sk: &SecretKey, e: &Encrypted) -> Vec<u8> {
-    let ck = gargamel::decrypt_point(sk, &e.e1);
-    bc_process(&ck, &e.e2)
+/// Encrypt a message using hybrid decryption
+pub fn hybrid_decrypt(sk: &SecretKey, ciphertext: &HybridCiphertext) -> Vec<u8> {
+    let symmetric_key = SymmetricKey {
+        group_repr: gargamel::decrypt_point(sk, &ciphertext.e1),
+    };
+
+    symmetric_key.process(&ciphertext.e2)
 }
 
 #[cfg(test)]
@@ -47,18 +78,18 @@ mod tests {
 
     #[test]
     fn encrypt_decrypt() {
-        let ck = CommitmentKey::generate_from_seed(&mut [0; 23]);
-
         let mut r = ChaCha20Rng::from_seed([0u8; 32]);
         let k = SecretKey::generate(&mut r);
         let k = Keypair::from_secretkey(k);
+
+        let sym_key = SymmetricKey::new(&mut r);
 
         let r = Scalar::random(&mut r);
 
         let m = [1, 3, 4, 5, 6, 7];
 
-        let encrypted = encrypt(&k.public_key, &ck, &m, &r);
-        let result = decrypt(&k.secret_key, &encrypted);
+        let encrypted = hybrid_encrypt(&k.public_key, &sym_key, &m, &r);
+        let result = hybrid_decrypt(&k.secret_key, &encrypted);
 
         assert_eq!(&m[..], &result[..])
     }

--- a/chain-vote/src/lib.rs
+++ b/chain-vote/src/lib.rs
@@ -58,22 +58,24 @@ pub type CRS = committee::CRS;
 /// Take a vote and encrypt it + provide a proof of correct voting
 pub fn encrypt_vote<R: RngCore + CryptoRng>(
     rng: &mut R,
+    crs: &CRS,
     public_key: &EncryptingVoteKey,
     vote: Vote,
 ) -> (EncryptedVote, ProofOfCorrectVote) {
     let ev = EncryptingVote::prepare(rng, &public_key.0, &vote);
-    let proof = shvzk::prove(rng, &public_key.0, ev.clone());
+    let proof = shvzk::prove(rng, &crs, &public_key.0, ev.clone());
     (ev.ciphertexts, proof)
 }
 
 /// Verify that the encrypted vote is valid without opening it
 #[allow(clippy::ptr_arg)]
 pub fn verify_vote(
+    crs: &CRS,
     public_key: &EncryptingVoteKey,
     vote: &EncryptedVote,
     proof: &ProofOfCorrectVote,
 ) -> bool {
-    shvzk::verify(&public_key.0, vote, proof)
+    shvzk::verify(&crs, &public_key.0, vote, proof)
 }
 
 /// The encrypted tally
@@ -313,9 +315,9 @@ mod tests {
         println!("encrypting vote");
 
         let vote_options = 2;
-        let e1 = encrypt_vote(&mut rng, &ek, Vote::new(vote_options, 0));
-        let e2 = encrypt_vote(&mut rng, &ek, Vote::new(vote_options, 1));
-        let e3 = encrypt_vote(&mut rng, &ek, Vote::new(vote_options, 0));
+        let e1 = encrypt_vote(&mut rng, &h, &ek, Vote::new(vote_options, 0));
+        let e2 = encrypt_vote(&mut rng, &h, &ek, Vote::new(vote_options, 1));
+        let e3 = encrypt_vote(&mut rng, &h, &ek, Vote::new(vote_options, 0));
 
         println!("tallying");
 
@@ -366,11 +368,11 @@ mod tests {
         println!("encrypting vote");
 
         let vote_options = 2;
-        let (e1, e1_proof) = encrypt_vote(&mut rng, &ek, Vote::new(vote_options, 0));
-        let e2 = encrypt_vote(&mut rng, &ek, Vote::new(vote_options, 1));
-        let e3 = encrypt_vote(&mut rng, &ek, Vote::new(vote_options, 0));
+        let (e1, e1_proof) = encrypt_vote(&mut rng, &h, &ek, Vote::new(vote_options, 0));
+        let e2 = encrypt_vote(&mut rng, &h, &ek, Vote::new(vote_options, 1));
+        let e3 = encrypt_vote(&mut rng, &h, &ek, Vote::new(vote_options, 0));
 
-        assert!(verify_vote(&ek, &e1, &e1_proof));
+        assert!(verify_vote(&h, &ek, &e1, &e1_proof));
         println!("tallying");
 
         let mut tally = EncryptedTally::new(vote_options);
@@ -418,7 +420,7 @@ mod tests {
         println!("encrypting vote");
 
         let vote_options = 2;
-        let (e1, _) = encrypt_vote(&mut rng, &ek, Vote::new(vote_options, 0));
+        let (e1, _) = encrypt_vote(&mut rng, &h, &ek, Vote::new(vote_options, 0));
 
         println!("tallying");
 
@@ -504,9 +506,9 @@ mod tests {
         println!("encrypting vote");
 
         let vote_options = 2;
-        let e1 = encrypt_vote(&mut rng, &ek, Vote::new(vote_options, 0));
-        let e2 = encrypt_vote(&mut rng, &ek, Vote::new(vote_options, 1));
-        let e3 = encrypt_vote(&mut rng, &ek, Vote::new(vote_options, 0));
+        let e1 = encrypt_vote(&mut rng, &h, &ek, Vote::new(vote_options, 0));
+        let e2 = encrypt_vote(&mut rng, &h, &ek, Vote::new(vote_options, 1));
+        let e3 = encrypt_vote(&mut rng, &h, &ek, Vote::new(vote_options, 0));
 
         let mut tally = EncryptedTally::new(vote_options);
         tally.add(&e1.0, 10);

--- a/chain-vote/src/lib.rs
+++ b/chain-vote/src/lib.rs
@@ -293,6 +293,8 @@ impl Tally {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cryptoxide::blake2b::Blake2b;
+    use cryptoxide::digest::Digest;
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
@@ -300,7 +302,11 @@ mod tests {
     fn encdec1() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-        let h = CRS::random(&mut rng);
+        let shared_string = b"Example of a shared string. This could be the latest block hash";
+        let mut hasher = Blake2b::new(32);
+        hasher.input(shared_string);
+
+        let h = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
         let mc = [mc1.to_public()];
@@ -349,7 +355,11 @@ mod tests {
     fn encdec3() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-        let h = CRS::random(&mut rng);
+        let shared_string = b"Example of a shared string. This could be the latest block hash";
+        let mut hasher = Blake2b::new(32);
+        hasher.input(shared_string);
+
+        let h = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
         let mc2 = MemberCommunicationKey::new(&mut rng);
@@ -405,7 +415,11 @@ mod tests {
     fn zero_and_max_votes() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-        let h = CRS::random(&mut rng);
+        let shared_string = b"Example of a shared string. This could be the latest block hash";
+        let mut hasher = Blake2b::new(32);
+        hasher.input(shared_string);
+
+        let h = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
         let mc = [mc1.to_public()];
@@ -450,7 +464,11 @@ mod tests {
     fn empty_tally() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-        let h = CRS::random(&mut rng);
+        let shared_string = b"Example of a shared string. This could be the latest block hash";
+        let mut hasher = Blake2b::new(32);
+        hasher.input(shared_string);
+
+        let h = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
         let mc = [mc1.to_public()];
@@ -487,7 +505,11 @@ mod tests {
     fn wrong_max_votes() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-        let h = CRS::random(&mut rng);
+        let shared_string = b"Example of a shared string. This could be the latest block hash";
+        let mut hasher = Blake2b::new(32);
+        hasher.input(shared_string);
+
+        let h = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
         let mc2 = MemberCommunicationKey::new(&mut rng);

--- a/chain-vote/src/lib.rs
+++ b/chain-vote/src/lib.rs
@@ -301,7 +301,7 @@ mod tests {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
         let mut shared_string =
-            b"Example of a shared string. This could be the latest block hash".to_owned();
+            b"Example of a shared string. This should be VotePlan.to_id()".to_owned();
         let h = CRS::from_hash(&mut shared_string);
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
@@ -352,7 +352,7 @@ mod tests {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
         let mut shared_string =
-            b"Example of a shared string. This could be the latest block hash".to_owned();
+            b"Example of a shared string. This should be VotePlan.to_id()".to_owned();
         let h = CRS::from_hash(&mut shared_string);
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
@@ -410,7 +410,7 @@ mod tests {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
         let mut shared_string =
-            b"Example of a shared string. This could be the latest block hash".to_owned();
+            b"Example of a shared string. This should be VotePlan.to_id()".to_owned();
         let h = CRS::from_hash(&mut shared_string);
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
@@ -457,7 +457,7 @@ mod tests {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
         let mut shared_string =
-            b"Example of a shared string. This could be the latest block hash".to_owned();
+            b"Example of a shared string. This should be VotePlan.to_id()".to_owned();
         let h = CRS::from_hash(&mut shared_string);
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
@@ -496,7 +496,7 @@ mod tests {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
         let mut shared_string =
-            b"Example of a shared string. This could be the latest block hash".to_owned();
+            b"Example of a shared string. This should be VotePlan.to_id()".to_owned();
         let h = CRS::from_hash(&mut shared_string);
 
         let mc1 = MemberCommunicationKey::new(&mut rng);

--- a/chain-vote/src/lib.rs
+++ b/chain-vote/src/lib.rs
@@ -293,8 +293,6 @@ impl Tally {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cryptoxide::blake2b::Blake2b;
-    use cryptoxide::digest::Digest;
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
@@ -302,11 +300,9 @@ mod tests {
     fn encdec1() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-        let shared_string = b"Example of a shared string. This could be the latest block hash";
-        let mut hasher = Blake2b::new(32);
-        hasher.input(shared_string);
-
-        let h = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
+        let mut shared_string =
+            b"Example of a shared string. This could be the latest block hash".to_owned();
+        let h = CRS::from_hash(&mut shared_string);
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
         let mc = [mc1.to_public()];
@@ -355,11 +351,9 @@ mod tests {
     fn encdec3() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-        let shared_string = b"Example of a shared string. This could be the latest block hash";
-        let mut hasher = Blake2b::new(32);
-        hasher.input(shared_string);
-
-        let h = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
+        let mut shared_string =
+            b"Example of a shared string. This could be the latest block hash".to_owned();
+        let h = CRS::from_hash(&mut shared_string);
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
         let mc2 = MemberCommunicationKey::new(&mut rng);
@@ -415,11 +409,9 @@ mod tests {
     fn zero_and_max_votes() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-        let shared_string = b"Example of a shared string. This could be the latest block hash";
-        let mut hasher = Blake2b::new(32);
-        hasher.input(shared_string);
-
-        let h = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
+        let mut shared_string =
+            b"Example of a shared string. This could be the latest block hash".to_owned();
+        let h = CRS::from_hash(&mut shared_string);
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
         let mc = [mc1.to_public()];
@@ -464,11 +456,9 @@ mod tests {
     fn empty_tally() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-        let shared_string = b"Example of a shared string. This could be the latest block hash";
-        let mut hasher = Blake2b::new(32);
-        hasher.input(shared_string);
-
-        let h = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
+        let mut shared_string =
+            b"Example of a shared string. This could be the latest block hash".to_owned();
+        let h = CRS::from_hash(&mut shared_string);
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
         let mc = [mc1.to_public()];
@@ -505,11 +495,9 @@ mod tests {
     fn wrong_max_votes() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
-        let shared_string = b"Example of a shared string. This could be the latest block hash";
-        let mut hasher = Blake2b::new(32);
-        hasher.input(shared_string);
-
-        let h = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
+        let mut shared_string =
+            b"Example of a shared string. This could be the latest block hash".to_owned();
+        let h = CRS::from_hash(&mut shared_string);
 
         let mc1 = MemberCommunicationKey::new(&mut rng);
         let mc2 = MemberCommunicationKey::new(&mut rng);

--- a/chain-vote/src/shvzk.rs
+++ b/chain-vote/src/shvzk.rs
@@ -419,7 +419,11 @@ mod tests {
         let unit_vector = UnitVector::new(2, 0);
         let ev = EncryptingVote::prepare(&mut r, &public_key, &unit_vector);
 
-        let crs = CRS::random(&mut r);
+        let shared_string = b"Example of a shared string. This could be the latest block hash";
+        let mut hasher = Blake2b::new(32);
+        hasher.input(shared_string);
+
+        let crs = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
 
         let proof = prove(&mut r, &crs, &public_key, ev.clone());
         assert!(verify(&crs, &public_key, &ev.ciphertexts, &proof))
@@ -432,7 +436,11 @@ mod tests {
         let unit_vector = UnitVector::new(5, 1);
         let ev = EncryptingVote::prepare(&mut r, &public_key, &unit_vector);
 
-        let crs = CRS::random(&mut r);
+        let shared_string = b"Example of a shared string. This could be the latest block hash";
+        let mut hasher = Blake2b::new(32);
+        hasher.input(shared_string);
+
+        let crs = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
 
         let proof = prove(&mut r, &crs, &public_key, ev.clone());
         assert!(verify(&crs, &public_key, &ev.ciphertexts, &proof))

--- a/chain-vote/src/shvzk.rs
+++ b/chain-vote/src/shvzk.rs
@@ -419,11 +419,9 @@ mod tests {
         let unit_vector = UnitVector::new(2, 0);
         let ev = EncryptingVote::prepare(&mut r, &public_key, &unit_vector);
 
-        let shared_string = b"Example of a shared string. This could be the latest block hash";
-        let mut hasher = Blake2b::new(32);
-        hasher.input(shared_string);
-
-        let crs = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
+        let mut shared_string =
+            b"Example of a shared string. This could be the latest block hash".to_owned();
+        let crs = CRS::from_hash(&mut shared_string);
 
         let proof = prove(&mut r, &crs, &public_key, ev.clone());
         assert!(verify(&crs, &public_key, &ev.ciphertexts, &proof))
@@ -436,11 +434,9 @@ mod tests {
         let unit_vector = UnitVector::new(5, 1);
         let ev = EncryptingVote::prepare(&mut r, &public_key, &unit_vector);
 
-        let shared_string = b"Example of a shared string. This could be the latest block hash";
-        let mut hasher = Blake2b::new(32);
-        hasher.input(shared_string);
-
-        let crs = CRS::from_hash(&mut hasher).expect("Size is big enough for point generation.");
+        let mut shared_string =
+            b"Example of a shared string. This could be the latest block hash".to_owned();
+        let crs = CRS::from_hash(&mut shared_string);
 
         let proof = prove(&mut r, &crs, &public_key, ev.clone());
         assert!(verify(&crs, &public_key, &ev.ciphertexts, &proof))

--- a/chain-vote/src/shvzk.rs
+++ b/chain-vote/src/shvzk.rs
@@ -141,17 +141,9 @@ impl Proof {
 fn commitkey(pk: &PublicKey) -> CommitmentKey {
     let mut ctx = Blake2b::new(32);
     ctx.input(&pk.to_bytes());
-    let mut i = 1u32;
-    let mut h = [0u8; 32];
-    loop {
-        ctx.input(&i.to_be_bytes());
-        ctx.result(&mut h);
-        match GroupElement::from_hash(&h) {
-            None => i += 1,
-            Some(fe) => {
-                break CommitmentKey { h: fe };
-            }
-        }
+
+    CommitmentKey {
+        h: GroupElement::from_hash(&mut ctx),
     }
 }
 

--- a/chain-vote/src/shvzk.rs
+++ b/chain-vote/src/shvzk.rs
@@ -4,10 +4,11 @@ use rand_core::{CryptoRng, RngCore};
 
 use crate::commitment::{Commitment, CommitmentKey};
 use crate::encrypted::{EncryptingVote, PTP};
-use crate::gang::{GroupElement, Scalar};
+use crate::gang::Scalar;
 use crate::gargamel::{encrypt, Ciphertext, PublicKey};
 use crate::math::Polynomial;
 use crate::unit_vector::binrep;
+use crate::CRS;
 
 struct ABCD {
     alpha: Scalar,
@@ -138,30 +139,21 @@ impl Proof {
     }
 }
 
-fn commitkey(pk: &PublicKey) -> CommitmentKey {
-    let mut ctx = Blake2b::new(32);
-    ctx.input(&pk.to_bytes());
-
-    CommitmentKey {
-        h: GroupElement::from_hash(&mut ctx),
-    }
-}
-
 impl IBA {
     fn new(ck: &CommitmentKey, abcd: &ABCD, index: &Scalar) -> Self {
         assert!(index == &Scalar::zero() || index == &Scalar::one());
 
         // commit index bit: 0 or 1
-        let i = Commitment::new(&ck, &index, &abcd.alpha);
+        let i = Commitment::new(ck, &index, &abcd.alpha);
         // commit beta
-        let b = Commitment::new(&ck, &abcd.beta, &abcd.gamma);
+        let b = Commitment::new(ck, &abcd.beta, &abcd.gamma);
         // commit i * B => 0 * B = 0 or 1 * B = B
         let acommited = if index == &Scalar::one() {
             abcd.beta.clone()
         } else {
             Scalar::zero()
         };
-        let a = Commitment::new(&ck, &acommited, &abcd.delta);
+        let a = Commitment::new(ck, &acommited, &abcd.delta);
 
         IBA { i, b, a }
     }
@@ -205,17 +197,17 @@ impl ChallengeContext {
 
 pub(crate) fn prove<R: RngCore + CryptoRng>(
     rng: &mut R,
+    crs: &CRS,
     public_key: &PublicKey,
     encrypting_vote: EncryptingVote,
 ) -> Proof {
+    let ck = CommitmentKey { h: crs.clone() };
     let ciphers = PTP::new(encrypting_vote.ciphertexts, Ciphertext::zero);
     let cipher_randoms = PTP::new(encrypting_vote.random_elements, Scalar::zero);
 
     assert_eq!(ciphers.bits(), cipher_randoms.bits());
 
     let bits = ciphers.bits();
-
-    let ck = commitkey(&public_key);
 
     let mut abcds = Vec::with_capacity(bits);
     for _ in 0..bits {
@@ -334,9 +326,13 @@ pub(crate) fn prove<R: RngCore + CryptoRng>(
     Proof { ibas, ds, zwvs, r }
 }
 
-pub(crate) fn verify(public_key: &PublicKey, ciphertexts: &[Ciphertext], proof: &Proof) -> bool {
-    let ck = commitkey(&public_key);
-
+pub(crate) fn verify(
+    crs: &CRS,
+    public_key: &PublicKey,
+    ciphertexts: &[Ciphertext],
+    proof: &Proof,
+) -> bool {
+    let ck = CommitmentKey { h: crs.clone() };
     let ciphertexts = PTP::new(ciphertexts.to_vec(), Ciphertext::zero);
     let bits = ciphertexts.bits();
     let cc = ChallengeContext::new(public_key, ciphertexts.as_ref(), &proof.ibas);
@@ -423,8 +419,10 @@ mod tests {
         let unit_vector = UnitVector::new(2, 0);
         let ev = EncryptingVote::prepare(&mut r, &public_key, &unit_vector);
 
-        let proof = prove(&mut r, &public_key, ev.clone());
-        assert!(verify(&public_key, &ev.ciphertexts, &proof))
+        let crs = CRS::random(&mut r);
+
+        let proof = prove(&mut r, &crs, &public_key, ev.clone());
+        assert!(verify(&crs, &public_key, &ev.ciphertexts, &proof))
     }
 
     #[test]
@@ -434,7 +432,9 @@ mod tests {
         let unit_vector = UnitVector::new(5, 1);
         let ev = EncryptingVote::prepare(&mut r, &public_key, &unit_vector);
 
-        let proof = prove(&mut r, &public_key, ev.clone());
-        assert!(verify(&public_key, &ev.ciphertexts, &proof))
+        let crs = CRS::random(&mut r);
+
+        let proof = prove(&mut r, &crs, &public_key, ev.clone());
+        assert!(verify(&crs, &public_key, &ev.ciphertexts, &proof))
     }
 }

--- a/chain-vote/src/shvzk.rs
+++ b/chain-vote/src/shvzk.rs
@@ -146,11 +146,10 @@ fn commitkey(pk: &PublicKey) -> CommitmentKey {
     loop {
         ctx.input(&i.to_be_bytes());
         ctx.result(&mut h);
-        match Scalar::from_bytes(&h) {
+        match GroupElement::from_hash(&h) {
             None => i += 1,
             Some(fe) => {
-                let h = &GroupElement::generator() * &fe;
-                break CommitmentKey { h };
+                break CommitmentKey { h: fe };
             }
         }
     }


### PR DESCRIPTION
Implement hash to group for sec2 curve, and adaptation of the rest of the code-base to new function. Changes: 
* hash to group by hashing a given slice, and generating a point out of it
* removed random generations of commitment key to the deterministic `from_hash()`
* generate and verify vote take as input the CRS
* adapt rest of the code base to the changes above