### PR TITLE
add explicit spending counter to account transaction inputs

### DIFF
--- a/chain-impl-mockchain/src/accounting/account/account_state.rs
+++ b/chain-impl-mockchain/src/accounting/account/account_state.rs
@@ -189,7 +189,7 @@ impl<Extra: Clone> AccountState<Extra> {
 /// the counter is incremented. A matching counter
 /// needs to be used in the spending phase to make
 /// sure we have non-replayability of a transaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SpendingCounter(pub(crate) u32);
 
 impl SpendingCounter {

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -1731,7 +1731,7 @@ fn input_single_account_verify<'a>(
         });
     }
 
-    let tidsc = WitnessAccountData::new(block0_hash, sign_data_hash, spending_counter);
+    let tidsc = WitnessAccountData::new(block0_hash, sign_data_hash);
     let verified = witness.verify(account.as_ref(), &tidsc);
     if verified == chain_crypto::Verification::Failed {
         return Err(Error::AccountInvalidSignature {
@@ -2763,7 +2763,6 @@ mod tests {
         let witness = Witness::new_account(
             &test_ledger.block0_hash,
             &tx_builder.get_auth_data_for_witness().hash(),
-            SpendingCounter::zero(),
             |d| faucet.private_key().sign(d),
         );
 

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -307,10 +307,11 @@ pub enum Error {
     VotePlan(#[from] VotePlanLedgerError),
     #[error("Scripts addresses are not yet supported by the system")]
     ScriptsAddressNotAllowedYet,
-    #[error("Invalid spending counter: expected {} but got {} instead", expected.0, got.0)]
+    #[error("Invalid spending counter for account {account}: expected {} but got {} instead", expected.0, got.0)]
     InvalidSpendingCounter {
         expected: SpendingCounter,
         got: SpendingCounter,
+        account: UnspecifiedAccountIdentifier,
     },
 }
 
@@ -1728,6 +1729,7 @@ fn input_single_account_verify<'a>(
         return Err(Error::InvalidSpendingCounter {
             expected: spending_counter_ledger,
             got: spending_counter,
+            account: UnspecifiedAccountIdentifier::from_single_account(account.clone()),
         });
     }
 
@@ -1760,6 +1762,7 @@ fn input_multi_account_verify<'a>(
         return Err(Error::InvalidSpendingCounter {
             expected: spending_counter_ledger,
             got: spending_counter,
+            account: UnspecifiedAccountIdentifier::from_multi_account(account.clone()),
         });
     }
 

--- a/chain-impl-mockchain/src/ledger/tests/transaction_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/transaction_tests.rs
@@ -63,7 +63,7 @@ pub fn duplicated_account_transaction() {
         Err(err) => panic!("first transaction should be succesful but {}", err),
         Ok(_) => {
             assert_err_match!(
-                ledger::Error::AccountInvalidSignature { .. },
+                ledger::Error::InvalidSpendingCounter { .. },
                 test_ledger.apply_transaction(fragment2)
             );
         }

--- a/chain-impl-mockchain/src/testing/builders/witness_builder.rs
+++ b/chain-impl-mockchain/src/testing/builders/witness_builder.rs
@@ -22,12 +22,9 @@ pub fn make_witness(
     transaction_hash: &TransactionSignDataHash,
 ) -> Witness {
     match addres_data.address.kind() {
-        Kind::Account(_) => Witness::new_account(
-            block0,
-            transaction_hash,
-            addres_data.spending_counter.unwrap(),
-            |d| addres_data.private_key().sign(d),
-        ),
+        Kind::Account(_) => Witness::new_account(block0, transaction_hash, |d| {
+            addres_data.private_key().sign(d)
+        }),
         _ => Witness::new_utxo(block0, transaction_hash, |d| {
             addres_data.private_key().sign(d)
         }),

--- a/chain-impl-mockchain/src/testing/data/address.rs
+++ b/chain-impl-mockchain/src/testing/data/address.rs
@@ -118,7 +118,11 @@ impl AddressData {
 
     pub fn make_input(&self, value: Value, utxo: Option<Entry<Address>>) -> Input {
         match self.address.kind() {
-            Kind::Account { .. } => Input::from_account_public_key(self.public_key(), value),
+            Kind::Account { .. } => Input::from_account_public_key(
+                self.public_key(),
+                self.spending_counter.unwrap(),
+                value,
+            ),
             Kind::Single { .. } | Kind::Group { .. } => {
                 Input::from_utxo_entry(utxo.unwrap_or_else(|| {
                     panic!(

--- a/chain-impl-mockchain/src/transaction/input.rs
+++ b/chain-impl-mockchain/src/transaction/input.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use super::utxo::UtxoPointer;
 use crate::account::{Identifier, SpendingCounter};
 use crate::fragment::FragmentId;
@@ -50,6 +52,12 @@ impl AsRef<[u8]> for UnspecifiedAccountIdentifier {
 impl From<[u8; INPUT_PTR_SIZE]> for UnspecifiedAccountIdentifier {
     fn from(v: [u8; INPUT_PTR_SIZE]) -> Self {
         UnspecifiedAccountIdentifier(v)
+    }
+}
+
+impl fmt::Display for UnspecifiedAccountIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
     }
 }
 

--- a/chain-impl-mockchain/src/transaction/transaction.rs
+++ b/chain-impl-mockchain/src/transaction/transaction.rs
@@ -364,6 +364,7 @@ impl<P> Transaction<P> {
     pub fn nb_witnesses(&self) -> u8 {
         self.tstruct.nb_inputs
     }
+
     pub fn nb_outputs(&self) -> u8 {
         self.tstruct.nb_outputs
     }

--- a/chain-impl-mockchain/src/transaction/witness.rs
+++ b/chain-impl-mockchain/src/transaction/witness.rs
@@ -98,14 +98,9 @@ impl AsRef<[u8]> for WitnessUtxoData {
 pub struct WitnessAccountData(Vec<u8>);
 
 impl WitnessAccountData {
-    pub fn new(
-        block0: &HeaderId,
-        transaction_id: &TransactionSignDataHash,
-        spending_counter: account::SpendingCounter,
-    ) -> Self {
+    pub fn new(block0: &HeaderId, transaction_id: &TransactionSignDataHash) -> Self {
         let mut v = Vec::with_capacity(69);
         witness_data_common(&mut v, WITNESS_TAG_ACCOUNT, block0, transaction_id);
-        v.extend_from_slice(&spending_counter.to_bytes());
         WitnessAccountData(v)
     }
 }
@@ -164,13 +159,12 @@ impl Witness {
     pub fn new_account<F>(
         block0: &HeaderId,
         sign_data_hash: &TransactionSignDataHash,
-        spending_counter: account::SpendingCounter,
         sign: F,
     ) -> Self
     where
         F: FnOnce(&WitnessAccountData) -> account::Witness,
     {
-        let wud = WitnessAccountData::new(block0, sign_data_hash, spending_counter);
+        let wud = WitnessAccountData::new(block0, sign_data_hash);
         let sig = sign(&wud);
         Witness::Account(sig)
     }


### PR DESCRIPTION
This is required for reordering transactions that were submitted out of the expected order.

The thing that is **very** debatable in this approach is that currently it introduces 4 bytes for each input that are going to be unused by UTXO inputs. This is by no means a good design and needs to be implemented in a less wasteful way. But good enough for the purpose of demonstrating the approach.