### PR TITLE
Update to tonic-build 0.5.1

### DIFF
--- a/chain-network/Cargo.toml
+++ b/chain-network/Cargo.toml
@@ -24,7 +24,7 @@ features = ["codegen", "prost"]
 rand = "0.8"
 
 [build-dependencies.tonic-build]
-version = "0.5"
+version = "0.5.1"
 default-features = false
 features = ["prost"]
 

--- a/chain-network/src/grpc/client.rs
+++ b/chain-network/src/grpc/client.rs
@@ -24,7 +24,6 @@ use tonic::metadata::MetadataValue;
 use tonic::transport;
 
 use std::convert::TryFrom;
-use std::fmt::Debug;
 
 #[cfg(feature = "transport")]
 use std::convert::TryInto;
@@ -140,7 +139,6 @@ where
     T::ResponseBody: Send + Sync + 'static,
     T::Error: Into<StdError>,
     <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    T: Debug, // https://github.com/hyperium/tonic/issues/718
 {
     /// Requests the identifier of the genesis block from the service node.
     ///


### PR DESCRIPTION
Removes a gratuitous Debug bound.