### PR TITLE
Rename SetValidity to SetTtl in tx builder

### DIFF
--- a/chain-impl-mockchain/src/testing/builders/initial_builder.rs
+++ b/chain-impl-mockchain/src/testing/builders/initial_builder.rs
@@ -94,7 +94,7 @@ pub fn create_initial_stake_pool_owner_delegation(delegation_type: DelegationTyp
 }
 
 fn set_initial_ios<P: Payload>(
-    builder: TxBuilderState<SetValidity<P>>,
+    builder: TxBuilderState<SetTtl<P>>,
     inputs: &[Input],
     outputs: &[OutputAddress],
 ) -> TxBuilderState<SetAuthData<P>> {

--- a/chain-impl-mockchain/src/testing/builders/tx_cert_builder.rs
+++ b/chain-impl-mockchain/src/testing/builders/tx_cert_builder.rs
@@ -13,7 +13,7 @@ use crate::{
     ledger::ledger::OutputAddress,
     testing::{data::Wallet, make_witness},
     transaction::{
-        AccountBindingSignature, Input, Payload, SetAuthData, SetValidity,
+        AccountBindingSignature, Input, Payload, SetAuthData, SetTtl,
         SingleAccountBindingSignature, TxBuilder, TxBuilderState, Witness,
     },
     value::Value,
@@ -44,7 +44,7 @@ impl TestTxCertBuilder {
     fn set_initial_ios<P: Payload>(
         &self,
         current_date: BlockDate,
-        builder: TxBuilderState<SetValidity<P>>,
+        builder: TxBuilderState<SetTtl<P>>,
         funder: &Wallet,
         inputs: &[Input],
         outputs: &[OutputAddress],

--- a/chain-impl-mockchain/src/transaction/builder.rs
+++ b/chain-impl-mockchain/src/transaction/builder.rs
@@ -27,7 +27,7 @@ impl<T> Clone for TxBuilderState<T> {
 }
 
 pub enum SetPayload {}
-pub struct SetValidity<P>(PhantomData<P>);
+pub struct SetTtl<P>(PhantomData<P>);
 pub struct SetIOs<P>(PhantomData<P>);
 pub struct SetWitnesses<P>(PhantomData<P>);
 pub struct SetAuthData<P: Payload>(PhantomData<P>);
@@ -73,7 +73,7 @@ impl<State> TxBuilderState<State> {
 
 impl TxBuilderState<SetPayload> {
     /// Set the payload of this transaction
-    pub fn set_payload<P: Payload>(mut self, payload: &P) -> TxBuilderState<SetValidity<P>> {
+    pub fn set_payload<P: Payload>(mut self, payload: &P) -> TxBuilderState<SetTtl<P>> {
         if P::HAS_DATA {
             self.data.extend_from_slice(payload.payload_data().as_ref());
         }
@@ -85,12 +85,12 @@ impl TxBuilderState<SetPayload> {
         }
     }
 
-    pub fn set_nopayload(self) -> TxBuilderState<SetValidity<NoExtra>> {
+    pub fn set_nopayload(self) -> TxBuilderState<SetTtl<NoExtra>> {
         self.set_payload(&NoExtra)
     }
 }
 
-impl<P> TxBuilderState<SetValidity<P>> {
+impl<P> TxBuilderState<SetTtl<P>> {
     pub fn set_expiry_date(mut self, valid_until: BlockDate) -> TxBuilderState<SetIOs<P>> {
         fn write_date(data: &mut Vec<u8>, date: BlockDate) {
             data.extend_from_slice(&date.epoch.to_be_bytes());

--- a/chain-impl-mockchain/src/transaction/mod.rs
+++ b/chain-impl-mockchain/src/transaction/mod.rs
@@ -17,7 +17,7 @@ use chain_core::property;
 
 // to remove..
 pub use builder::{
-    SetAuthData, SetIOs, SetPayload, SetValidity, SetWitnesses, TxBuilder, TxBuilderState,
+    SetAuthData, SetIOs, SetPayload, SetTtl, SetWitnesses, TxBuilder, TxBuilderState,
 };
 pub use element::*;
 pub use input::*;


### PR DESCRIPTION
Like done elsewhere in the API for tx expiration,
"validity" is a too general term.