### PR TITLE
WIP: Prototype EVM abstractions

### DIFF
--- a/chain-evm/Cargo.toml
+++ b/chain-evm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+evm = "0.28.0"
 imhamt = { path = "../imhamt" }
 primitive-types = "0.10.1"
 

--- a/chain-evm/Cargo.toml
+++ b/chain-evm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 evm = "0.28.0"
 imhamt = { path = "../imhamt" }
-primitive-types = "0.10.1"
+primitive-types = "0.9.1"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/chain-evm/Cargo.toml
+++ b/chain-evm/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-evm = "0.28.0"
+evm = "0.30.0"
 imhamt = { path = "../imhamt" }
-primitive-types = "0.9.1"
+primitive-types = "0.10.1"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/chain-evm/src/lib.rs
+++ b/chain-evm/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod machine;
 pub mod state;

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -1,0 +1,8 @@
+//! Abstractions for the EVM runtime.
+//!
+//! This module contains types that abstract away implementation details from the `evm` crate,
+//! specially those involving node and stack configurations, and runtime execution.
+
+pub fn code_to_execute_evm_runtime() -> Result<(), ()> {
+    todo!("put together the puzzle of types needed to run evm code");
+}

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -18,6 +18,7 @@ use primitive_types::{H160, H256, U256};
 
 use crate::state::AccountTrie;
 
+/// Environment values for the machine backend.
 pub type Environment = MemoryVicinity;
 
 /// The context of the EVM runtime
@@ -27,56 +28,49 @@ pub type RuntimeContext = Context;
 /// necessary types used to get the runtime going.
 pub struct VirtualMachine {
     _context: RuntimeContext,
-    config: MachineConfig,
-    state: AccountTrie,
-}
-
-/// EVM configuration
-pub struct MachineConfig {
-    _evm_config: Config,
     environment: Environment,
 }
 
 impl Backend for VirtualMachine {
     fn gas_price(&self) -> U256 {
-        self.config.environment.gas_price
+        self.environment.gas_price
     }
     fn origin(&self) -> H160 {
-        self.config.environment.origin
+        self.environment.origin
     }
     fn block_hash(&self, number: U256) -> H256 {
-        if number >= self.config.environment.block_number
-            || self.config.environment.block_number - number - U256::one()
-                >= U256::from(self.config.environment.block_hashes.len())
+        if number >= self.environment.block_number
+            || self.environment.block_number - number - U256::one()
+                >= U256::from(self.environment.block_hashes.len())
         {
             H256::default()
         } else {
-            let index = (self.config.environment.block_number - number - U256::one()).as_usize();
-            self.config.environment.block_hashes[index]
+            let index = (self.environment.block_number - number - U256::one()).as_usize();
+            self.environment.block_hashes[index]
         }
     }
     fn block_number(&self) -> U256 {
-        self.config.environment.block_number
+        self.environment.block_number
     }
     fn block_coinbase(&self) -> H160 {
-        self.config.environment.block_coinbase
+        self.environment.block_coinbase
     }
     fn block_timestamp(&self) -> U256 {
-        self.config.environment.block_timestamp
+        self.environment.block_timestamp
     }
     fn block_difficulty(&self) -> U256 {
-        self.config.environment.block_difficulty
+        self.environment.block_difficulty
     }
     fn block_gas_limit(&self) -> U256 {
-        self.config.environment.block_gas_limit
+        self.environment.block_gas_limit
     }
     fn chain_id(&self) -> U256 {
-        self.config.environment.chain_id
+        self.environment.chain_id
     }
     fn exists(&self, address: H160) -> bool {
         self.state.contains(&address)
     }
-    fn basic(&self, address: H160) -> evm::backend::Basic {
+    fn basic(&self, address: H160) -> Basic {
         self.state
             .get(&address)
             .map(|a| Basic {

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -30,6 +30,7 @@ pub struct VirtualMachine {
     _context: RuntimeContext,
     environment: Environment,
     state: AccountTrie,
+    logs: Vec<Log>,
 }
 
 impl Backend for VirtualMachine {
@@ -98,7 +99,7 @@ impl Backend for VirtualMachine {
 }
 
 impl ApplyBackend for VirtualMachine {
-    fn apply<A, I, L>(&mut self, values: A, _logs: L, _delete_empty: bool)
+    fn apply<A, I, L>(&mut self, values: A, logs: L, _delete_empty: bool)
     where
         A: IntoIterator<Item = Apply<I>>,
         I: IntoIterator<Item = (H256, H256)>,
@@ -136,6 +137,11 @@ impl ApplyBackend for VirtualMachine {
                     self.state.delete(&address);
                 }
             }
+        }
+
+        // save the logs
+        for log in logs {
+            self.logs.push(log);
         }
     }
 }

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -113,6 +113,60 @@ impl ApplyBackend for VirtualMachine {
     }
 }
 
+impl<'config> StackState<'config> for VirtualMachine {
+    fn metadata(&self) -> &evm::executor::StackSubstateMetadata<'config> {
+        todo!();
+    }
+    fn metadata_mut(&mut self) -> &mut evm::executor::StackSubstateMetadata<'config> {
+        todo!();
+    }
+    fn enter(&mut self, _gas_limit: u64, _is_static: bool) {
+        todo!();
+    }
+    fn exit_commit(&mut self) -> Result<(), evm::ExitError> {
+        todo!();
+    }
+    fn exit_revert(&mut self) -> Result<(), evm::ExitError> {
+        todo!();
+    }
+    fn exit_discard(&mut self) -> Result<(), evm::ExitError> {
+        todo!();
+    }
+    fn is_empty(&self, _address: H160) -> bool {
+        todo!();
+    }
+    fn deleted(&self, _address: H160) -> bool {
+        todo!();
+    }
+    fn inc_nonce(&mut self, _address: H160) {
+        todo!();
+    }
+    fn set_storage(&mut self, _address: H160, _key: H256, _value: H256) {
+        todo!();
+    }
+    fn reset_storage(&mut self, _address: H160) {
+        todo!();
+    }
+    fn log(&mut self, _address: H160, _topics: Vec<H256>, _data: Vec<u8>) {
+        todo!();
+    }
+    fn set_deleted(&mut self, _address: H160) {
+        todo!();
+    }
+    fn set_code(&mut self, _address: H160, _code: Vec<u8>) {
+        todo!();
+    }
+    fn transfer(&mut self, _transfer: evm::Transfer) -> Result<(), evm::ExitError> {
+        todo!();
+    }
+    fn reset_balance(&mut self, _address: H160) {
+        todo!();
+    }
+    fn touch(&mut self, _address: H160) {
+        todo!();
+    }
+}
+
 pub fn code_to_execute_evm_runtime() -> Result<(), String> {
     todo!("put together the puzzle of types needed to run evm code");
 }

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -29,6 +29,7 @@ pub type RuntimeContext = Context;
 pub struct VirtualMachine {
     _context: RuntimeContext,
     environment: Environment,
+    state: AccountTrie,
 }
 
 impl Backend for VirtualMachine {
@@ -97,13 +98,39 @@ impl Backend for VirtualMachine {
 }
 
 impl ApplyBackend for VirtualMachine {
-    fn apply<A, I, L>(&mut self, _values: A, _logs: L, _delete_empty: bool)
+    fn apply<A, I, L>(&mut self, values: A, _logs: L, delete_empty: bool)
     where
         A: IntoIterator<Item = Apply<I>>,
         I: IntoIterator<Item = (H256, H256)>,
         L: IntoIterator<Item = Log>,
     {
-        todo!("Add code to apply logs and values in the machine state");
+        for apply in values {
+            match apply {
+                Apply::Modify {
+                    address,
+                    basic,
+                    code,
+                    storage,
+                    reset_storage,
+                } => {
+                    let is_empty = {
+                        // modify existing or create default/empty account
+                        // apply field values
+                        // return whether the account is empty
+                        // save logs
+                        todo!("implement updating account values");
+                    };
+                    if is_empty && delete_empty {
+                        // if account is empty and the delete_empty flag is
+                        // present, we remove it from storage.
+                        //todo!("remove empty account after modification");
+                    }
+                }
+                Apply::Delete { address } => {
+                    todo!("remove empty account with address");
+                }
+            }
+        }
     }
 }
 

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -184,7 +184,49 @@ impl ApplyBackend for VirtualMachine {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
 
-pub fn code_to_execute_evm_runtime() -> Result<(), String> {
-    todo!("put together the puzzle of types needed to run evm code");
+    use evm::{Capture, ExitReason, ExitSucceed};
+
+    use super::*;
+
+    #[test]
+    fn code_to_execute_evm_runtime_with_defaults_and_no_code_no_data() {
+        let environment = Environment {
+            gas_price: Default::default(),
+            origin: Default::default(),
+            chain_id: Default::default(),
+            block_hashes: Default::default(),
+            block_number: Default::default(),
+            block_coinbase: Default::default(),
+            block_timestamp: Default::default(),
+            block_difficulty: Default::default(),
+            block_gas_limit: Default::default(),
+        };
+        let state = AccountTrie::default();
+
+        let vm = VirtualMachine::new(environment, state);
+
+        let gas_limit = u64::max_value();
+        let config = Config::istanbul();
+        let mut executor = vm.executor(gas_limit, &config);
+
+        let code = Rc::new(Vec::new());
+        let data = Rc::new(Vec::new());
+        let context = RuntimeContext {
+            address: Default::default(),
+            caller: Default::default(),
+            apparent_value: Default::default(),
+        };
+        let mut runtime = vm.runtime(code, data, context, &config);
+
+        let reason = runtime.run(&mut executor);
+        if let Capture::Exit(ExitReason::Succeed(ExitSucceed::Stopped)) = reason {
+            assert!(true);
+        } else {
+            panic!("unexpected evm result");
+        }
+    }
 }

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -43,6 +43,8 @@ impl VirtualMachine {
             logs: Default::default(),
         }
     }
+
+    #[allow(dead_code)]
     /// Returns an initialized instance of `evm::executor::StackExecutor`.
     fn executor<'backend, 'config>(
         &'backend self,
@@ -53,6 +55,8 @@ impl VirtualMachine {
         let memory_stack_state = MemoryStackState::new(metadata, self);
         StackExecutor::new(memory_stack_state, config)
     }
+
+    #[allow(dead_code)]
     /// Returns an initialized instance of `evm::Runtime`.
     fn runtime<'config>(
         &self,

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -10,7 +10,7 @@
 //!
 
 use evm::{
-    backend::{ApplyBackend, Backend, Basic, MemoryVicinity},
+    backend::{Apply, ApplyBackend, Backend, Basic, Log, MemoryVicinity},
     executor::StackState,
     Config, Context,
 };
@@ -105,9 +105,9 @@ impl Backend for VirtualMachine {
 impl ApplyBackend for VirtualMachine {
     fn apply<A, I, L>(&mut self, _values: A, _logs: L, _delete_empty: bool)
     where
-        A: IntoIterator<Item = evm::backend::Apply<I>>,
+        A: IntoIterator<Item = Apply<I>>,
         I: IntoIterator<Item = (H256, H256)>,
-        L: IntoIterator<Item = evm::backend::Log>,
+        L: IntoIterator<Item = Log>,
     {
         todo!("Add code to apply logs and values in the machine state");
     }

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -1,60 +1,104 @@
+//! # The Virtual Machine
+//!
 //! Abstractions for the EVM runtime.
 //!
 //! This module contains types that abstract away implementation details from the `evm` crate,
 //! specially those involving node and stack configurations, and runtime execution.
+//!
+//! ## Handler <- EVM Context Handler
+//! ## StackState<'config>
+//!
 
 use evm::{
-    backend::{ApplyBackend, Backend},
+    backend::{ApplyBackend, Backend, Basic, MemoryVicinity},
+    executor::StackState,
+    Config, Context,
 };
 use primitive_types::{H160, H256, U256};
 
+use crate::state::AccountTrie;
 
-pub struct Machine {
-    //
+pub type Environment = MemoryVicinity;
+
+/// The context of the EVM runtime
+pub type RuntimeContext = Context;
+
+/// Top-level abstraction for the EVM with the
+/// necessary types used to get the runtime going.
+pub struct VirtualMachine {
+    _context: RuntimeContext,
+    config: MachineConfig,
+    state: AccountTrie,
 }
 
-impl Backend for Machine {
+/// EVM configuration
+pub struct MachineConfig {
+    _evm_config: Config,
+    environment: Environment,
+}
+
+impl Backend for VirtualMachine {
     fn gas_price(&self) -> U256 {
-        todo!();
+        self.config.environment.gas_price
     }
     fn origin(&self) -> H160 {
-        todo!();
+        self.config.environment.origin
     }
     fn block_hash(&self, number: U256) -> H256 {
-        todo!();
+        if number >= self.config.environment.block_number
+            || self.config.environment.block_number - number - U256::one()
+                >= U256::from(self.config.environment.block_hashes.len())
+        {
+            H256::default()
+        } else {
+            let index = (self.config.environment.block_number - number - U256::one()).as_usize();
+            self.config.environment.block_hashes[index]
+        }
     }
     fn block_number(&self) -> U256 {
-        todo!();
+        self.config.environment.block_number
     }
     fn block_coinbase(&self) -> H160 {
-        todo!();
+        self.config.environment.block_coinbase
     }
     fn block_timestamp(&self) -> U256 {
-        todo!();
+        self.config.environment.block_timestamp
     }
     fn block_difficulty(&self) -> U256 {
-        todo!();
+        self.config.environment.block_difficulty
     }
     fn block_gas_limit(&self) -> U256 {
-        todo!();
+        self.config.environment.block_gas_limit
     }
     fn chain_id(&self) -> U256 {
-        todo!();
+        self.config.environment.chain_id
     }
     fn exists(&self, address: H160) -> bool {
-        todo!();
+        self.state.contains(&address)
     }
     fn basic(&self, address: H160) -> evm::backend::Basic {
-        todo!();
+        self.state
+            .get(&address)
+            .map(|a| Basic {
+                balance: a.balance,
+                nonce: a.nonce,
+            })
+            .unwrap_or_default()
     }
     fn code(&self, address: H160) -> Vec<u8> {
-        todo!();
+        self.state
+            .get(&address)
+            .map(|val| val.code.clone())
+            .unwrap_or_default()
     }
     fn storage(&self, address: H160, index: H256) -> H256 {
-        todo!();
+        self.state
+            .get(&address)
+            .map(|val| val.storage.get(&index).cloned().unwrap_or_default())
+            .unwrap_or_default()
     }
     fn original_storage(&self, address: H160, index: H256) -> Option<H256> {
-        todo!();
+        Some(self.storage(address, index))
     }
 }
 

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -135,6 +135,8 @@ impl ApplyBackend for VirtualMachine {
 
                     if delete_empty && account.is_empty() {
                         self.state.delete(&address);
+                    } else {
+                        self.state.insert_or_update(address, account);
                     }
                 }
                 Apply::Delete { address } => {

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -44,7 +44,7 @@ impl VirtualMachine {
         }
     }
     /// Returns an initialized instance of `evm::executor::StackExecutor`.
-    pub fn executor<'backend, 'config>(
+    fn executor<'backend, 'config>(
         &'backend self,
         gas_limit: u64,
         config: &'config Config,
@@ -54,7 +54,7 @@ impl VirtualMachine {
         StackExecutor::new(memory_stack_state, config)
     }
     /// Returns an initialized instance of `evm::Runtime`.
-    pub fn runtime<'config>(
+    fn runtime<'config>(
         &self,
         code: Rc<Vec<u8>>,
         data: Rc<Vec<u8>>,

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -125,22 +125,22 @@ impl ApplyBackend for VirtualMachine {
                     // iterate over the apply_storage keys and values
                     // and put them into the account.
                     for (index, value) in apply_storage {
-                        if value == crate::state::Value::default() {
+                        account.storage = if value == crate::state::Value::default() {
                             // value is full of zeroes, remove it
-                            account.storage = account.storage.remove(&index);
+                            account.storage.clone().remove(&index)
                         } else {
-                            account.storage = account.storage.put(index, value);
+                            account.storage.clone().put(index, value)
                         }
                     }
 
-                    if delete_empty && account.is_empty() {
-                        self.state.delete(&address);
+                    self.state = if delete_empty && account.is_empty() {
+                        self.state.clone().remove(&address)
                     } else {
-                        self.state.insert_or_update(address, account);
+                        self.state.clone().put(address, account)
                     }
                 }
                 Apply::Delete { address } => {
-                    self.state.delete(&address);
+                    self.state = self.state.clone().remove(&address);
                 }
             }
         }

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -99,7 +99,7 @@ impl Backend for VirtualMachine {
 }
 
 impl ApplyBackend for VirtualMachine {
-    fn apply<A, I, L>(&mut self, values: A, logs: L, _delete_empty: bool)
+    fn apply<A, I, L>(&mut self, values: A, logs: L, delete_empty: bool)
     where
         A: IntoIterator<Item = Apply<I>>,
         I: IntoIterator<Item = (H256, H256)>,
@@ -131,6 +131,10 @@ impl ApplyBackend for VirtualMachine {
                         } else {
                             account.storage = account.storage.put(index, value);
                         }
+                    }
+
+                    if delete_empty && account.is_empty() {
+                        self.state.delete(&address);
                     }
                 }
                 Apply::Delete { address } => {

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -12,7 +12,7 @@
 use evm::{
     backend::{Apply, ApplyBackend, Backend, Basic, Log, MemoryVicinity},
     executor::StackState,
-    Config, Context,
+    Context,
 };
 use primitive_types::{H160, H256, U256};
 
@@ -98,7 +98,7 @@ impl Backend for VirtualMachine {
 }
 
 impl ApplyBackend for VirtualMachine {
-    fn apply<A, I, L>(&mut self, values: A, _logs: L, delete_empty: bool)
+    fn apply<A, I, L>(&mut self, values: A, _logs: L, _delete_empty: bool)
     where
         A: IntoIterator<Item = Apply<I>>,
         I: IntoIterator<Item = (H256, H256)>,
@@ -107,27 +107,16 @@ impl ApplyBackend for VirtualMachine {
         for apply in values {
             match apply {
                 Apply::Modify {
-                    address,
-                    basic,
-                    code,
-                    storage,
-                    reset_storage,
+                    address: _,
+                    basic: _,
+                    code: _,
+                    storage: _,
+                    reset_storage: _,
                 } => {
-                    let is_empty = {
-                        // modify existing or create default/empty account
-                        // apply field values
-                        // return whether the account is empty
-                        // save logs
-                        todo!("implement updating account values");
-                    };
-                    if is_empty && delete_empty {
-                        // if account is empty and the delete_empty flag is
-                        // present, we remove it from storage.
-                        //todo!("remove empty account after modification");
-                    }
+                    todo!();
                 }
-                Apply::Delete { address } => {
-                    todo!("remove empty account with address");
+                Apply::Delete { address: _ } => {
+                    todo!();
                 }
             }
         }

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -3,6 +3,72 @@
 //! This module contains types that abstract away implementation details from the `evm` crate,
 //! specially those involving node and stack configurations, and runtime execution.
 
+use evm::{
+    backend::{ApplyBackend, Backend},
+};
+use primitive_types::{H160, H256, U256};
+
+
+pub struct Machine {
+    //
+}
+
+impl Backend for Machine {
+    fn gas_price(&self) -> U256 {
+        todo!();
+    }
+    fn origin(&self) -> H160 {
+        todo!();
+    }
+    fn block_hash(&self, number: U256) -> H256 {
+        todo!();
+    }
+    fn block_number(&self) -> U256 {
+        todo!();
+    }
+    fn block_coinbase(&self) -> H160 {
+        todo!();
+    }
+    fn block_timestamp(&self) -> U256 {
+        todo!();
+    }
+    fn block_difficulty(&self) -> U256 {
+        todo!();
+    }
+    fn block_gas_limit(&self) -> U256 {
+        todo!();
+    }
+    fn chain_id(&self) -> U256 {
+        todo!();
+    }
+    fn exists(&self, address: H160) -> bool {
+        todo!();
+    }
+    fn basic(&self, address: H160) -> evm::backend::Basic {
+        todo!();
+    }
+    fn code(&self, address: H160) -> Vec<u8> {
+        todo!();
+    }
+    fn storage(&self, address: H160, index: H256) -> H256 {
+        todo!();
+    }
+    fn original_storage(&self, address: H160, index: H256) -> Option<H256> {
+        todo!();
+    }
+}
+
+impl ApplyBackend for Machine {
+    fn apply<A, I, L>(&mut self, values: A, logs: L, delete_empty: bool)
+    where
+        A: IntoIterator<Item = evm::backend::Apply<I>>,
+        I: IntoIterator<Item = (H256, H256)>,
+        L: IntoIterator<Item = evm::backend::Log>,
+    {
+        todo!("Add code to apply logs and values in the machine state");
+    }
+}
+
 pub fn code_to_execute_evm_runtime() -> Result<(), ()> {
     todo!("put together the puzzle of types needed to run evm code");
 }

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -116,7 +116,7 @@ impl Backend for VirtualMachine {
     fn code(&self, address: H160) -> Vec<u8> {
         self.state
             .get(&address)
-            .map(|val| val.code.clone())
+            .map(|val| val.code.to_vec())
             .unwrap_or_default()
     }
     fn storage(&self, address: H160, index: H256) -> H256 {

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -102,8 +102,8 @@ impl Backend for VirtualMachine {
     }
 }
 
-impl ApplyBackend for Machine {
-    fn apply<A, I, L>(&mut self, values: A, logs: L, delete_empty: bool)
+impl ApplyBackend for VirtualMachine {
+    fn apply<A, I, L>(&mut self, _values: A, _logs: L, _delete_empty: bool)
     where
         A: IntoIterator<Item = evm::backend::Apply<I>>,
         I: IntoIterator<Item = (H256, H256)>,
@@ -113,6 +113,6 @@ impl ApplyBackend for Machine {
     }
 }
 
-pub fn code_to_execute_evm_runtime() -> Result<(), ()> {
+pub fn code_to_execute_evm_runtime() -> Result<(), String> {
     todo!("put together the puzzle of types needed to run evm code");
 }

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -132,8 +132,8 @@ impl ApplyBackend for VirtualMachine {
                         }
                     }
                 }
-                Apply::Delete { address: _ } => {
-                    todo!();
+                Apply::Delete { address } => {
+                    self.state.delete(&address);
                 }
             }
         }

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -142,15 +142,18 @@ impl ApplyBackend for VirtualMachine {
                     address,
                     basic: Basic { balance, nonce },
                     code,
-                    storage: _apply_storage,
+                    storage: apply_storage,
                     reset_storage,
                 } => {
                     // get the account if stored, else use default
                     let _account =
                         modify_account(&self.state, &address, balance, nonce, reset_storage, code);
 
-                    // WIP:
-                    todo!();
+                    // iterate over the apply_storage keys and values
+                    // and put them into the AccountTrie.
+                    for (_index, _value) in apply_storage {
+                        todo!();
+                    }
                 }
                 Apply::Delete { address: _ } => {
                     todo!();

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -184,59 +184,6 @@ impl ApplyBackend for VirtualMachine {
     }
 }
 
-impl<'config> StackState<'config> for VirtualMachine {
-    fn metadata(&self) -> &evm::executor::StackSubstateMetadata<'config> {
-        todo!();
-    }
-    fn metadata_mut(&mut self) -> &mut evm::executor::StackSubstateMetadata<'config> {
-        todo!();
-    }
-    fn enter(&mut self, _gas_limit: u64, _is_static: bool) {
-        todo!();
-    }
-    fn exit_commit(&mut self) -> Result<(), evm::ExitError> {
-        todo!();
-    }
-    fn exit_revert(&mut self) -> Result<(), evm::ExitError> {
-        todo!();
-    }
-    fn exit_discard(&mut self) -> Result<(), evm::ExitError> {
-        todo!();
-    }
-    fn is_empty(&self, _address: H160) -> bool {
-        todo!();
-    }
-    fn deleted(&self, _address: H160) -> bool {
-        todo!();
-    }
-    fn inc_nonce(&mut self, _address: H160) {
-        todo!();
-    }
-    fn set_storage(&mut self, _address: H160, _key: H256, _value: H256) {
-        todo!();
-    }
-    fn reset_storage(&mut self, _address: H160) {
-        todo!();
-    }
-    fn log(&mut self, _address: H160, _topics: Vec<H256>, _data: Vec<u8>) {
-        todo!();
-    }
-    fn set_deleted(&mut self, _address: H160) {
-        todo!();
-    }
-    fn set_code(&mut self, _address: H160, _code: Vec<u8>) {
-        todo!();
-    }
-    fn transfer(&mut self, _transfer: evm::Transfer) -> Result<(), evm::ExitError> {
-        todo!();
-    }
-    fn reset_balance(&mut self, _address: H160) {
-        todo!();
-    }
-    fn touch(&mut self, _address: H160) {
-        todo!();
-    }
-}
 
 pub fn code_to_execute_evm_runtime() -> Result<(), String> {
     todo!("put together the puzzle of types needed to run evm code");

--- a/chain-evm/src/state/account.rs
+++ b/chain-evm/src/state/account.rs
@@ -39,7 +39,7 @@ impl AccountTrie {
         code: Option<Vec<u8>>,
         reset_storage: bool,
     ) -> Account {
-        let account = if let Some(acct) = self.get(&address) {
+        let account = if let Some(acct) = self.get(address) {
             acct.clone()
         } else {
             Default::default()

--- a/chain-evm/src/state/account.rs
+++ b/chain-evm/src/state/account.rs
@@ -15,7 +15,7 @@ pub struct Account {
     /// Account data storage.
     pub storage: Storage,
     /// EVM bytecode of this account.
-    pub code: Vec<u8>,
+    pub code: Box<[u8]>,
 }
 
 impl Account {
@@ -50,7 +50,7 @@ impl AccountTrie {
             account.storage
         };
         let code = if let Some(code) = code {
-            code
+            code.into_boxed_slice()
         } else {
             account.code
         };

--- a/chain-evm/src/state/account.rs
+++ b/chain-evm/src/state/account.rs
@@ -23,3 +23,37 @@ pub type AccountAddress = H160;
 
 /// In-memory representation of all accounts.
 pub type AccountTrie = Trie<AccountAddress, Account>;
+
+impl AccountTrie {
+    pub fn modify_account(
+        &self,
+        address: &AccountAddress,
+        nonce: Nonce,
+        balance: Balance,
+        code: Option<Vec<u8>>,
+        reset_storage: bool,
+    ) -> Account {
+        let account = if let Some(acct) = self.get(&address) {
+            acct.clone()
+        } else {
+            Default::default()
+        };
+        let acct_storage = if reset_storage {
+            Default::default()
+        } else {
+            account.storage
+        };
+        let code = if let Some(code) = code {
+            code
+        } else {
+            account.code
+        };
+
+        Account {
+            nonce,
+            balance,
+            storage: acct_storage,
+            code,
+        }
+    }
+}

--- a/chain-evm/src/state/account.rs
+++ b/chain-evm/src/state/account.rs
@@ -6,7 +6,7 @@ pub type Nonce = U256;
 pub type Balance = U256;
 
 /// A represantation of an EVM account.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Account {
     /// Account nonce. A number of value transfers from this account.
     pub nonce: Nonce,

--- a/chain-evm/src/state/account.rs
+++ b/chain-evm/src/state/account.rs
@@ -18,6 +18,12 @@ pub struct Account {
     pub code: Vec<u8>,
 }
 
+impl Account {
+    pub fn is_empty(&self) -> bool {
+        self.nonce == Nonce::zero() && self.balance == Balance::zero() && self.storage.is_empty()
+    }
+}
+
 /// An address of an EVM account.
 pub type AccountAddress = H160;
 

--- a/chain-evm/src/state/account.rs
+++ b/chain-evm/src/state/account.rs
@@ -15,7 +15,7 @@ pub struct Account {
     /// Account data storage.
     pub storage: Storage,
     /// EVM bytecode of this account.
-    pub code: Box<[u8]>,
+    pub code: Vec<u8>,
 }
 
 /// An address of an EVM account.

--- a/chain-evm/src/state/mod.rs
+++ b/chain-evm/src/state/mod.rs
@@ -9,5 +9,5 @@ mod storage;
 mod trie;
 
 pub use account::{Account, AccountAddress, AccountTrie, Balance, Nonce};
-pub use storage::Storage;
+pub use storage::{Key, Storage, Value};
 pub use trie::Trie;

--- a/chain-evm/src/state/storage.rs
+++ b/chain-evm/src/state/storage.rs
@@ -1,10 +1,10 @@
 use crate::state::trie::Trie;
 
-use primitive_types::U256;
+use primitive_types::H256;
 
-/// Representation of a storage key. 256-bit big-endian integer.
-pub type Key = U256;
-/// Representation of a storage key. 256-bit big-endian integer.
-pub type Value = U256;
+/// Representation of a storage key. Fixed-size uninterpreted hash type with 32 bytes (256 bits) size.
+pub type Key = H256;
+/// Representation of a storage key. Fixed-size uninterpreted hash type with 32 bytes (256 bits) size.
+pub type Value = H256;
 /// In-memory representation of account storage.
 pub type Storage = Trie<Key, Value>;

--- a/chain-evm/src/state/trie.rs
+++ b/chain-evm/src/state/trie.rs
@@ -48,36 +48,6 @@ impl<K: Clone + Hash + Eq, V: Clone> Trie<K, V> {
         }
     }
 
-    /// Put a value into a trie, replacing an existing value if there was any.
-    /// This method is useful when you have a mutable reference to the Trie.
-    ///
-    /// This method is similar to `Trie::put`, except that it uses `&mut self` to
-    /// modify the inner state.
-    pub fn insert_or_update(&mut self, key: K, value: V) {
-        // using two branches instead of `Hamt::insert_or_update` to avoid unnecessary cloning
-        let new_state = if self.0.contains_key(&key) {
-            self.0
-                .update(&key, |_| Ok::<_, Infallible>(Some(value)))
-                .expect("we already checked that the key is present")
-        } else {
-            self.0
-                .insert(key, value)
-                .expect("we already checked that the key does not exist")
-        };
-        *self = Self(new_state);
-    }
-
-    /// Similar to remove a value from a trie, but uses mutable reference.
-    pub fn delete(&mut self, key: &K) {
-        match self.0.remove(key) {
-            Ok(new_state) => *self = Self(new_state),
-            Err(RemoveError::KeyNotFound) => (),
-            Err(RemoveError::ValueNotMatching) => {
-                unreachable!("this error should never occur: we are not matching the removed value")
-            }
-        }
-    }
-
     pub fn iter(&self) -> HamtIter<'_, K, V> {
         self.0.iter()
     }
@@ -112,18 +82,5 @@ mod tests {
 
         // removing non-existent value should not error
         storage_new3.remove(&key);
-    }
-
-    #[proptest]
-    fn insert_or_update(key: u8, value1: u8, value2: u8) {
-        let mut storage = Trie::<u8, u8>::new();
-
-        prop_assert_eq!(None, storage.get(&key));
-
-        storage.insert_or_update(key, value1);
-        prop_assert_eq!(Some(&value1), storage.get(&key));
-
-        storage.insert_or_update(key, value2);
-        prop_assert_eq!(Some(&value2), storage.get(&key))
     }
 }

--- a/chain-evm/src/state/trie.rs
+++ b/chain-evm/src/state/trie.rs
@@ -75,4 +75,15 @@ mod tests {
         // removing non-existent value should not error
         storage_new3.remove(&key);
     }
+
+    #[proptest]
+    fn insert_or_update(key: u8, value1: u8, value2: u8) {
+        let mut storage = Trie::<u8, u8>::new();
+
+        storage.insert_or_update(key, value1);
+        prop_assert_eq!(Some(&value1), storage.get(&key));
+
+        storage.insert_or_update(key, value2);
+        prop_assert_eq!(Some(&value2), storage.get(&key))
+    }
 }

--- a/chain-evm/src/state/trie.rs
+++ b/chain-evm/src/state/trie.rs
@@ -67,6 +67,17 @@ impl<K: Clone + Hash + Eq, V: Clone> Trie<K, V> {
         *self = Self(new_state);
     }
 
+    /// Similar to remove a value from a trie, but uses mutable reference.
+    pub fn delete(&mut self, key: &K) {
+        match self.0.remove(key) {
+            Ok(new_state) => *self = Self(new_state),
+            Err(RemoveError::KeyNotFound) => (),
+            Err(RemoveError::ValueNotMatching) => {
+                unreachable!("this error should never occur: we are not matching the removed value")
+            }
+        }
+    }
+
     pub fn iter(&self) -> HamtIter<'_, K, V> {
         self.0.iter()
     }

--- a/chain-evm/src/state/trie.rs
+++ b/chain-evm/src/state/trie.rs
@@ -99,6 +99,8 @@ mod tests {
     fn insert_or_update(key: u8, value1: u8, value2: u8) {
         let mut storage = Trie::<u8, u8>::new();
 
+        prop_assert_eq!(None, storage.get(&key));
+
         storage.insert_or_update(key, value1);
         prop_assert_eq!(Some(&value1), storage.get(&key));
 

--- a/chain-evm/src/state/trie.rs
+++ b/chain-evm/src/state/trie.rs
@@ -1,4 +1,4 @@
-use imhamt::{Hamt, RemoveError};
+use imhamt::{Hamt, HamtIter, RemoveError};
 
 use std::collections::hash_map::DefaultHasher;
 use std::convert::Infallible;
@@ -65,6 +65,10 @@ impl<K: Clone + Hash + Eq, V: Clone> Trie<K, V> {
                 .expect("we already checked that the key does not exist")
         };
         *self = Self(new_state);
+    }
+
+    pub fn iter(&self) -> HamtIter<'_, K, V> {
+        self.0.iter()
     }
 }
 

--- a/chain-evm/src/state/trie.rs
+++ b/chain-evm/src/state/trie.rs
@@ -81,6 +81,10 @@ impl<K: Clone + Hash + Eq, V: Clone> Trie<K, V> {
     pub fn iter(&self) -> HamtIter<'_, K, V> {
         self.0.iter()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/chain-evm/src/state/trie.rs
+++ b/chain-evm/src/state/trie.rs
@@ -47,6 +47,25 @@ impl<K: Clone + Hash + Eq, V: Clone> Trie<K, V> {
             }
         }
     }
+
+    /// Put a value into a trie, replacing an existing value if there was any.
+    /// This method is useful when you have a mutable reference to the Trie.
+    ///
+    /// This method is similar to `Trie::put`, except that it uses `&mut self` to
+    /// modify the inner state.
+    pub fn insert_or_update(&mut self, key: K, value: V) {
+        // using two branches instead of `Hamt::insert_or_update` to avoid unnecessary cloning
+        let new_state = if self.0.contains_key(&key) {
+            self.0
+                .update(&key, |_| Ok::<_, Infallible>(Some(value)))
+                .expect("we already checked that the key is present")
+        } else {
+            self.0
+                .insert(key, value)
+                .expect("we already checked that the key does not exist")
+        };
+        *self = Self(new_state);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add code to chain-evm crate in chain-libs abstracting execution of EVM smart contracts, wrapping the details of SputnikVM integration in a way that will allow an alternative implementation to be swapped in later if needed.

It can expose the EVM data types such as addresses, hashes, bytecode payloads etc., and it can pass and return account state around as HAMTs, but the details of runtime initialization and running of a smart contract should be abstracted away from the user.