### PR TITLE
uniform keys API

### DIFF
--- a/chain-vote/src/committee.rs
+++ b/chain-vote/src/committee.rs
@@ -148,6 +148,12 @@ impl MemberSecretKey {
         let sk = Scalar::from_bytes(bytes)?;
         Some(Self(SecretKey { sk }))
     }
+
+    pub fn to_public(&self) -> MemberPublicKey {
+        MemberPublicKey(PublicKey {
+            pk: GroupElement::generator() * &self.0.sk,
+        })
+    }
 }
 
 impl MemberPublicKey {
@@ -165,14 +171,6 @@ impl MemberPublicKey {
 impl From<PublicKey> for MemberPublicKey {
     fn from(pk: PublicKey) -> MemberPublicKey {
         MemberPublicKey(pk)
-    }
-}
-
-impl From<&MemberSecretKey> for MemberPublicKey {
-    fn from(sk: &MemberSecretKey) -> Self {
-        MemberPublicKey(PublicKey {
-            pk: GroupElement::generator() * &sk.0.sk,
-        })
     }
 }
 
@@ -197,13 +195,19 @@ impl MemberCommunicationKey {
     }
 }
 
-impl MemberCommunicationPublicKey {
-    pub fn from_public_key(pk: PublicKey) -> Self {
+impl From<PublicKey> for MemberCommunicationPublicKey {
+    fn from(pk: PublicKey) -> MemberCommunicationPublicKey {
         Self(pk)
     }
+}
 
+impl MemberCommunicationPublicKey {
     pub fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        PublicKey::from_bytes(bytes).map(Self)
     }
 }
 

--- a/chain-vote/src/tally.rs
+++ b/chain-vote/src/tally.rs
@@ -109,7 +109,7 @@ impl EncryptedTally {
         for r in &self.r {
             // todo: we are decrypting twice, we can probably improve this
             let decrypted_share = &r.e1 * &secret_key.0.sk;
-            let pk = MemberPublicKey::from(secret_key);
+            let pk = secret_key.to_public();
             let proof = ProofOfCorrectShare::generate(&r, &pk.0, &secret_key.0, rng);
             dshares.push(ProvenDecryptShare {
                 r1: decrypted_share,


### PR DESCRIPTION
Uniform API across different key structs and expose `MemberCommunicationPublicKey::from_bytes`