### PR TITLE
[Test] Add API tests

### DIFF
--- a/chain-impl-mockchain/src/testing/e2e/fees/mod.rs
+++ b/chain-impl-mockchain/src/testing/e2e/fees/mod.rs
@@ -182,3 +182,91 @@ pub fn owner_delegates_fee() {
 
     ledger_verifier.total_value_is(&Value(expected_total_funds_after));
 }
+
+#[test]
+/// Verifies that after a transaction in a ledger without fees, the total funds do not change and
+/// the fee pots remain empty.
+fn transaction_without_fees() {
+    const ALICE: &str = "Alice";
+    const ALICE_FUNDS: u64 = 42;
+
+    const BOB: &str = "Bob";
+    const BOB_FUNDS: u64 = 13;
+
+    const TRANSFER: u64 = 10;
+
+    let (mut ledger, controller) = prepare_scenario()
+        .with_config(ConfigBuilder::new(0).with_fee(LinearFee::new(0, 0, 0)))
+        .with_initials(vec![
+            wallet(ALICE).with(ALICE_FUNDS),
+            wallet(BOB).with(BOB_FUNDS),
+        ])
+        .build()
+        .expect("Could not build scenario");
+
+    let total_funds = ledger.total_funds();
+
+    let mut alice_wallet = controller.wallet(ALICE).unwrap();
+    let bob_wallet = controller.wallet(BOB).unwrap();
+
+    controller
+        .transfer_funds(&alice_wallet, &bob_wallet, &mut ledger, TRANSFER)
+        .unwrap();
+    alice_wallet.confirm_transaction();
+
+    LedgerStateVerifier::new(ledger.clone().into())
+        .address_has_expected_balance(
+            alice_wallet.as_account_data(),
+            Value(ALICE_FUNDS - TRANSFER),
+        )
+        .address_has_expected_balance(bob_wallet.as_account_data(), Value(BOB_FUNDS + TRANSFER))
+        .total_value_is(&total_funds)
+        .pots()
+        .has_fee_equals_to(&Value(0));
+}
+
+#[test]
+/// Verifies that after a transaction in a ledger with fees, the total funds do not change and the
+/// fee pots contain the fee.
+fn transaction_with_fees() {
+    const ALICE: &str = "Alice";
+    const ALICE_FUNDS: u64 = 42;
+
+    const BOB: &str = "Bob";
+    const BOB_FUNDS: u64 = 13;
+
+    const TRANSFER: u64 = 10;
+    const FEE: u64 = 7;
+
+    let (mut ledger, controller) = prepare_scenario()
+        .with_config(ConfigBuilder::new(0).with_fee(LinearFee::new(FEE, 0, 0)))
+        .with_initials(vec![
+            wallet(ALICE).with(ALICE_FUNDS),
+            wallet(BOB).with(BOB_FUNDS),
+        ])
+        .build()
+        .expect("Could not build scenario");
+
+    let total_funds = ledger.total_funds();
+
+    let mut alice_wallet = controller.wallet(ALICE).unwrap();
+    let bob_wallet = controller.wallet(BOB).unwrap();
+
+    controller
+        .transfer_funds(&alice_wallet, &bob_wallet, &mut ledger, TRANSFER)
+        .unwrap();
+    alice_wallet.confirm_transaction();
+
+    LedgerStateVerifier::new(ledger.clone().into())
+        .address_has_expected_balance(
+            alice_wallet.as_account_data(),
+            Value(ALICE_FUNDS - TRANSFER),
+        )
+        .address_has_expected_balance(
+            bob_wallet.as_account_data(),
+            Value(BOB_FUNDS + TRANSFER - FEE),
+        )
+        .total_value_is(&total_funds)
+        .pots()
+        .has_fee_equals_to(&Value(FEE));
+}

--- a/chain-impl-mockchain/src/testing/e2e/fees/mod.rs
+++ b/chain-impl-mockchain/src/testing/e2e/fees/mod.rs
@@ -12,6 +12,10 @@ use chain_addr::Discrimination;
 
 use std::num::NonZeroU64;
 
+const ALICE: &str = "Alice";
+const BOB: &str = "Bob";
+const STAKE_POOL: &str = "stake_pool";
+
 #[test]
 pub fn per_certificate_fees() {
     let input_constant = 1;
@@ -47,14 +51,14 @@ pub fn per_certificate_fees() {
                 )),
         )
         .with_initials(vec![
-            wallet("Alice").with(alice_funds),
-            wallet("Bob").with(bob_funds),
+            wallet(ALICE).with(alice_funds),
+            wallet(BOB).with(bob_funds),
         ])
         .build()
         .unwrap();
 
-    let mut alice = controller.wallet("Alice").unwrap();
-    let mut bob = controller.wallet("Bob").unwrap();
+    let mut alice = controller.wallet(ALICE).unwrap();
+    let mut bob = controller.wallet(BOB).unwrap();
     let stake_pool = StakePoolBuilder::new()
         .with_owners(vec![alice.public_key()])
         .build();
@@ -158,12 +162,12 @@ pub fn owner_delegates_fee() {
                 .with_discrimination(Discrimination::Test)
                 .with_fee(LinearFee::new(1, 1, 1)),
         )
-        .with_initials(vec![wallet("Alice").with(alice_funds).owns("stake_pool")])
+        .with_initials(vec![wallet(ALICE).with(alice_funds).owns(STAKE_POOL)])
         .build()
         .unwrap();
 
-    let mut alice = controller.wallet("Alice").unwrap();
-    let stake_pool = controller.stake_pool("stake_pool").unwrap();
+    let mut alice = controller.wallet(ALICE).unwrap();
+    let stake_pool = controller.stake_pool(STAKE_POOL).unwrap();
 
     LedgerStateVerifier::new(ledger.clone().into())
         .total_value_is(&Value(expected_total_funds_before));
@@ -187,12 +191,8 @@ pub fn owner_delegates_fee() {
 /// Verifies that after a transaction in a ledger without fees, the total funds do not change and
 /// the fee pots remain empty.
 fn transaction_without_fees() {
-    const ALICE: &str = "Alice";
     const ALICE_FUNDS: u64 = 42;
-
-    const BOB: &str = "Bob";
     const BOB_FUNDS: u64 = 13;
-
     const TRANSFER: u64 = 10;
 
     let (mut ledger, controller) = prepare_scenario()
@@ -229,12 +229,8 @@ fn transaction_without_fees() {
 /// Verifies that after a transaction in a ledger with fees, the total funds do not change and the
 /// fee pots contain the fee.
 fn transaction_with_fees() {
-    const ALICE: &str = "Alice";
     const ALICE_FUNDS: u64 = 42;
-
-    const BOB: &str = "Bob";
     const BOB_FUNDS: u64 = 13;
-
     const TRANSFER: u64 = 10;
     const FEE: u64 = 7;
 


### PR DESCRIPTION
Introduced two API tests:
1. Verifies that after a transaction in a ledger **without** fees, the total funds do not change and the fee pots remain empty.
2. Verifies that after a transaction in a ledger **with** fees, the total funds do not change and the fee pots contain the fee.