### PR TITLE
Removed EC features from chain-vote

### DIFF
--- a/chain-crypto/src/ec/p256k1.rs
+++ b/chain-crypto/src/ec/p256k1.rs
@@ -147,6 +147,29 @@ impl GroupElement {
         }
         sum
     }
+
+    /// Non-optimised multiscalar multiplication. If we end up using sec2 backend, this function
+    /// could be optimised.
+    pub fn multiscalar_multiplication<I, J>(scalars: I, points: J) -> Self
+    where
+        I: IntoIterator<Item = Scalar>,
+        J: IntoIterator<Item = GroupElement>,
+    {
+        let mut sum = GroupElement::zero();
+        for (scalar, point) in scalars.into_iter().zip(points.into_iter()) {
+            sum = sum + scalar * point;
+        }
+        sum
+    }
+
+    /// Exposing this function in the API, even though it does not perform vartime operations.
+    pub fn vartime_multiscalar_multiplication<I, J>(scalars: I, points: J) -> Self
+    where
+        I: IntoIterator<Item = Scalar>,
+        J: IntoIterator<Item = GroupElement>,
+    {
+        multiscalar_multiplication(scalar, points)
+    }
 }
 
 impl Scalar {

--- a/chain-crypto/src/ec/ristretto255.rs
+++ b/chain-crypto/src/ec/ristretto255.rs
@@ -82,6 +82,7 @@ impl GroupElement {
         sum
     }
 
+    /// Constant-time multiscalar multiplication using Straus algorithm
     pub fn multiscalar_multiplication<I, J>(scalars: I, points: J) -> Self
     where
         I: IntoIterator<Item = Scalar>,
@@ -93,6 +94,8 @@ impl GroupElement {
         ))
     }
 
+    /// Variable multiscalar multiplication. This function is vulnerable to side-channel attacks and
+    /// should only be used when the scalars are not secret.
     pub fn vartime_multiscalar_multiplication<I, J>(scalars: I, points: J) -> Self
     where
         I: IntoIterator<Item = Scalar>,

--- a/chain-crypto/src/ec/ristretto255.rs
+++ b/chain-crypto/src/ec/ristretto255.rs
@@ -12,7 +12,7 @@ use rand_core::{CryptoRng, RngCore};
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, Mul, Sub};
 
-use curve25519_dalek_ng::traits::VartimeMultiscalarMul;
+use curve25519_dalek_ng::traits::{MultiscalarMul, VartimeMultiscalarMul};
 use std::array::TryFromSliceError;
 use std::convert::TryInto;
 
@@ -81,7 +81,19 @@ impl GroupElement {
         }
         sum
     }
+
     pub fn multiscalar_multiplication<I, J>(scalars: I, points: J) -> Self
+    where
+        I: IntoIterator<Item = Scalar>,
+        J: IntoIterator<Item = GroupElement>,
+    {
+        GroupElement(Point::multiscalar_mul(
+            scalars.into_iter().map(|s| s.0),
+            points.into_iter().map(|p| p.0),
+        ))
+    }
+
+    pub fn vartime_multiscalar_multiplication<I, J>(scalars: I, points: J) -> Self
     where
         I: IntoIterator<Item = Scalar>,
         J: IntoIterator<Item = GroupElement>,

--- a/chain-vote/src/cryptography/mod.rs
+++ b/chain-vote/src/cryptography/mod.rs
@@ -3,7 +3,7 @@ mod elgamal;
 mod zkps;
 
 pub(crate) use self::{
-    commitment::{CommitmentKey, Open},
+    commitment::CommitmentKey,
     elgamal::{HybridCiphertext, PublicKey, SecretKey},
     zkps::{CorrectElGamalDecrZkp, UnitVectorZkp},
 };


### PR DESCRIPTION
A few features for ec backends where left over, for using optimised multiscalar algorithms which are not available in `eccoxide`. Exposed multiscalar and vartime multiscalar functions to both backends (even if for the case of `eccoxide`, multiscalar is not only non-optimised, but constant time). 