### PR TITLE
ditch custom eccoxide version

### DIFF
--- a/chain-vote/Cargo.toml
+++ b/chain-vote/Cargo.toml
@@ -11,8 +11,7 @@ rand_core = "0.6"
 rayon = "1.5"
 thiserror = "1.0"
 cryptoxide = "0.3"
-# TODO replace with the crates.io version once it has faster scalar multiplication
-eccoxide = { git = "https://github.com/eugene-babichenko/eccoxide.git", branch = "fast-u64-scalar-mul", features = ["fast-u64-scalar-mul"], optional = true }
+eccoxide = {version = "0.3", optional = true }
 curve25519-dalek-ng = { version = "4.0.1", optional = true}
 
 [dev-dependencies]

--- a/chain-vote/src/gang/p256k1.rs
+++ b/chain-vote/src/gang/p256k1.rs
@@ -346,15 +346,25 @@ impl<'a> Mul<&'a GroupElement> for u64 {
     type Output = GroupElement;
 
     fn mul(self, other: &'a GroupElement) -> GroupElement {
-        GroupElement(&other.0 * self)
+        other * self
     }
 }
 
 impl<'a> Mul<u64> for &'a GroupElement {
     type Output = GroupElement;
 
-    fn mul(self, other: u64) -> GroupElement {
-        GroupElement(other * &self.0)
+    fn mul(self, mut other: u64) -> GroupElement {
+        let mut a = self.0.clone();
+        let mut q = Point::infinity();
+
+        while other != 0 {
+            if other & 1 != 0 {
+                q = &q + &a;
+            }
+            a = &a + &a;
+            other >>= 1;
+        }
+        GroupElement(q)
     }
 }
 


### PR DESCRIPTION
Port the fast u64 trick to chain-vote to avoid maintaining a branch of eccoxide.
There is a little cost in performance for doing so (~18% for building the encrypted tally), but ristretto will probably be the default backend in the future anyway 