### PR TITLE
sparse-array: proptest usage proof-of-concept

### DIFF
--- a/sparse-array/Cargo.toml
+++ b/sparse-array/Cargo.toml
@@ -5,5 +5,4 @@ authors = ["Yevhenii Babichenko <eugene.babichenko@iohk.io>"]
 edition = "2018"
 
 [dev-dependencies]
-quickcheck = "0.9"
-quickcheck_macros = "0.9"
+proptest = "1.0.0"

--- a/sparse-array/Cargo.toml
+++ b/sparse-array/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dev-dependencies]
 proptest = "1.0.0"
-proptest-attr = { git = "https://github.com/eugene-babichenko/proptest-attr.git" }
+test-strategy = "0.1"

--- a/sparse-array/Cargo.toml
+++ b/sparse-array/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dev-dependencies]
 proptest = "1.0.0"
+proptest-attr = { git = "https://github.com/eugene-babichenko/proptest-attr.git" }

--- a/sparse-array/src/bitmap.rs
+++ b/sparse-array/src/bitmap.rs
@@ -86,6 +86,9 @@ impl BitmapIndex {
 mod tests {
     use super::*;
 
+    use crate::testing::test_indexes;
+    use proptest::prelude::*;
+
     #[test]
     fn is_empty_when_created_test() {
         let bitmap = BitmapIndex::new();
@@ -93,58 +96,70 @@ mod tests {
         assert!(bitmap.get_first_index().is_none());
     }
 
-    #[quickcheck]
-    fn set_index_test(indices: Vec<u8>) -> bool {
-        let mut bitmap = BitmapIndex::new();
-        for idx in indices.iter() {
-            bitmap.set_index(*idx);
-        }
-        indices.iter().all(|idx| bitmap.get_index(*idx))
-            && (!bitmap.is_empty() || indices.is_empty())
+    #[test]
+    fn set_index_test() {
+        let mut runner = prop::test_runner::TestRunner::new(Default::default());
+        let result = runner.run(&test_indexes(), |indexes| {
+            let mut bitmap = BitmapIndex::new();
+            for idx in indexes.iter() {
+                bitmap.set_index(*idx);
+            }
+            prop_assert!(indexes.iter().all(|idx| bitmap.get_index(*idx)));
+            Ok(())
+        });
+        result.unwrap();
     }
 
-    #[quickcheck]
-    fn remove_indextest(indices: Vec<u8>) -> bool {
-        // this test will not work correctly if there are two same numbers in
-        // both splits (see below)
-        let mut indices = indices;
-        indices.sort();
-        indices.dedup();
+    #[test]
+    fn remove_indextest() {
+        let mut runner = prop::test_runner::TestRunner::new(Default::default());
+        let result = runner.run(&test_indexes(), |indexes| {
+            let mut bitmap = BitmapIndex::new();
+            for idx in indexes.iter() {
+                bitmap.set_index(*idx);
+            }
 
-        let mut bitmap = BitmapIndex::new();
-        for idx in indices.iter() {
-            bitmap.set_index(*idx);
-        }
+            // split indices vector in two and remove elements only from the first
+            // vector
+            let (to_remove, to_set) = indexes.split_at(indexes.len() / 2);
+            for idx in to_remove.iter() {
+                bitmap.remove_index(*idx);
+            }
 
-        // split indices vector in two and remove elements only from the first
-        // vector
-        let (to_remove, to_set) = indices.split_at(indices.len() / 2);
-        for idx in to_remove.iter() {
-            bitmap.remove_index(*idx);
-        }
-        to_remove.iter().all(|idx| !bitmap.get_index(*idx))
-            && to_set.iter().all(|idx| bitmap.get_index(*idx))
+            prop_assert!(to_remove.iter().all(|idx| !bitmap.get_index(*idx)));
+            prop_assert!(to_set.iter().all(|idx| bitmap.get_index(*idx)));
+
+            Ok(())
+        });
+        result.unwrap();
     }
 
-    #[quickcheck]
-    fn get_real_index_test(indices: Vec<u8>) -> bool {
-        let mut indices = indices;
-        indices.sort();
-        indices.dedup();
-        let mut bitmap = BitmapIndex::new();
-        for idx in indices.iter() {
-            bitmap.set_index(*idx);
-        }
-        indices
-            .iter()
-            .enumerate()
-            .all(|(expected, idx)| bitmap.get_real_index(*idx) == Some(expected as u8))
+    #[test]
+    fn get_real_index_test() {
+        let mut runner = prop::test_runner::TestRunner::new(Default::default());
+        let result = runner.run(&test_indexes(), |indexes| {
+            let mut bitmap = BitmapIndex::new();
+            for idx in indexes.iter() {
+                bitmap.set_index(*idx);
+            }
+            prop_assert!(indexes
+                .iter()
+                .enumerate()
+                .all(|(expected, idx)| bitmap.get_real_index(*idx) == Some(expected as u8)));
+            Ok(())
+        });
+        result.unwrap();
     }
 
-    #[quickcheck]
-    fn get_first_index_test(idx: u8) -> bool {
-        let mut bitmap = BitmapIndex::new();
-        bitmap.set_index(idx);
-        bitmap.get_first_index() == Some(idx)
+    #[test]
+    fn get_first_index_test() {
+        let mut runner = prop::test_runner::TestRunner::new(Default::default());
+        let result = runner.run(&(0..=u8::MAX), |idx| {
+            let mut bitmap = BitmapIndex::new();
+            bitmap.set_index(idx);
+            prop_assert!(bitmap.get_first_index() == Some(idx));
+            Ok(())
+        });
+        result.unwrap();
     }
 }

--- a/sparse-array/src/bitmap.rs
+++ b/sparse-array/src/bitmap.rs
@@ -88,7 +88,7 @@ mod tests {
 
     use crate::testing::test_indexes;
     use proptest::prelude::*;
-    use proptest_attr::proptest;
+    use test_strategy::proptest;
 
     #[test]
     fn is_empty_when_created_test() {
@@ -97,18 +97,17 @@ mod tests {
         assert!(bitmap.get_first_index().is_none());
     }
 
-    #[proptest(strategy = "test_indexes()")]
-    fn set_index_test(indexes: Vec<u8>) -> prop::test_runner::TestCaseResult {
+    #[proptest]
+    fn set_index_test(#[strategy(test_indexes())] indexes: Vec<u8>) {
         let mut bitmap = BitmapIndex::new();
         for idx in indexes.iter() {
             bitmap.set_index(*idx);
         }
         prop_assert!(indexes.iter().all(|idx| bitmap.get_index(*idx)));
-        Ok(())
     }
 
-    #[proptest(strategy = "test_indexes()")]
-    fn remove_indextest(indexes: Vec<u8>) -> prop::test_runner::TestCaseResult {
+    #[proptest]
+    fn remove_indextest(#[strategy(test_indexes())] indexes: Vec<u8>) {
         let mut bitmap = BitmapIndex::new();
         for idx in indexes.iter() {
             bitmap.set_index(*idx);
@@ -123,12 +122,10 @@ mod tests {
 
         prop_assert!(to_remove.iter().all(|idx| !bitmap.get_index(*idx)));
         prop_assert!(to_set.iter().all(|idx| bitmap.get_index(*idx)));
-
-        Ok(())
     }
 
-    #[proptest(strategy = "test_indexes()")]
-    fn get_real_index_test(indexes: Vec<u8>) -> prop::test_runner::TestCaseResult {
+    #[proptest]
+    fn get_real_index(#[strategy(test_indexes())] indexes: Vec<u8>) {
         let mut bitmap = BitmapIndex::new();
         for idx in indexes.iter() {
             bitmap.set_index(*idx);
@@ -137,14 +134,12 @@ mod tests {
             .iter()
             .enumerate()
             .all(|(expected, idx)| bitmap.get_real_index(*idx) == Some(expected as u8)));
-        Ok(())
     }
 
-    #[proptest(strategy = "0..=u8::MAX")]
-    fn get_first_index_test(idx: u8) -> prop::test_runner::TestCaseResult {
+    #[proptest]
+    fn get_first_index(idx: u8) {
         let mut bitmap = BitmapIndex::new();
         bitmap.set_index(idx);
         prop_assert!(bitmap.get_first_index() == Some(idx));
-        Ok(())
     }
 }

--- a/sparse-array/src/fast.rs
+++ b/sparse-array/src/fast.rs
@@ -153,45 +153,53 @@ impl<'a, V> Iterator for FastSparseArrayIter<'a, V> {
 mod tests {
     use super::*;
 
-    #[quickcheck]
-    fn add_test(data: Vec<(u8, u8)>) -> bool {
-        let mut data = data;
-        data.sort_by(|a, b| a.0.cmp(&b.0));
-        data.dedup_by(|a, b| a.0.eq(&b.0));
+    use crate::testing::sparse_array_test_data;
+    use proptest::prelude::*;
 
-        let mut sparse_array = FastSparseArray::new();
-        for (idx, value) in data.iter() {
-            sparse_array.set(*idx, value);
-        }
+    #[test]
+    fn add_test() {
+        let mut runner = prop::test_runner::TestRunner::new(Default::default());
+        let result = runner.run(&sparse_array_test_data(), |data| {
+            let mut sparse_array = FastSparseArray::new();
+            for (idx, value) in data.iter() {
+                sparse_array.set(*idx, value);
+            }
 
-        data.iter()
-            .all(|(idx, value)| sparse_array.get(*idx) == Some(&value))
+            prop_assert!(data
+                .iter()
+                .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
+
+            Ok(())
+        });
+        result.unwrap();
     }
 
-    #[quickcheck]
-    fn remove_test(data: Vec<(u8, u8)>) -> bool {
-        let mut data = data;
-        data.sort_by(|a, b| a.0.cmp(&b.0));
-        data.dedup_by(|a, b| a.0.eq(&b.0));
+    #[test]
+    fn remove_test() {
+        let mut runner = prop::test_runner::TestRunner::new(Default::default());
+        let result = runner.run(&sparse_array_test_data(), |data| {
+            let mut sparse_array = FastSparseArray::new();
+            for (idx, value) in data.iter() {
+                sparse_array.set(*idx, value);
+            }
 
-        let mut sparse_array = FastSparseArray::new();
-        for (idx, value) in data.iter() {
-            sparse_array.set(*idx, value);
-        }
+            let (to_remove, to_set) = data.split_at(data.len() / 2);
+            for (idx, _) in to_remove.iter() {
+                sparse_array.remove(*idx);
+            }
 
-        let (to_remove, to_set) = data.split_at(data.len() / 2);
-        for (idx, _) in to_remove.iter() {
-            sparse_array.remove(*idx);
-        }
+            sparse_array.shrink();
 
-        sparse_array.shrink();
-
-        to_remove
-            .iter()
-            .all(|(idx, _)| sparse_array.get(*idx) == None)
-            && to_set
+            prop_assert!(to_remove
                 .iter()
-                .all(|(idx, value)| sparse_array.get(*idx) == Some(&value))
+                .all(|(idx, _)| sparse_array.get(*idx) == None));
+            prop_assert!(to_set
+                .iter()
+                .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
+
+            Ok(())
+        });
+        result.unwrap();
     }
 
     #[test]

--- a/sparse-array/src/fast.rs
+++ b/sparse-array/src/fast.rs
@@ -155,51 +155,44 @@ mod tests {
 
     use crate::testing::sparse_array_test_data;
     use proptest::prelude::*;
+    use proptest_attr::proptest;
 
-    #[test]
-    fn add_test() {
-        let mut runner = prop::test_runner::TestRunner::new(Default::default());
-        let result = runner.run(&sparse_array_test_data(), |data| {
-            let mut sparse_array = FastSparseArray::new();
-            for (idx, value) in data.iter() {
-                sparse_array.set(*idx, value);
-            }
+    #[proptest(strategy = "sparse_array_test_data()")]
+    fn add_test(data: Vec<(u8, u8)>) -> prop::test_runner::TestCaseResult {
+        let mut sparse_array = FastSparseArray::new();
+        for (idx, value) in data.iter() {
+            sparse_array.set(*idx, value);
+        }
 
-            prop_assert!(data
-                .iter()
-                .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
+        prop_assert!(data
+            .iter()
+            .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
 
-            Ok(())
-        });
-        result.unwrap();
+        Ok(())
     }
 
-    #[test]
-    fn remove_test() {
-        let mut runner = prop::test_runner::TestRunner::new(Default::default());
-        let result = runner.run(&sparse_array_test_data(), |data| {
-            let mut sparse_array = FastSparseArray::new();
-            for (idx, value) in data.iter() {
-                sparse_array.set(*idx, value);
-            }
+    #[proptest(strategy = "sparse_array_test_data()")]
+    fn remove_test(data: Vec<(u8, u8)>) -> prop::test_runner::TestCaseResult {
+        let mut sparse_array = FastSparseArray::new();
+        for (idx, value) in data.iter() {
+            sparse_array.set(*idx, value);
+        }
 
-            let (to_remove, to_set) = data.split_at(data.len() / 2);
-            for (idx, _) in to_remove.iter() {
-                sparse_array.remove(*idx);
-            }
+        let (to_remove, to_set) = data.split_at(data.len() / 2);
+        for (idx, _) in to_remove.iter() {
+            sparse_array.remove(*idx);
+        }
 
-            sparse_array.shrink();
+        sparse_array.shrink();
 
-            prop_assert!(to_remove
-                .iter()
-                .all(|(idx, _)| sparse_array.get(*idx) == None));
-            prop_assert!(to_set
-                .iter()
-                .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
+        prop_assert!(to_remove
+            .iter()
+            .all(|(idx, _)| sparse_array.get(*idx) == None));
+        prop_assert!(to_set
+            .iter()
+            .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
 
-            Ok(())
-        });
-        result.unwrap();
+        Ok(())
     }
 
     #[test]

--- a/sparse-array/src/fast.rs
+++ b/sparse-array/src/fast.rs
@@ -155,10 +155,10 @@ mod tests {
 
     use crate::testing::sparse_array_test_data;
     use proptest::prelude::*;
-    use proptest_attr::proptest;
+    use test_strategy::proptest;
 
-    #[proptest(strategy = "sparse_array_test_data()")]
-    fn add_test(data: Vec<(u8, u8)>) -> prop::test_runner::TestCaseResult {
+    #[proptest]
+    fn add_test(#[strategy(sparse_array_test_data())] data: Vec<(u8, u8)>) {
         let mut sparse_array = FastSparseArray::new();
         for (idx, value) in data.iter() {
             sparse_array.set(*idx, value);
@@ -167,12 +167,10 @@ mod tests {
         prop_assert!(data
             .iter()
             .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
-
-        Ok(())
     }
 
-    #[proptest(strategy = "sparse_array_test_data()")]
-    fn remove_test(data: Vec<(u8, u8)>) -> prop::test_runner::TestCaseResult {
+    #[proptest]
+    fn remove_test(#[strategy(sparse_array_test_data())] data: Vec<(u8, u8)>) {
         let mut sparse_array = FastSparseArray::new();
         for (idx, value) in data.iter() {
             sparse_array.set(*idx, value);
@@ -191,8 +189,6 @@ mod tests {
         prop_assert!(to_set
             .iter()
             .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
-
-        Ok(())
     }
 
     #[test]

--- a/sparse-array/src/lib.rs
+++ b/sparse-array/src/lib.rs
@@ -1,12 +1,11 @@
 ///! Implementation of a sparse array storing maximum of 256 elements
 
-#[cfg(test)]
-#[macro_use(quickcheck)]
-extern crate quickcheck_macros;
-
 mod bitmap;
 mod fast;
 mod sparse_array;
+
+#[cfg(test)]
+mod testing;
 
 pub use crate::{
     fast::{FastSparseArray, FastSparseArrayBuilder, FastSparseArrayIter},

--- a/sparse-array/src/lib.rs
+++ b/sparse-array/src/lib.rs
@@ -1,5 +1,4 @@
 ///! Implementation of a sparse array storing maximum of 256 elements
-
 mod bitmap;
 mod fast;
 mod sparse_array;

--- a/sparse-array/src/sparse_array.rs
+++ b/sparse-array/src/sparse_array.rs
@@ -154,48 +154,41 @@ mod tests {
 
     use crate::testing::sparse_array_test_data;
     use proptest::prelude::*;
+    use proptest_attr::proptest;
 
-    #[test]
-    fn add_test() {
-        let mut runner = prop::test_runner::TestRunner::new(Default::default());
-        let result = runner.run(&sparse_array_test_data(), |data| {
-            let mut sparse_array = SparseArray::new();
-            for (idx, value) in data.iter() {
-                sparse_array = sparse_array.set(*idx, value);
-            }
+    #[proptest(strategy = "sparse_array_test_data()")]
+    fn add_test(data: Vec<(u8, u8)>) -> prop::test_runner::TestCaseResult {
+        let mut sparse_array = SparseArray::new();
+        for (idx, value) in data.iter() {
+            sparse_array = sparse_array.set(*idx, value);
+        }
 
-            prop_assert!(data
-                .iter()
-                .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
+        prop_assert!(data
+            .iter()
+            .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
 
-            Ok(())
-        });
-        result.unwrap();
+        Ok(())
     }
 
-    #[test]
-    fn remove_test() {
-        let mut runner = prop::test_runner::TestRunner::new(Default::default());
-        let result = runner.run(&sparse_array_test_data(), |data| {
-            let mut sparse_array = SparseArray::new();
-            for (idx, value) in data.iter() {
-                sparse_array = sparse_array.set(*idx, value);
-            }
+    #[proptest(strategy = "sparse_array_test_data()")]
+    fn remove_test(data: Vec<(u8, u8)>) -> prop::test_runner::TestCaseResult {
+        let mut sparse_array = SparseArray::new();
+        for (idx, value) in data.iter() {
+            sparse_array = sparse_array.set(*idx, value);
+        }
 
-            let (to_remove, to_set) = data.split_at(data.len() / 2);
-            for (idx, _) in to_remove.iter() {
-                sparse_array = sparse_array.remove(*idx).0;
-            }
+        let (to_remove, to_set) = data.split_at(data.len() / 2);
+        for (idx, _) in to_remove.iter() {
+            sparse_array = sparse_array.remove(*idx).0;
+        }
 
-            prop_assert!(to_remove
-                .iter()
-                .all(|(idx, _)| sparse_array.get(*idx) == None));
-            prop_assert!(to_set
-                .iter()
-                .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
+        prop_assert!(to_remove
+            .iter()
+            .all(|(idx, _)| sparse_array.get(*idx) == None));
+        prop_assert!(to_set
+            .iter()
+            .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
 
-            Ok(())
-        });
-        result.unwrap();
+        Ok(())
     }
 }

--- a/sparse-array/src/sparse_array.rs
+++ b/sparse-array/src/sparse_array.rs
@@ -154,10 +154,10 @@ mod tests {
 
     use crate::testing::sparse_array_test_data;
     use proptest::prelude::*;
-    use proptest_attr::proptest;
+    use test_strategy::proptest;
 
-    #[proptest(strategy = "sparse_array_test_data()")]
-    fn add_test(data: Vec<(u8, u8)>) -> prop::test_runner::TestCaseResult {
+    #[proptest]
+    fn add_test(#[strategy(sparse_array_test_data())] data: Vec<(u8, u8)>) {
         let mut sparse_array = SparseArray::new();
         for (idx, value) in data.iter() {
             sparse_array = sparse_array.set(*idx, value);
@@ -166,12 +166,10 @@ mod tests {
         prop_assert!(data
             .iter()
             .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
-
-        Ok(())
     }
 
-    #[proptest(strategy = "sparse_array_test_data()")]
-    fn remove_test(data: Vec<(u8, u8)>) -> prop::test_runner::TestCaseResult {
+    #[proptest]
+    fn remove_test(#[strategy(sparse_array_test_data())] data: Vec<(u8, u8)>) {
         let mut sparse_array = SparseArray::new();
         for (idx, value) in data.iter() {
             sparse_array = sparse_array.set(*idx, value);
@@ -188,7 +186,5 @@ mod tests {
         prop_assert!(to_set
             .iter()
             .all(|(idx, value)| sparse_array.get(*idx) == Some(&value)));
-
-        Ok(())
     }
 }

--- a/sparse-array/src/testing.rs
+++ b/sparse-array/src/testing.rs
@@ -5,7 +5,7 @@ const MAX_INDEX: usize = 255;
 /// Generates a list of indexes for testing sparse arrays and bitmaps.
 pub(crate) fn test_indexes() -> impl Strategy<Value = Vec<u8>> {
     // generate the list of free & occupied positions in a sparse aray
-    prop::bits::bool_vec::between(0, MAX_INDEX).prop_map(|occupied_entries| {
+    prop::bits::bool_vec::between(0, MAX_INDEX + 1).prop_map(|occupied_entries| {
         occupied_entries
             .into_iter()
             .enumerate()
@@ -20,7 +20,7 @@ pub(crate) fn test_indexes() -> impl Strategy<Value = Vec<u8>> {
 pub(crate) fn sparse_array_test_data() -> impl Strategy<Value = Vec<(u8, u8)>> {
     test_indexes().prop_flat_map(|indexes: Vec<u8>| {
         // populate an array with the given indexes
-        prop::collection::vec(0..=u8::MAX, indexes.len()).prop_map(move |values| {
+        prop::collection::vec(prop::arbitrary::any::<u8>(), indexes.len()).prop_map(move |values| {
             let indexes = indexes.clone();
             indexes.into_iter().zip(values.into_iter()).collect()
         })

--- a/sparse-array/src/testing.rs
+++ b/sparse-array/src/testing.rs
@@ -1,0 +1,28 @@
+use proptest::prelude::*;
+
+const MAX_INDEX: usize = 255;
+
+/// Generates a list of indexes for testing sparse arrays and bitmaps.
+pub(crate) fn test_indexes() -> impl Strategy<Value = Vec<u8>> {
+    // generate the list of free & occupied positions in a sparse aray
+    prop::bits::bool_vec::between(0, MAX_INDEX).prop_map(|occupied_entries| {
+        occupied_entries
+            .into_iter()
+            .enumerate()
+            .filter(|(_, occupied)| *occupied) // take occupied positions...
+            .map(|(i, _)| i as u8) // ...and get their indexes
+            .collect()
+    })
+}
+
+/// Generates an ordered list of entries for sparse arrays. There are no entries with repeating
+/// numbers.
+pub(crate) fn sparse_array_test_data() -> impl Strategy<Value = Vec<(u8, u8)>> {
+    test_indexes().prop_flat_map(|indexes: Vec<u8>| {
+        // populate an array with the given indexes
+        prop::collection::vec(0..=u8::MAX, indexes.len()).prop_map(move |values| {
+            let indexes = indexes.clone();
+            indexes.into_iter().zip(values.into_iter()).collect()
+        })
+    })
+}


### PR DESCRIPTION
This demonstrates the basic use of `proptest` instead of `quickcheck`
including examples of high-order strategies.

`proptest!` and `prop_compose!` macros are not used **on purpose**. They
have their own limitations and the syntax inside them is not valid Rust
syntex. On top of that, they are `cargo fmt`-friendly. With that in
mind, it is preferred to abstain from using these macros.

One thing that could be improved is the way `TestRunner` is used.
Instead of using `proptest!` or invoking the runner directly, an
attribute-style macro could be implemented (this is not set in stone,
just an example of how it may look like):

    #[proptest(strategy = "strategy to generate Value")]
    fn test_case(v: Value) -> TestCaseResult {
        // the actual test code goes here
    }

This is perfectly valid Rust code and it is less boilerplaty than
invoking `TestRunner` by hand.