### PR TITLE
Peers update

### DIFF
--- a/chain-network/proto/node.proto
+++ b/chain-network/proto/node.proto
@@ -61,31 +61,8 @@ message FragmentIds {
 // Request for peers
 message PeersRequest { uint32 limit = 1; }
 
-// Responses as a bunch of peers
-message PeersResponse { repeated Peer peers = 1; }
-
-// A Peer on the network
-message Peer {
-  // FIXME: make the port field common, indicate TCP protocol selection
-  // by the field number.
-  oneof peer {
-    PeerV4 v4 = 1;
-    PeerV6 v6 = 2;
-  }
-}
-
-// An ipv4 peer
-message PeerV4 {
-  fixed32 ip = 1;
-  fixed32 port = 2; // FIXME: uint32 is more efficient for port numbers
-}
-
-// An ipv6 peer
-message PeerV6 {
-  fixed64 ip_high = 1;
-  fixed64 ip_low = 2;
-  fixed32 port = 3; // FIXME: uint32 is more efficient for port numbers
-}
+// Responses as a bunch of peers, similar to Gossip
+message PeersResponse { repeated bytes peers = 2; }
 
 // Request message for method PullHeaders.
 // This message can also be send by the service as a BlockEvent variant.

--- a/chain-network/src/core/server/gossip.rs
+++ b/chain-network/src/core/server/gossip.rs
@@ -1,5 +1,5 @@
 use super::PushStream;
-use crate::data::{Gossip, Peer, Peers};
+use crate::data::{Gossip, Peer};
 use crate::error::Error;
 use async_trait::async_trait;
 use futures::stream::Stream;
@@ -8,7 +8,7 @@ use futures::stream::Stream;
 /// exchanging P2P network gossip.
 #[async_trait]
 pub trait GossipService {
-    async fn peers(&self, limit: u32) -> Result<Peers, Error>;
+    async fn peers(&self, limit: u32) -> Result<Gossip, Error>;
 
     /// The type of outbound asynchronous streams returned by the
     /// `subscription` method.

--- a/chain-network/src/data/mod.rs
+++ b/chain-network/src/data/mod.rs
@@ -8,4 +8,4 @@ pub use block::{Block, BlockEvent, BlockId, BlockIds, Header};
 pub use fragment::{Fragment, FragmentId, FragmentIds};
 pub use gossip::Gossip;
 pub use handshake::HandshakeResponse;
-pub use p2p::{AuthenticatedNodeId, NodeId, NodeKeyPair, Peer, Peers};
+pub use p2p::{AuthenticatedNodeId, NodeId, NodeKeyPair, Peer};

--- a/chain-network/src/data/p2p.rs
+++ b/chain-network/src/data/p2p.rs
@@ -11,8 +11,6 @@ pub struct Peer {
     addr: SocketAddr,
 }
 
-pub type Peers = Box<[Peer]>;
-
 impl Peer {
     #[inline]
     pub fn addr(&self) -> SocketAddr {

--- a/chain-network/src/grpc/client.rs
+++ b/chain-network/src/grpc/client.rs
@@ -8,7 +8,7 @@ use super::legacy;
 use crate::data::block::{Block, BlockEvent, BlockId, BlockIds, Header};
 use crate::data::fragment::{Fragment, FragmentIds};
 use crate::data::p2p::{AuthenticatedNodeId, NodeId};
-use crate::data::{Gossip, HandshakeResponse, Peers};
+use crate::data::{Gossip, HandshakeResponse};
 use crate::error::{Error, HandshakeError};
 use crate::PROTOCOL_VERSION;
 use futures::prelude::*;
@@ -189,10 +189,11 @@ where
     /// The peers are picked up accordingly to the Poldercast algorithm
     /// modules. This request is typically used during bootstrap from
     /// a trusted peer.
-    pub async fn peers(&mut self, limit: u32) -> Result<Peers, Error> {
+    pub async fn peers(&mut self, limit: u32) -> Result<Gossip, Error> {
+        use crate::grpc::convert::FromProtobuf;
         let req = proto::PeersRequest { limit };
         let res = self.inner.peers(req).await?.into_inner();
-        let peers = convert::from_protobuf_repeated(res.peers)?;
+        let peers = Gossip::from_message(res)?;
         Ok(peers)
     }
 

--- a/chain-network/src/grpc/convert.rs
+++ b/chain-network/src/grpc/convert.rs
@@ -3,13 +3,11 @@ use crate::data::{
     block::{self, Block, BlockEvent, BlockId, ChainPullRequest, Header},
     fragment::Fragment,
     gossip::{Gossip, Node},
-    p2p::Peer,
 };
 use crate::error::{self, Error};
 use tonic::{Code, Status};
 
 use std::convert::TryFrom;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 pub(super) fn error_into_grpc(err: Error) -> Status {
     use error::Code::*;
@@ -71,21 +69,6 @@ pub trait FromProtobuf<R>: Sized {
 pub trait IntoProtobuf {
     type Message;
     fn into_message(self) -> Self::Message;
-}
-
-pub(super) fn from_protobuf_repeated<P, T>(message: Vec<P>) -> Result<Box<[T]>, Error>
-where
-    T: FromProtobuf<P>,
-{
-    message.into_iter().map(T::from_message).collect()
-}
-
-pub(super) fn into_protobuf_repeated<I>(iter: I) -> Vec<<I::Item as IntoProtobuf>::Message>
-where
-    I: IntoIterator,
-    I::Item: IntoProtobuf,
-{
-    iter.into_iter().map(|item| item.into_message()).collect()
 }
 
 pub(super) fn ids_into_repeated_bytes<I>(ids: I) -> Vec<Vec<u8>>
@@ -173,97 +156,18 @@ impl IntoProtobuf for Gossip {
     }
 }
 
-impl FromProtobuf<proto::Peer> for Peer {
-    fn from_message(message: proto::Peer) -> Result<Self, Error> {
-        use proto::peer;
-
-        match message.peer {
-            Some(peer::Peer::V4(pv4)) => {
-                let port = pv4.port as u16;
-                let segments = pv4.ip.to_be_bytes();
-                let ipv4 = Ipv4Addr::new(segments[0], segments[1], segments[2], segments[3]);
-                let addr = SocketAddr::new(IpAddr::V4(ipv4), port);
-                Ok(addr.into())
-            }
-            Some(peer::Peer::V6(pv6)) => {
-                let port = pv6.port as u16;
-                let ipv6 = unserialize_ipv6(pv6.ip_high, pv6.ip_low);
-                let addr = SocketAddr::new(IpAddr::V6(ipv6), port);
-                Ok(addr.into())
-            }
-            None => Err(Error::new(
-                error::Code::InvalidArgument,
-                "invalid Peer payload, one of the fields is required",
-            )),
-        }
-    }
-}
-
-fn unserialize_ipv6(high: u64, low: u64) -> Ipv6Addr {
-    let h = high.to_be_bytes();
-    let l = low.to_be_bytes();
-    fn from_be_bytes(h: u8, l: u8) -> u16 {
-        u16::from_be_bytes([h, l])
-    }
-    let segments: [u16; 8] = [
-        from_be_bytes(h[0], h[1]),
-        from_be_bytes(h[2], h[3]),
-        from_be_bytes(h[4], h[5]),
-        from_be_bytes(h[6], h[7]),
-        from_be_bytes(l[0], l[1]),
-        from_be_bytes(l[2], l[3]),
-        from_be_bytes(l[4], l[5]),
-        from_be_bytes(l[6], l[7]),
-    ];
-    std::net::Ipv6Addr::new(
-        segments[0],
-        segments[1],
-        segments[2],
-        segments[3],
-        segments[4],
-        segments[5],
-        segments[6],
-        segments[7],
-    )
-}
-
-impl IntoProtobuf for Peer {
-    type Message = proto::Peer;
-
-    fn into_message(self) -> proto::Peer {
-        let peer = match self.addr() {
-            SocketAddr::V4(v4addr) => {
-                let port: u32 = v4addr.port().into();
-                let ip = u32::from_be_bytes(v4addr.ip().octets());
-                proto::peer::Peer::V4(proto::PeerV4 { ip, port })
-            }
-            SocketAddr::V6(v6addr) => {
-                let port: u32 = v6addr.port().into();
-                let (ip_high, ip_low) = serialize_ipv6(v6addr.ip());
-                proto::peer::Peer::V6(proto::PeerV6 {
-                    port,
-                    ip_high,
-                    ip_low,
-                })
-            }
+impl FromProtobuf<proto::PeersResponse> for Gossip {
+    fn from_message(message: proto::PeersResponse) -> Result<Self, Error> {
+        let gossip = Gossip {
+            nodes: message
+                .peers
+                .into_iter()
+                .map(Node::from_bytes)
+                .collect::<Vec<_>>()
+                .into(),
         };
-        proto::Peer { peer: Some(peer) }
+        Ok(gossip)
     }
-}
-
-fn serialize_ipv6(ip: &Ipv6Addr) -> (u64, u64) {
-    let segs = ip.segments();
-    let mut out = [0u64; 2];
-    for i in 0..2 {
-        let mut v = [0u8; 8];
-        for j in 0..4 {
-            let b: [u8; 2] = segs[i * 4 + j].to_be_bytes();
-            v[j * 2] = b[0];
-            v[j * 2 + 1] = b[1];
-        }
-        out[i] = u64::from_be_bytes(v)
-    }
-    (out[0], out[1])
 }
 
 impl FromProtobuf<proto::BlockEvent> for BlockEvent {

--- a/chain-network/src/grpc/server.rs
+++ b/chain-network/src/grpc/server.rs
@@ -1,4 +1,3 @@
-use super::convert;
 use super::proto;
 use super::streaming::{InboundStream, OutboundTryStream};
 
@@ -167,7 +166,12 @@ where
         let service = self.gossip_service()?;
         let peers = service.peers(req.into_inner().limit).await?;
         let res = proto::PeersResponse {
-            peers: convert::into_protobuf_repeated(peers.into_vec()),
+            peers: peers
+                .nodes
+                .to_vec()
+                .into_iter()
+                .map(|node| node.into_bytes())
+                .collect(),
         };
         Ok(tonic::Response::new(res))
     }


### PR DESCRIPTION
Make `GossipService::peers` return a valid gossip instead of just the address of a peer. A gossip includes also the node public key and is signed with that key, so that it cannot be tampered.