### PR TITLE
Add lowest common ancestor function to storage

### DIFF
--- a/chain-storage/src/block_store.rs
+++ b/chain-storage/src/block_store.rs
@@ -348,10 +348,11 @@ impl BlockStore {
             return Ok(true);
         }
 
-        self.info_tree
-            .get(block_id)
-            .map(|maybe_block| maybe_block.is_some())
-            .map_err(Into::into)
+        self.block_exists_volatile(block_id)
+    }
+
+    fn block_exists_volatile(&self, block_id: &[u8]) -> Result<bool, Error> {
+        self.info_tree.contains_key(block_id).map_err(Into::into)
     }
 
     /// Determine whether block identified by `ancestor_id` is an ancestor of


### PR DESCRIPTION
Add a function to retrieve the lowest common ancestor (lca) of two blocks in the chain.
Will be used for https://github.com/input-output-hk/jormungandr/pull/3267