### PR TITLE
Support early verification of ballots at the typesystem level

### DIFF
--- a/chain-impl-mockchain/src/certificate/test.rs
+++ b/chain-impl-mockchain/src/certificate/test.rs
@@ -181,7 +181,7 @@ impl Arbitrary for VotePlan {
 
         let mut keys = Vec::new();
         // it should have been 256 but is limited for the sake of adequate test times
-        let keys_n = g.next_u32() % 16;
+        let keys_n = g.next_u32() % 15 + 1;
         let mut seed = [0u8; 32];
         g.fill_bytes(&mut seed);
         let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed);

--- a/chain-impl-mockchain/src/testing/gen/vote.rs
+++ b/chain-impl-mockchain/src/testing/gen/vote.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use chain_core::property::BlockDate as BlockDateProp;
 use chain_crypto::digest::DigestOf;
-use chain_vote::Crs;
+use chain_vote::{Crs, ElectionPublicKey, Vote};
 use rand_core::{CryptoRng, RngCore};
 use typed_bytes::ByteBuilder;
 
@@ -105,13 +105,13 @@ impl VoteTestGen {
         rng: &mut R,
     ) -> Payload {
         let encrypting_key =
-            chain_vote::ElectionPublicKey::from_participants(vote_plan.committee_public_keys());
+            ElectionPublicKey::from_participants(vote_plan.committee_public_keys());
 
         let crs = Crs::from_hash(&vote_plan.to_id().as_ref());
         let (encrypted_vote, proof) = encrypting_key.encrypt_and_prove_vote(
             rng,
             &crs,
-            chain_vote::Vote::new(
+            Vote::new(
                 proposal.options().choice_range().clone().max().unwrap() as usize + 1,
                 choice.as_byte() as usize,
             ),

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -51,8 +51,8 @@ enum ProposalManagers {
     },
     Private {
         managers: Vec<ProposalManager>,
-        crs: Crs,
-        election_pk: ElectionPublicKey,
+        crs: Arc<Crs>,
+        election_pk: Arc<ElectionPublicKey>,
     },
 }
 
@@ -433,9 +433,10 @@ impl ProposalManagers {
         match plan.payload_type() {
             PayloadType::Public => Self::Public { managers },
             PayloadType::Private => {
-                let crs = Crs::from_hash(plan.to_id().as_ref());
-                let election_pk =
-                    ElectionPublicKey::from_participants(plan.committee_public_keys());
+                let crs = Arc::new(Crs::from_hash(plan.to_id().as_ref()));
+                let election_pk = Arc::new(ElectionPublicKey::from_participants(
+                    plan.committee_public_keys(),
+                ));
 
                 Self::Private {
                     managers,

--- a/chain-impl-mockchain/src/vote/mod.rs
+++ b/chain-impl-mockchain/src/vote/mod.rs
@@ -16,7 +16,7 @@ pub use self::{
     choice::{Choice, Options},
     committee::CommitteeId,
     ledger::{VotePlanLedger, VotePlanLedgerError},
-    manager::{VoteError, VotePlanManager},
+    manager::{ValidatedVote, VoteError, VotePlanManager},
     payload::{EncryptedVote, Payload, PayloadType, ProofOfCorrectVote, TryFromIntError},
     privacy::encrypt_vote,
     status::{VotePlanStatus, VoteProposalStatus},

--- a/chain-impl-mockchain/src/vote/mod.rs
+++ b/chain-impl-mockchain/src/vote/mod.rs
@@ -16,7 +16,7 @@ pub use self::{
     choice::{Choice, Options},
     committee::CommitteeId,
     ledger::{VotePlanLedger, VotePlanLedgerError},
-    manager::{ValidatedVote, VoteError, VotePlanManager},
+    manager::{ValidatedPayload, VoteError, VotePlanManager},
     payload::{EncryptedVote, Payload, PayloadType, ProofOfCorrectVote, TryFromIntError},
     privacy::encrypt_vote,
     status::{VotePlanStatus, VoteProposalStatus},

--- a/chain-impl-mockchain/src/vote/payload.rs
+++ b/chain-impl-mockchain/src/vote/payload.rs
@@ -190,6 +190,7 @@ impl Default for PayloadType {
 #[cfg(any(test, feature = "property-test-api"))]
 mod tests {
     use super::*;
+    use chain_vote::{Crs, ElectionPublicKey};
     use quickcheck::{Arbitrary, Gen};
 
     impl Arbitrary for PayloadType {
@@ -204,7 +205,7 @@ mod tests {
 
     impl Arbitrary for Payload {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            use chain_vote::{Crs, ElectionPublicKey, MemberCommunicationKey, MemberState, Vote};
+            use chain_vote::{MemberCommunicationKey, MemberState, Vote};
             use rand_core::SeedableRng;
 
             match PayloadType::arbitrary(g) {

--- a/chain-impl-mockchain/src/vote/status.rs
+++ b/chain-impl-mockchain/src/vote/status.rs
@@ -2,7 +2,7 @@ use crate::{
     certificate::{ExternalProposalId, VotePlanId},
     date::BlockDate,
     transaction::UnspecifiedAccountIdentifier,
-    vote::{Options, PayloadType, Tally, ValidatedVote},
+    vote::{Options, PayloadType, Tally, ValidatedPayload},
 };
 use chain_vote::MemberPublicKey;
 use imhamt::Hamt;
@@ -23,5 +23,5 @@ pub struct VoteProposalStatus {
     pub proposal_id: ExternalProposalId,
     pub options: Options,
     pub tally: Option<Tally>,
-    pub votes: Hamt<DefaultHasher, UnspecifiedAccountIdentifier, ValidatedVote>,
+    pub votes: Hamt<DefaultHasher, UnspecifiedAccountIdentifier, ValidatedPayload>,
 }

--- a/chain-impl-mockchain/src/vote/status.rs
+++ b/chain-impl-mockchain/src/vote/status.rs
@@ -2,7 +2,7 @@ use crate::{
     certificate::{ExternalProposalId, VotePlanId},
     date::BlockDate,
     transaction::UnspecifiedAccountIdentifier,
-    vote::{Options, Payload, PayloadType, Tally},
+    vote::{Options, PayloadType, Tally, ValidatedVote},
 };
 use chain_vote::MemberPublicKey;
 use imhamt::Hamt;
@@ -23,5 +23,5 @@ pub struct VoteProposalStatus {
     pub proposal_id: ExternalProposalId,
     pub options: Options,
     pub tally: Option<Tally>,
-    pub votes: Hamt<DefaultHasher, UnspecifiedAccountIdentifier, Payload>,
+    pub votes: Hamt<DefaultHasher, UnspecifiedAccountIdentifier, ValidatedVote>,
 }

--- a/chain-vote/src/encrypted_vote.rs
+++ b/chain-vote/src/encrypted_vote.rs
@@ -1,4 +1,6 @@
 use crate::cryptography::{Ciphertext, UnitVectorZkp};
+use crate::tally::ElectionFingerprint;
+use crate::{Crs, ElectionPublicKey};
 use chain_crypto::ec::Scalar;
 /// A vote is represented by a standard basis unit vector of an N dimensional space
 ///
@@ -16,6 +18,39 @@ pub type EncryptedVote = Vec<Ciphertext>;
 /// A proof of correct vote encryption consists of a unit vector zkp, where the voter proves that
 /// the `EncryptedVote` is indeed a unit vector, and contains a vote for a single candidate.
 pub type ProofOfCorrectVote = UnitVectorZkp;
+
+/// Submitted ballot, which contains an always verified vote.
+/// Used for early verification of a vote without requiring additional
+/// checks down the chain.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Ballot {
+    pub vote: EncryptedVote,
+    // Used to verify that the ballot is applied to the correct
+    // encrypted tally
+    pub(super) fingerprint: ElectionFingerprint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("Invalid vote proof")]
+pub struct BallotVerificationError;
+
+impl Ballot {
+    pub fn try_from_vote_and_proof(
+        vote: EncryptedVote,
+        proof: &ProofOfCorrectVote,
+        crs: &Crs,
+        pk: &ElectionPublicKey,
+    ) -> Result<Self, BallotVerificationError> {
+        if !proof.verify(crs, &pk.0, &vote) {
+            return Err(BallotVerificationError);
+        }
+
+        Ok(Self {
+            vote,
+            fingerprint: (pk, crs).into(),
+        })
+    }
+}
 
 /// To achieve logarithmic communication complexity in the unit_vector ZKP, we represent
 /// votes as Power of Two Padded vector structures.

--- a/chain-vote/src/encrypted_vote.rs
+++ b/chain-vote/src/encrypted_vote.rs
@@ -24,10 +24,10 @@ pub type ProofOfCorrectVote = UnitVectorZkp;
 /// checks down the chain.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Ballot {
-    pub vote: EncryptedVote,
+    vote: EncryptedVote,
     // Used to verify that the ballot is applied to the correct
     // encrypted tally
-    pub(super) fingerprint: ElectionFingerprint,
+    fingerprint: ElectionFingerprint,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -49,6 +49,14 @@ impl Ballot {
             vote,
             fingerprint: (pk, crs).into(),
         })
+    }
+
+    pub fn vote(&self) -> &EncryptedVote {
+        &self.vote
+    }
+
+    pub(super) fn fingerprint(&self) -> &ElectionFingerprint {
+        &self.fingerprint
     }
 }
 

--- a/chain-vote/src/lib.rs
+++ b/chain-vote/src/lib.rs
@@ -19,6 +19,6 @@ pub use chain_crypto::ec::BabyStepsTable as TallyOptimizationTable;
 pub use crate::{
     committee::{ElectionPublicKey, MemberCommunicationKey, MemberPublicKey, MemberState},
     cryptography::Ciphertext, //todo: why this?
-    encrypted_vote::{EncryptedVote, ProofOfCorrectVote, Vote},
+    encrypted_vote::{Ballot, BallotVerificationError, EncryptedVote, ProofOfCorrectVote, Vote},
     tally::{Crs, EncryptedTally, Tally, TallyDecryptShare},
 };

--- a/chain-vote/src/tally.rs
+++ b/chain-vote/src/tally.rs
@@ -1,13 +1,16 @@
 use crate::{
     committee::*,
     cryptography::{Ciphertext, CorrectElGamalDecrZkp},
-    encrypted_vote::EncryptedVote,
+    encrypted_vote::Ballot,
 };
 
 use chain_crypto::ec::{
     baby_step_giant_step, BabyStepsTable as TallyOptimizationTable, GroupElement,
 };
+use cryptoxide::blake2b::Blake2b;
+use cryptoxide::digest::Digest;
 use rand_core::{CryptoRng, RngCore};
+use std::convert::TryInto;
 
 /// Secret key for opening vote
 pub type OpeningVoteKey = MemberSecretKey;
@@ -21,11 +24,36 @@ pub type ProofOfCorrectShare = CorrectElGamalDecrZkp;
 /// Common Reference String
 pub type Crs = GroupElement;
 
+/// An encrypted vote is only valid for specific values of the election public key and crs.
+/// It may be useful to check early if a vote is valid before actually adding it to the tally,
+/// and it is therefore important to verify that it is later added to an encrypted tally that
+/// is consistent with the election public key and crs it was verified against.
+/// To reduce memory occupation, we use a hash of those two values.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) struct ElectionFingerprint([u8; ElectionFingerprint::BYTES_LEN]);
+
+impl ElectionFingerprint {
+    const BYTES_LEN: usize = 32;
+}
+
+impl From<(&ElectionPublicKey, &Crs)> for ElectionFingerprint {
+    fn from(from: (&ElectionPublicKey, &Crs)) -> Self {
+        let (election_pk, crs) = from;
+        let mut hasher = Blake2b::new(32);
+        hasher.input(&crs.to_bytes());
+        hasher.input(&election_pk.to_bytes());
+        let mut fingerprint = [0; 32];
+        hasher.result(&mut fingerprint);
+        Self(fingerprint)
+    }
+}
+
 /// `EncryptedTally` is formed by one ciphertext per existing option, the `election_pk`, and the
 /// `crs`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EncryptedTally {
     r: Vec<Ciphertext>,
+    fingerprint: ElectionFingerprint,
 }
 
 /// `TallyDecryptShare` contains one decryption share per existing option. All committee
@@ -79,20 +107,26 @@ impl EncryptedTally {
     /// Initialise a new tally with N different options. The `EncryptedTally` is computed using
     /// the additive homomorphic property of the elgamal `Ciphertext`s, and is therefore initialised
     /// with zero ciphertexts.
-    pub fn new(options: usize) -> Self {
+    pub fn new(options: usize, election_pk: ElectionPublicKey, crs: Crs) -> Self {
         let r = vec![Ciphertext::zero(); options];
-        EncryptedTally { r }
+        EncryptedTally {
+            r,
+            fingerprint: (&election_pk, &crs).into(),
+        }
     }
 
-    /// Add a submitted `ballot`, with a specific `weight` to the tally, if
-    /// the `ballot` contains a valid proof. If the proof is invalid, it will
-    /// panic. todo: maybe we want to handle these errors?
+    /// Add a submitted `ballot`, with a specific `weight` to the tally.
+    /// Remember that a vote is only valid for a specific election (i.e. pair of
+    /// election public key and crs), and trying to add a ballot validated for a
+    /// different one will result in a panic.
     ///
     /// Note that the encrypted vote needs to have the exact same number of
     /// options as the initialised tally, otherwise an assert will trigger.
     #[allow(clippy::ptr_arg)]
-    pub fn add(&mut self, vote: &EncryptedVote, weight: u64) {
-        for (ri, ci) in self.r.iter_mut().zip(vote.iter()) {
+    pub fn add(&mut self, ballot: &Ballot, weight: u64) {
+        assert_eq!(ballot.vote.len(), self.r.len());
+        assert_eq!(ballot.fingerprint, self.fingerprint);
+        for (ri, ci) in self.r.iter_mut().zip(ballot.vote.iter()) {
             *ri = &*ri + &(ci * weight);
         }
     }
@@ -140,7 +174,10 @@ impl EncryptedTally {
 
     /// Returns a byte array with every ciphertext in the `EncryptedTally`
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes: Vec<u8> = Vec::with_capacity(Ciphertext::BYTES_LEN * self.r.len());
+        let mut bytes: Vec<u8> = Vec::with_capacity(
+            Ciphertext::BYTES_LEN * self.r.len() + ElectionFingerprint::BYTES_LEN,
+        );
+        bytes.extend_from_slice(&self.fingerprint.0);
         for ri in &self.r {
             bytes.extend_from_slice(ri.to_bytes().as_ref());
         }
@@ -150,15 +187,17 @@ impl EncryptedTally {
     /// Tries to generate an `EncryptedTally` out of an array of bytes. Returns `None` if the
     /// size of the byte array is not a multiply of `Ciphertext::BYTES_LEN`.
     pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() % Ciphertext::BYTES_LEN != 0 {
+        if (bytes.len() - ElectionFingerprint::BYTES_LEN) % Ciphertext::BYTES_LEN != 0 {
             return None;
         }
-        let r = bytes
+        let fingerprint =
+            ElectionFingerprint(bytes[0..ElectionFingerprint::BYTES_LEN].try_into().unwrap());
+        let r = bytes[ElectionFingerprint::BYTES_LEN..]
             .chunks(Ciphertext::BYTES_LEN)
             .map(Ciphertext::from_bytes)
             .collect::<Option<Vec<_>>>()?;
 
-        Some(Self { r })
+        Some(Self { r, fingerprint })
     }
 }
 
@@ -207,7 +246,10 @@ impl std::ops::Add for EncryptedTally {
             .zip(rhs.r.iter())
             .map(|(left, right)| left + right)
             .collect();
-        Self { r }
+        Self {
+            r,
+            fingerprint: self.fingerprint,
+        }
     }
 }
 

--- a/chain-vote/src/tally.rs
+++ b/chain-vote/src/tally.rs
@@ -124,9 +124,9 @@ impl EncryptedTally {
     /// options as the initialised tally, otherwise an assert will trigger.
     #[allow(clippy::ptr_arg)]
     pub fn add(&mut self, ballot: &Ballot, weight: u64) {
-        assert_eq!(ballot.vote.len(), self.r.len());
-        assert_eq!(ballot.fingerprint, self.fingerprint);
-        for (ri, ci) in self.r.iter_mut().zip(ballot.vote.iter()) {
+        assert_eq!(ballot.vote().len(), self.r.len());
+        assert_eq!(ballot.fingerprint(), &self.fingerprint);
+        for (ri, ci) in self.r.iter_mut().zip(ballot.vote().iter()) {
             *ri = &*ri + &(ci * weight);
         }
     }

--- a/chain-vote/src/tally.rs
+++ b/chain-vote/src/tally.rs
@@ -48,8 +48,8 @@ impl From<(&ElectionPublicKey, &Crs)> for ElectionFingerprint {
     }
 }
 
-/// `EncryptedTally` is formed by one ciphertext per existing option, the `election_pk`, and the
-/// `crs`.
+/// `EncryptedTally` is formed by one ciphertext per existing option and a fingerprint that
+/// identifies the election parameters used (crs and election public key)
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EncryptedTally {
     r: Vec<Ciphertext>,


### PR DESCRIPTION
Create a new struct `Ballot` which is used to avoid double checking when adding and encrypted vote that was verified early to an `EncryptedTally`, all while preserving correctness guarantees (it was previously possible to add an invalid encrypted vote).