### PR TITLE
Test crypto backends

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         toolchain: [stable]
-        mode: ['', '--release', '--features p256k1']
+        mode: ['', '--release', '--features chain-crypto/p256k1']
         experimental: [false]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         toolchain: [stable]
-        mode: ['', '--release']
+        mode: ['', '--release', '--features p256k1']
         experimental: [false]
         include:
           - os: ubuntu-latest
@@ -153,6 +153,7 @@ jobs:
           args: >-
             ${{ matrix.mode }} --locked
             --manifest-path chain-network/Cargo.toml --no-default-features
+
 
   lints:
     name: Lints

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,12 +70,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         toolchain: [stable]
-        mode: ['', '--release', '--features chain-crypto/p256k1']
+        mode: ['', '--release']
         experimental: [false]
         include:
           - os: ubuntu-latest
             toolchain: nightly
             experimental: true
+          - os: ubuntu-latest
+            toolchain: stable
+            experimental: false
+            mode: '--features chain-crypto/p256k1'
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 30

--- a/chain-crypto/Cargo.toml
+++ b/chain-crypto/Cargo.toml
@@ -26,11 +26,15 @@ typed-bytes = { path = "../typed-bytes" }
 
 criterion = { version = "0.3.0", optional = true }
 
+
 [dev-dependencies]
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
 rand = { version = "0.8", features = ["small_rng"] }
 smoke = "^0.2.1"
+
+[build-dependencies]
+cfg-if = "1"
 
 [features]
 with-bench = ["criterion"]

--- a/chain-crypto/build.rs
+++ b/chain-crypto/build.rs
@@ -1,0 +1,25 @@
+#![allow(dead_code)]
+/// This build script serves as a way to select a single crypto backend to use
+/// without polluting the code with chains of if-else cfg everywhere a mutually
+/// exclusive choice about the backend has to be made.
+///
+/// The backend is selected with the following rules:
+/// * if a non-default feature is selected, activate the corresponding backend
+/// * If no non-default feature is selected, activate the default backend
+///
+/// Flags exported by this module are guaranteed to be mutually exclusive.
+
+const BACKEND_FLAG_P256K1: &str = "__internal_ex_backend_p256k1";
+const BACKEND_FLAG_RISTRETTO255: &str = "__internal_ex_backend_ristretto255";
+
+fn main() {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "p256k1")] {
+            println!("cargo:rustc-cfg=crypto_backend=\"{}\"", BACKEND_FLAG_P256K1);
+        } else if #[cfg(feature = "ristretto255")] {
+            println!("cargo:rustc-cfg=crypto_backend=\"{}\"", BACKEND_FLAG_RISTRETTO255);
+        } else {
+            compile_error!("one of the features \"p256k1\", \"ristretto255\' has to be selected as the backend");
+        }
+    }
+}

--- a/chain-crypto/src/algorithms/mod.rs
+++ b/chain-crypto/src/algorithms/mod.rs
@@ -12,4 +12,4 @@ pub use ed25519::Ed25519;
 pub use ed25519_derive::Ed25519Bip32;
 pub use ed25519_extended::Ed25519Extended;
 pub use sumed25519::SumEd25519_12;
-pub use vrf::Curve25519_2HashDh;
+pub use vrf::EllipticCurve2hashDh;

--- a/chain-crypto/src/algorithms/vrf/mod.rs
+++ b/chain-crypto/src/algorithms/vrf/mod.rs
@@ -11,9 +11,9 @@ use rand_core::{CryptoRng, RngCore};
 pub use vrf::ProvenOutputSeed;
 
 /// VRF
-pub struct Curve25519_2HashDh;
+pub struct EllipticCurve2hashDh;
 
-impl AsymmetricPublicKey for Curve25519_2HashDh {
+impl AsymmetricPublicKey for EllipticCurve2hashDh {
     type Public = vrf::PublicKey;
     const PUBLIC_BECH32_HRP: &'static str = "vrf_pk";
     const PUBLIC_KEY_SIZE: usize = vrf::PublicKey::BYTES_LEN;
@@ -22,9 +22,9 @@ impl AsymmetricPublicKey for Curve25519_2HashDh {
     }
 }
 
-impl AsymmetricKey for Curve25519_2HashDh {
+impl AsymmetricKey for EllipticCurve2hashDh {
     type Secret = vrf::SecretKey;
-    type PubAlg = Curve25519_2HashDh;
+    type PubAlg = EllipticCurve2hashDh;
 
     const SECRET_BECH32_HRP: &'static str = "vrf_sk";
 
@@ -49,11 +49,11 @@ impl AsymmetricKey for Curve25519_2HashDh {
     }
 }
 
-impl SecretKeySizeStatic for Curve25519_2HashDh {
+impl SecretKeySizeStatic for EllipticCurve2hashDh {
     const SECRET_KEY_SIZE: usize = vrf::SecretKey::BYTES_LEN;
 }
 
-impl VerifiableRandomFunction for Curve25519_2HashDh {
+impl VerifiableRandomFunction for EllipticCurve2hashDh {
     type VerifiedRandomOutput = vrf::ProvenOutputSeed;
     type RandomOutput = vrf::OutputSeed;
     type Input = [u8];

--- a/chain-crypto/src/asymlock.rs
+++ b/chain-crypto/src/asymlock.rs
@@ -20,10 +20,10 @@ pub enum DecryptionError {
 
 fn shared_key_to_symmetric_key(app_level_info: &[u8], p: &GroupElement) -> ChaCha20Poly1305 {
     // use the compressed point as PRK directly
-    #[cfg(feature = "ristretto255")]
+    #[cfg(not(feature = "p256k1"))]
     let prk = &p.to_bytes();
     // if we work with sec2 curves, we use only the x coordinate as a key
-    #[cfg(not(feature = "ristretto255"))]
+    #[cfg(feature = "p256k1")]
     let prk = &p.to_bytes()[1..33];
     let mut symkey = [0u8; 32 + 12];
     hkdf_expand(sha2::Sha256::new(), prk, app_level_info, &mut symkey);

--- a/chain-crypto/src/asymlock.rs
+++ b/chain-crypto/src/asymlock.rs
@@ -20,10 +20,10 @@ pub enum DecryptionError {
 
 fn shared_key_to_symmetric_key(app_level_info: &[u8], p: &GroupElement) -> ChaCha20Poly1305 {
     // use the compressed point as PRK directly
-    #[cfg(not(feature = "p256k1"))]
+    #[cfg(crypto_backend = "__internal_ex_backend_ristretto255")]
     let prk = &p.to_bytes();
     // if we work with sec2 curves, we use only the x coordinate as a key
-    #[cfg(feature = "p256k1")]
+    #[cfg(crypto_backend = "__internal_ex_backend_p256k1")]
     let prk = &p.to_bytes()[1..33];
     let mut symkey = [0u8; 32 + 12];
     hkdf_expand(sha2::Sha256::new(), prk, app_level_info, &mut symkey);

--- a/chain-crypto/src/ec/babystep.rs
+++ b/chain-crypto/src/ec/babystep.rs
@@ -13,9 +13,9 @@ const DEFAULT_BALANCE: u64 = 2;
 /// for solving discrete log on ECC
 #[derive(Debug, Clone)]
 pub struct BabyStepsTable {
-    #[cfg(not(feature = "ristretto255"))]
+    #[cfg(feature = "p256k1")]
     table: HashMap<Option<[u8; Coordinate::BYTES_LEN]>, u64>,
-    #[cfg(feature = "ristretto255")]
+    #[cfg(not(feature = "p256k1"))]
     table: HashMap<Option<[u8; GroupElement::BYTES_LEN]>, u64>,
     baby_step_size: u64,
     giant_step: GroupElement,
@@ -43,14 +43,14 @@ impl BabyStepsTable {
         let mut e = GroupElement::zero();
 
         // With sec2 curves we can use the property that P and -P share a coordinate
-        #[cfg(not(feature = "ristretto255"))]
+        #[cfg(feature = "p256k1")]
         for i in 0..=baby_step_size / 2 {
             bs.insert(e.compress().map(|(c, _sign)| c.to_bytes()), i);
             e = e + &gen;
         }
         // Not with ristretto group. the ristretto group API does not allow to use the x coordinate
         // for security properties (see [here](https://github.com/dalek-cryptography/curve25519-dalek/issues/235))
-        #[cfg(feature = "ristretto255")]
+        #[cfg(not(feature = "p256k1"))]
         for i in 0..=baby_step_size {
             bs.insert(Some(e.to_bytes()), i);
             e = e + &gen;
@@ -82,7 +82,7 @@ pub fn baby_step_giant_step(
         .map(|mut point| {
             let mut a = 0;
             loop {
-                #[cfg(not(feature = "ristretto255"))]
+                #[cfg(feature = "p256k1")]
                 if let Some(x) = table.get(&point.compress().map(|(c, _sign)| c.to_bytes())) {
                     let r = if Scalar::from_u64(*x) * GroupElement::generator() == point {
                         a * baby_step_size + x
@@ -92,7 +92,7 @@ pub fn baby_step_giant_step(
                     return Ok(r);
                 }
 
-                #[cfg(feature = "ristretto255")]
+                #[cfg(not(feature = "p256k1"))]
                 if let Some(x) = table.get(&Some(point.to_bytes())) {
                     let r = a * baby_step_size + x;
                     return Ok(r);

--- a/chain-crypto/src/ec/mod.rs
+++ b/chain-crypto/src/ec/mod.rs
@@ -2,16 +2,16 @@
 //! curves), or the other (ristretto255).
 #[macro_use]
 mod macros;
-#[cfg(not(feature = "ristretto255"))]
+#[cfg(feature = "p256k1")]
 mod p256k1;
-#[cfg(feature = "ristretto255")]
+#[cfg(not(feature = "p256k1"))]
 mod ristretto255;
 
 mod babystep;
 
-#[cfg(not(feature = "ristretto255"))]
+#[cfg(feature = "p256k1")]
 pub use self::p256k1::*;
-#[cfg(feature = "ristretto255")]
+#[cfg(not(feature = "p256k1"))]
 pub use self::ristretto255::*;
 
 pub use babystep::{baby_step_giant_step, BabyStepsTable};

--- a/chain-crypto/src/ec/mod.rs
+++ b/chain-crypto/src/ec/mod.rs
@@ -2,16 +2,16 @@
 //! curves), or the other (ristretto255).
 #[macro_use]
 mod macros;
-#[cfg(feature = "p256k1")]
+#[cfg(crypto_backend = "__internal_ex_backend_p256k1")]
 mod p256k1;
-#[cfg(not(feature = "p256k1"))]
+#[cfg(crypto_backend = "__internal_ex_backend_ristretto255")]
 mod ristretto255;
 
 mod babystep;
 
-#[cfg(feature = "p256k1")]
+#[cfg(crypto_backend = "__internal_ex_backend_p256k1")]
 pub use self::p256k1::*;
-#[cfg(not(feature = "p256k1"))]
+#[cfg(crypto_backend = "__internal_ex_backend_ristretto255")]
 pub use self::ristretto255::*;
 
 pub use babystep::{baby_step_giant_step, BabyStepsTable};

--- a/chain-crypto/src/ec/p256k1.rs
+++ b/chain-crypto/src/ec/p256k1.rs
@@ -168,7 +168,7 @@ impl GroupElement {
         I: IntoIterator<Item = Scalar>,
         J: IntoIterator<Item = GroupElement>,
     {
-        multiscalar_multiplication(scalar, points)
+        Self::multiscalar_multiplication(scalars, points)
     }
 }
 

--- a/chain-impl-mockchain/src/header/cstruct.rs
+++ b/chain-impl-mockchain/src/header/cstruct.rs
@@ -1,6 +1,7 @@
 // lowlevel header binary accessors, use module qualified and fundamentally allow to do invalid construction
 #![allow(dead_code)]
 
+use chain_crypto::{EllipticCurve2hashDh, VerifiableRandomFunction};
 use std::mem::size_of;
 
 // ************************************************************************
@@ -19,7 +20,8 @@ pub(super) type BftLeaderId = [u8; 32];
 pub(super) type BftSignature = [u8; 64];
 
 pub(super) type GpNodeId = [u8; 32];
-pub(super) type GpVrfProof = [u8; 96];
+pub(super) type GpVrfProof =
+    [u8; <EllipticCurve2hashDh as VerifiableRandomFunction>::VerifiedRandomOutput::BYTES_LEN];
 pub(super) type GpKesSignature = [u8; 484];
 
 // common parts
@@ -440,7 +442,7 @@ mod tests {
         let mut header = Header::new(VERSION_GP);
         let gp_node_id = [0; 32];
         header.set_gp_node_id_slice(&gp_node_id);
-        let gp_vrf_proof_slice = [0; 96];
+        let gp_vrf_proof_slice = [0; size_of::<GpVrfProof>()];
         header.set_gp_vrf_proof_slice(&gp_vrf_proof_slice);
         let gp_kes_signature = [0; 484];
         header.set_gp_kes_signature(&gp_kes_signature);

--- a/chain-impl-mockchain/src/header/test.rs
+++ b/chain-impl-mockchain/src/header/test.rs
@@ -3,7 +3,7 @@ use crate::chaintypes::ChainLength;
 use crate::header::{BftProof, BftSignature, Common, GenesisPraosProof, KesSignature};
 use crate::key::BftLeaderId;
 use chain_crypto::{
-    self, AsymmetricKey, Curve25519_2HashDh, Ed25519, SecretKey, SumEd25519_12,
+    self, AsymmetricKey, Ed25519, EllipticCurve2hashDh, SecretKey, SumEd25519_12,
     VerifiableRandomFunction,
 };
 use lazy_static::lazy_static;
@@ -61,8 +61,8 @@ impl Arbitrary for GenesisPraosProof {
         let node_id = Arbitrary::arbitrary(g);
 
         let vrf_proof = {
-            let sk = Curve25519_2HashDh::generate(&mut tcg.get_rng(0));
-            Curve25519_2HashDh::evaluate_and_prove(&sk, &[0, 1, 2, 3], &mut tcg.get_rng(1))
+            let sk = EllipticCurve2hashDh::generate(&mut tcg.get_rng(0));
+            EllipticCurve2hashDh::evaluate_and_prove(&sk, &[0, 1, 2, 3], &mut tcg.get_rng(1))
         };
 
         let kes_proof = {

--- a/chain-impl-mockchain/src/key.rs
+++ b/chain-impl-mockchain/src/key.rs
@@ -5,8 +5,9 @@ use chain_core::mempack::{read_mut_slice, ReadBuf, ReadError, Readable};
 use chain_core::property;
 use chain_crypto as crypto;
 use chain_crypto::{
-    digest::DigestOf, AsymmetricKey, AsymmetricPublicKey, Blake2b256, Curve25519_2HashDh, Ed25519,
-    PublicKey, SecretKey, SigningAlgorithm, SumEd25519_12, VerificationAlgorithm,
+    digest::DigestOf, AsymmetricKey, AsymmetricPublicKey, Blake2b256, Ed25519,
+    EllipticCurve2hashDh, PublicKey, SecretKey, SigningAlgorithm, SumEd25519_12,
+    VerificationAlgorithm,
 };
 use rand_core::{CryptoRng, RngCore};
 use typed_bytes::ByteBuilder;
@@ -375,7 +376,7 @@ impl From<PublicKey<BftVerificationAlg>> for BftLeaderId {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GenesisPraosLeader {
     pub kes_public_key: PublicKey<SumEd25519_12>,
-    pub vrf_public_key: PublicKey<Curve25519_2HashDh>,
+    pub vrf_public_key: PublicKey<EllipticCurve2hashDh>,
 }
 
 impl GenesisPraosLeader {
@@ -404,7 +405,7 @@ impl Readable for GenesisPraosLeader {
 #[cfg(any(test, feature = "property-test-api"))]
 mod tests {
     use super::*;
-    use chain_crypto::{testing, Curve25519_2HashDh, PublicKey, SecretKey, SumEd25519_12};
+    use chain_crypto::{testing, EllipticCurve2hashDh, PublicKey, SecretKey, SumEd25519_12};
     #[cfg(test)]
     use chain_test_utils::property::serialization_bijection;
     use lazy_static::lazy_static;
@@ -435,7 +436,7 @@ mod tests {
 
             let tcg = testing::TestCryptoGen::arbitrary(g);
             let mut rng = tcg.get_rng(0);
-            let vrf_sk: SecretKey<Curve25519_2HashDh> = SecretKey::generate(&mut rng);
+            let vrf_sk: SecretKey<EllipticCurve2hashDh> = SecretKey::generate(&mut rng);
             GenesisPraosLeader {
                 vrf_public_key: vrf_sk.to_public(),
                 kes_public_key: PK_KES.clone(),

--- a/chain-impl-mockchain/src/leadership/genesis/mod.rs
+++ b/chain-impl-mockchain/src/leadership/genesis/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     stake::{PercentStake, PoolsState, Stake, StakeDistribution},
 };
 use chain_crypto::Verification as SigningVerification;
-use chain_crypto::{Curve25519_2HashDh, SecretKey};
+use chain_crypto::{EllipticCurve2hashDh, SecretKey};
 use thiserror::Error;
 pub(crate) use vrfeval::witness_to_nonce;
 use vrfeval::VrfEvaluator;
@@ -74,7 +74,7 @@ impl LeadershipData {
     pub fn leader(
         &self,
         pool_id: &PoolId,
-        vrf_key: &SecretKey<Curve25519_2HashDh>,
+        vrf_key: &SecretKey<EllipticCurve2hashDh>,
         date: BlockDate,
     ) -> Result<Option<Witness>, Error> {
         if date.epoch != self.epoch {
@@ -229,11 +229,11 @@ mod tests {
     };
     use crate::value::Value;
     use chain_core::property::ChainLength;
-    use chain_crypto::{Curve25519_2HashDh, SecretKey};
+    use chain_crypto::{EllipticCurve2hashDh, SecretKey};
 
     use std::collections::HashMap;
 
-    fn make_pool(ledger: &mut Ledger) -> (PoolId, SecretKey<Curve25519_2HashDh>) {
+    fn make_pool(ledger: &mut Ledger) -> (PoolId, SecretKey<EllipticCurve2hashDh>) {
         let stake_pool = StakePoolBuilder::new().build();
         ledger
             .delegation()
@@ -270,7 +270,7 @@ mod tests {
         }
     }
 
-    type Pools = HashMap<PoolId, (SecretKey<Curve25519_2HashDh>, u64, Stake)>;
+    type Pools = HashMap<PoolId, (SecretKey<EllipticCurve2hashDh>, u64, Stake)>;
 
     fn make_leadership_with_pools(ledger: &Ledger, pools: &Pools) -> LeadershipData {
         let mut selection = LeadershipData::new(0, &ledger);
@@ -308,7 +308,7 @@ mod tests {
             .expect("cannot build test ledger")
             .ledger;
 
-        let mut pools = HashMap::<PoolId, (SecretKey<Curve25519_2HashDh>, u64, Stake)>::new();
+        let mut pools = HashMap::<PoolId, (SecretKey<EllipticCurve2hashDh>, u64, Stake)>::new();
 
         for _i in 0..leader_election_parameters.pools_count {
             let (pool_id, pool_vrf_private_key) = make_pool(&mut ledger);

--- a/chain-impl-mockchain/src/leadership/mod.rs
+++ b/chain-impl-mockchain/src/leadership/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     ledger::{Ledger, LedgerParameters},
     stake::StakeDistribution,
 };
-use chain_crypto::{Curve25519_2HashDh, Ed25519, SecretKey, SumEd25519_12};
+use chain_crypto::{Ed25519, EllipticCurve2hashDh, SecretKey, SumEd25519_12};
 use chain_time::era::TimeEra;
 
 pub mod bft;
@@ -55,7 +55,7 @@ pub struct BftLeader {
 pub struct GenesisLeader {
     pub node_id: PoolId,
     pub sig_key: SecretKey<SumEd25519_12>,
-    pub vrf_key: SecretKey<Curve25519_2HashDh>,
+    pub vrf_key: SecretKey<EllipticCurve2hashDh>,
 }
 
 pub struct Leader {

--- a/chain-impl-mockchain/src/testing/builders/stake_pool_builder.rs
+++ b/chain-impl-mockchain/src/testing/builders/stake_pool_builder.rs
@@ -7,7 +7,7 @@ use crate::{
     value::Value,
 };
 use chain_addr::Discrimination;
-use chain_crypto::{Curve25519_2HashDh, Ed25519, KeyPair, PublicKey, SumEd25519_12};
+use chain_crypto::{Ed25519, EllipticCurve2hashDh, KeyPair, PublicKey, SumEd25519_12};
 use chain_time::DurationSeconds;
 use std::num::NonZeroU64;
 
@@ -94,7 +94,7 @@ impl StakePoolBuilder {
     pub fn build(&self) -> StakePool {
         let mut rng = rand_core::OsRng;
 
-        let pool_vrf: KeyPair<Curve25519_2HashDh> = KeyPair::generate(&mut rng);
+        let pool_vrf: KeyPair<EllipticCurve2hashDh> = KeyPair::generate(&mut rng);
         let pool_kes: KeyPair<SumEd25519_12> = KeyPair::generate(&mut rng);
 
         let permissions = match self.pool_permissions {

--- a/chain-impl-mockchain/src/testing/data/stake_pool.rs
+++ b/chain-impl-mockchain/src/testing/data/stake_pool.rs
@@ -3,7 +3,7 @@ use crate::{
     testing::{builders::StakePoolBuilder, data::address::AddressData, TestGen},
 };
 
-use chain_crypto::{Curve25519_2HashDh, Ed25519, KeyPair, PublicKey, SumEd25519_12};
+use chain_crypto::{Ed25519, EllipticCurve2hashDh, KeyPair, PublicKey, SumEd25519_12};
 use quickcheck::{Arbitrary, Gen};
 use std::iter;
 
@@ -11,7 +11,7 @@ use std::iter;
 pub struct StakePool {
     alias: String,
     id: PoolId,
-    vrf: KeyPair<Curve25519_2HashDh>,
+    vrf: KeyPair<EllipticCurve2hashDh>,
     kes: KeyPair<SumEd25519_12>,
     pool_info: PoolRegistration,
     reward_account: Option<AddressData>,
@@ -21,7 +21,7 @@ impl StakePool {
     pub fn new(
         alias: &str,
         id: PoolId,
-        vrf: KeyPair<Curve25519_2HashDh>,
+        vrf: KeyPair<EllipticCurve2hashDh>,
         kes: KeyPair<SumEd25519_12>,
         pool_info: PoolRegistration,
         reward_account: Option<AddressData>,
@@ -40,7 +40,7 @@ impl StakePool {
         self.id.clone()
     }
 
-    pub fn vrf(&self) -> KeyPair<Curve25519_2HashDh> {
+    pub fn vrf(&self) -> KeyPair<EllipticCurve2hashDh> {
         self.vrf.clone()
     }
 


### PR DESCRIPTION
Now that we have the choice of elliptic curve backends for curve-agnostic protocols, we should add tests for both in the CI to ensure we do not forget about the non-default one and it does not lag behind when we add new features.

Changelog:
* Reversed the precedence of compile time features in `chain-crypto`. Rust features were not meant to be used this way but this is required when we change the default feature to be able to select the secondary backend with `--feature p256k1`.
* Rename the Vrf function we use from `Cruve25519_2HashDh` to `EllipticCurve2hashDh`. The curve used will now depend on the backend chosen so let's remove any reference to it from the name (+ clippy camel case suggestions).
* Adapt constants in `chain-impl-mockchain/src/hear/cstruct.rs` to the backend used. I'm not really sure on this one. It seems like a lot of those constants are defined independently from the underlying objects used (i.e. raw bytes sequences with a hardcoded length) and I do not understand the rationale there. 
Should we tie at least the length of those byte sequences to the object they represent like
```
type BftSignature = [u8; Signature<_, Ed25519>::SIGNATURE_SIZE]
```
instead of 
```
type BftSignature = [u8; 64]
```