### PR TITLE
non-node clients grpc api proposal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "cardano-legacy-address",
     "sparse-array",
     "typed-bytes",
+    "chain-watch",
 ]
 
 [profile.bench]

--- a/chain-watch/Cargo.toml
+++ b/chain-watch/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "chain-watch"
+version = "0.1.0"
+authors = ["Enzo Cioppettini <ecioppettini@atixlabs.com>"]
+edition = "2018"
+
+[dependencies]
+prost = "0.7"
+
+[dependencies.tonic]
+version = "0.4"
+default-features = false
+features = ["codegen", "prost"]
+
+[build-dependencies.tonic-build]
+version = "0.4"
+default-features = false
+features = ["prost"]
+
+[features]
+default = ["tonic/transport", "tonic-build/transport"]

--- a/chain-watch/build.rs
+++ b/chain-watch/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tonic_build::compile_protos("proto/watch.proto").unwrap();
+}

--- a/chain-watch/proto/watch.proto
+++ b/chain-watch/proto/watch.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package iohk.chain.watch;
+
+
+message Block {
+  bytes content = 1;
+}
+
+message BlockSubscriptionRequest {}
+
+message TipSubscriptionRequest {}
+
+message MempoolSubscriptionRequest {}
+
+message SyncMultiverseRequest {
+  // send blocks with this chain_length or greater
+  uint32 from = 1;
+}
+
+message BlockId {
+  bytes content = 1;
+}
+
+message MempoolEvent {
+    bytes fragment_id = 1;
+    oneof event {
+        MempoolFragmentInserted inserted = 2;
+        MempoolFragmentRejected rejected = 3;
+        MempoolFragmentInABlock in_a_block = 4;
+    };
+}
+
+
+message MempoolFragmentInserted {}
+
+message MempoolFragmentRejected {
+    string reason = 1;
+}
+
+message MempoolFragmentInABlock {
+    BlockId block = 1;
+}
+
+
+service SubscriptionService {
+  // get a stream of blocks succesfully processed by the node, this means they
+  // are already validated.
+  // the parent of a block will always be streamed before the block itself.
+  rpc BlockSubscription(BlockSubscriptionRequest) returns (stream Block);
+
+  // get tip updates
+  rpc TipSubscription(TipSubscriptionRequest) returns (stream BlockId);
+
+  rpc MempoolSubscription(MempoolSubscriptionRequest) returns (stream MempoolEvent);
+
+  // fetch all blocks from the given initial chainlength to the tip, from all
+  // possible branches and in increasing order 
+  rpc SyncMultiverse(SyncMultiverseRequest) returns (stream Block);
+}

--- a/chain-watch/src/lib.rs
+++ b/chain-watch/src/lib.rs
@@ -1,0 +1,1 @@
+tonic::include_proto!("iohk.chain.watch");


### PR DESCRIPTION
# Context 

It seems there is a need for some API's to support heterogeneous clients (not nodes, basically), besides the one's that we have in rest.

See https://github.com/input-output-hk/jormungandr/issues/3227 and maybe https://github.com/input-output-hk/jormungandr/issues/2354 for some context.

The kinds of clients we could support are:

- explorers
- wallets
- a mempool watching service (which could be considered a subsystem of a wallet...)

## Disclaimers

Just a PoC to get a conversation started. I think this belongs in `chain-libs` and I wanted to put it in `chain-network`, but I think it doesn't fit as it is, and I don't want to spend time reorganizing things without having some discussion about it first.

Also, the name `chain-watch` is only half-serious... I just couldn't think of something better yet.

## Extra comments

The `SyncMultiverse` procedure is somewhat a placeholder to bring out discussion about it... I think it would be a valid way to bootstrap something like the explorer, but there are more than one way we could go about that.
For example, we could re-expose some of the procedures in the `node` service. (None does exactly the same, but there are some similar things). Or have a third common service for those things... Or just let clients use the `node` service.

Also, I think this may be also missing a way to get the current fragments in the mempool (which we already have in rest, so that brings out another question).

Another thing I think could be nice for these API's, is that we could try to send 