### PR TITLE
Fix CI only testing alternative backend on ubuntu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
         toolchain: [stable]
         mode: ['', '--release']
         experimental: [false]
+        features: ['']
         include:
           - os: ubuntu-latest
             toolchain: nightly


### PR DESCRIPTION
The 'include' field has a tricky behavior. It creates a new job
only if the tags do not match any point in the existing matrix,
and modifies that particular config otherwise. This caused our
current configuration to only test the alternative backend on
ubuntu.

To solve this, add a (empty) 'features' field to the original
matrix.