### PR TITLE
EVM account trie in chain-libs

### DIFF
--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 chain-core = { path = "../chain-core" }
 chain-addr = { path = "../chain-addr" }
 chain-crypto = { path = "../chain-crypto" }
-chain-evm = { path = "../chain-evm" }
+chain-evm = { path = "../chain-evm", optional = true }
 chain-ser = { path = "../chain-ser" }
 chain-time = { path = "../chain-time" }
 chain-vote = { path = "../chain-vote" }
@@ -33,6 +33,7 @@ rand = "0.8"
 primitive-types = "0.10.1"
 
 [features]
+evm = ["chain-evm"]
 property-test-api = [
         "chain-crypto/property-test-api",
         "chain-time/property-test-api",

--- a/chain-impl-mockchain/Cargo.toml
+++ b/chain-impl-mockchain/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 chain-core = { path = "../chain-core" }
 chain-addr = { path = "../chain-addr" }
 chain-crypto = { path = "../chain-crypto" }
+chain-evm = { path = "../chain-evm" }
 chain-ser = { path = "../chain-ser" }
 chain-time = { path = "../chain-time" }
 chain-vote = { path = "../chain-vote" }
@@ -29,6 +30,7 @@ rand_chacha = { version = "0.3", optional = true }
 rayon = "1.5.0"
 criterion = { version = "0.3.0", optional = true }
 rand = "0.8"
+primitive-types = "0.10.1"
 
 [features]
 property-test-api = [


### PR DESCRIPTION
Define data structures to represent state of EVM accounts, in a new chain-libs crate chain-evm (coordinate with EAS-68) to support EVM smart contract features. The accounts are identified by 160-bit addresses in the EVM format.

It could be a specialization of account::Ledger with EVM-specific additions, modeled by the MemoryAccount struct in the evm library.