### PR TITLE
Update bech32 dependency to 0.8, fix potential encoding ambiguity

### DIFF
--- a/chain-addr/Cargo.toml
+++ b/chain-addr/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [ "Cardano", "Wallet", "Crypto", "Address" ]
 property-test-api = ["chain-crypto/property-test-api", "quickcheck"]
 
 [dependencies]
-bech32 = "0.7"
+bech32 = "0.8"
 chain-core = { path = "../chain-core" }
 chain-crypto = { path = "../chain-crypto" }
 cryptoxide = "0.3"

--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -367,7 +367,9 @@ impl AddressReadable {
     /// Create a new AddressReadable from an encoded address
     pub fn from_address(prefix: &str, addr: &Address) -> Self {
         let v = ToBase32::to_base32(&addr.to_bytes());
-        // FIXME: switch to Bech32m?
+        // Use the original Bech32 format from BIP-0173.
+        // As long as the binary length of addresses is fixed, there is
+        // no ambiguity in encoding.
         let r = bech32::encode(prefix, v, bech32::Variant::Bech32).unwrap();
         AddressReadable(r)
     }

--- a/chain-addr/src/lib.rs
+++ b/chain-addr/src/lib.rs
@@ -332,10 +332,15 @@ impl AddressReadable {
 
     /// Validate from a String to create a valid AddressReadable
     pub fn from_string(expected_prefix: &str, s: &str) -> Result<Self, Error> {
-        let (hrp, data) = bech32::decode(s)?;
+        let (hrp, data, variant) = bech32::decode(s)?;
         if hrp != expected_prefix {
             return Err(Error::InvalidPrefix);
         };
+        // We have to fix the address format to the original Bech32 encoding
+        // for compatibility with tools and whatnot.
+        if variant != bech32::Variant::Bech32 {
+            return Err(Error::InvalidInternalEncoding);
+        }
         let dat = Vec::from_base32(&data)?;
         let _ = is_valid_data(&dat[..])?;
 
@@ -343,7 +348,12 @@ impl AddressReadable {
     }
 
     pub fn from_str_anyprefix(s: &str) -> Result<Self, Error> {
-        let (_, data) = bech32::decode(s)?;
+        let (_, data, variant) = bech32::decode(s)?;
+        // We have to fix the address format to the original Bech32 encoding
+        // for compatibility with tools and whatnot.
+        if variant != bech32::Variant::Bech32 {
+            return Err(Error::InvalidInternalEncoding);
+        }
         let dat = Vec::from_base32(&data)?;
         let _ = is_valid_data(&dat[..])?;
 
@@ -357,14 +367,15 @@ impl AddressReadable {
     /// Create a new AddressReadable from an encoded address
     pub fn from_address(prefix: &str, addr: &Address) -> Self {
         let v = ToBase32::to_base32(&addr.to_bytes());
-        let r = bech32::encode(prefix, v).unwrap();
+        // FIXME: switch to Bech32m?
+        let r = bech32::encode(prefix, v, bech32::Variant::Bech32).unwrap();
         AddressReadable(r)
     }
 
     /// Convert a valid AddressReadable to an decoded address
     pub fn to_address(&self) -> Address {
         // the data has been verified ahead of time, so all unwrap are safe
-        let (_, data) = bech32::decode(&self.0).unwrap();
+        let (_, data, _variant) = bech32::decode(&self.0).unwrap();
         let dat = Vec::from_base32(&data).unwrap();
         Address::from_bytes(&dat[..]).unwrap()
     }

--- a/chain-crypto/Cargo.toml
+++ b/chain-crypto/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 keywords = [ "Crypto", "VRF", "Ed25519", "MMM" ]
 
 [dependencies]
-bech32 = "0.7"
+bech32 = "0.8"
 cryptoxide = "0.3"
 curve25519-dalek-ng = { version = "4.0" }
 # TODO replace with the crates.io version once it has faster scalar multiplication

--- a/chain-crypto/src/bech32.rs
+++ b/chain-crypto/src/bech32.rs
@@ -16,12 +16,13 @@ pub trait Bech32 {
 }
 
 pub fn to_bech32_from_bytes<B: Bech32>(bytes: &[u8]) -> String {
-    bech32::encode(B::BECH32_HRP, bytes.to_base32())
+    // FIXME: should switch to Bech32m?
+    bech32::encode(B::BECH32_HRP, bytes.to_base32(), bech32::Variant::Bech32)
         .unwrap_or_else(|e| panic!("Failed to build bech32: {}", e))
 }
 
 pub fn try_from_bech32_to_bytes<B: Bech32>(bech32_str: &str) -> Result<Vec<u8>> {
-    let (hrp, data) = bech32::decode(bech32_str)?;
+    let (hrp, data, _variant) = bech32::decode(bech32_str)?;
     if hrp != B::BECH32_HRP {
         return Err(Error::HrpInvalid {
             expected: B::BECH32_HRP,

--- a/chain-crypto/src/bech32.rs
+++ b/chain-crypto/src/bech32.rs
@@ -5,18 +5,34 @@ use std::result::Result as StdResult;
 
 pub type Result<T> = StdResult<T, Error>;
 
+/// Bech32 encoding for fixed-size binary objects.
 pub trait Bech32 {
+    /// The human-readable prefix that is used to represent the
+    /// the object in the Bech32 format. On decoding, the HRP of the input
+    /// string is checked against this value.
     const BECH32_HRP: &'static str;
 
+    /// Length of the encoded binary data.
+    const BYTES_LEN: usize;
+
+    /// Decodes the object from its Bech32 string representation.
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self>
     where
         Self: Sized;
 
+    /// Produces a Bech32 string format representation of the object.
     fn to_bech32_str(&self) -> String;
 }
 
 pub fn to_bech32_from_bytes<B: Bech32>(bytes: &[u8]) -> String {
-    // FIXME: should switch to Bech32m?
+    // As long as the size of the object is fixed, the original Bech32 format
+    // described in BIP-0173 should produce unambiguous encoding.
+    assert_eq!(
+        bytes.len(),
+        B::BYTES_LEN,
+        "encoded binary length should be {} bytes",
+        B::BYTES_LEN
+    );
     bech32::encode(B::BECH32_HRP, bytes.to_base32(), bech32::Variant::Bech32)
         .unwrap_or_else(|e| panic!("Failed to build bech32: {}", e))
 }
@@ -29,7 +45,14 @@ pub fn try_from_bech32_to_bytes<B: Bech32>(bech32_str: &str) -> Result<Vec<u8>> 
             actual: hrp,
         });
     }
-    Vec::<u8>::from_base32(&data).map_err(Into::into)
+    let data = Vec::<u8>::from_base32(&data)?;
+    if data.len() != B::BYTES_LEN {
+        return Err(Error::UnexpectedDataLen {
+            expected: B::BYTES_LEN,
+            actual: data.len(),
+        });
+    }
+    Ok(data)
 }
 
 #[derive(Debug)]
@@ -40,6 +63,10 @@ pub enum Error {
         actual: String,
     },
     DataInvalid(Box<dyn StdError + Send + Sync + 'static>),
+    UnexpectedDataLen {
+        expected: usize,
+        actual: usize,
+    },
 }
 
 impl Error {
@@ -64,6 +91,11 @@ impl fmt::Display for Error {
                 actual, expected
             ),
             Error::DataInvalid(_) => write!(f, "Failed to parse data decoded from bech32"),
+            Error::UnexpectedDataLen { expected, actual } => write!(
+                f,
+                "parsed bech32 data has length {}, expected {}",
+                actual, expected
+            ),
         }
     }
 }

--- a/chain-crypto/src/digest.rs
+++ b/chain-crypto/src/digest.rs
@@ -172,6 +172,7 @@ macro_rules! define_from_instances {
         }
         impl Bech32 for Digest<$hash_ty> {
             const BECH32_HRP: &'static str = $bech32_hrp;
+            const BYTES_LEN: usize = $hash_size;
 
             fn try_from_bech32_str(bech32_str: &str) -> bech32::Result<Self> {
                 let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;
@@ -421,6 +422,7 @@ macro_rules! typed_define_from_instances {
         }
         impl<T> Bech32 for DigestOf<$hash_ty, T> {
             const BECH32_HRP: &'static str = $bech32_hrp;
+            const BYTES_LEN: usize = $hash_size;
 
             fn try_from_bech32_str(bech32_str: &str) -> bech32::Result<Self> {
                 let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;

--- a/chain-crypto/src/hash.rs
+++ b/chain-crypto/src/hash.rs
@@ -118,6 +118,7 @@ macro_rules! define_hash_object {
         }
         impl Bech32 for $hash_ty {
             const BECH32_HRP: &'static str = $bech32_hrp;
+            const BYTES_LEN: usize = $hash_size;
 
             fn try_from_bech32_str(bech32_str: &str) -> bech32::Result<Self> {
                 let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;

--- a/chain-crypto/src/key.rs
+++ b/chain-crypto/src/key.rs
@@ -234,6 +234,7 @@ impl<A: AsymmetricPublicKey> Hash for PublicKey<A> {
 
 impl<A: AsymmetricPublicKey> Bech32 for PublicKey<A> {
     const BECH32_HRP: &'static str = A::PUBLIC_BECH32_HRP;
+    const BYTES_LEN: usize = A::PUBLIC_KEY_SIZE;
 
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self, bech32::Error> {
         let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;
@@ -245,8 +246,9 @@ impl<A: AsymmetricPublicKey> Bech32 for PublicKey<A> {
     }
 }
 
-impl<A: AsymmetricKey> Bech32 for SecretKey<A> {
+impl<A: SecretKeySizeStatic> Bech32 for SecretKey<A> {
     const BECH32_HRP: &'static str = A::SECRET_BECH32_HRP;
+    const BYTES_LEN: usize = A::SECRET_KEY_SIZE;
 
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self, bech32::Error> {
         let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;

--- a/chain-crypto/src/sign.rs
+++ b/chain-crypto/src/sign.rs
@@ -197,6 +197,7 @@ impl<T: ?Sized, A: VerificationAlgorithm> AsRef<[u8]> for Signature<T, A> {
 
 impl<T, A: VerificationAlgorithm> Bech32 for Signature<T, A> {
     const BECH32_HRP: &'static str = A::SIGNATURE_BECH32_HRP;
+    const BYTES_LEN: usize = A::SIGNATURE_SIZE;
 
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self, bech32::Error> {
         let bytes = bech32::try_from_bech32_to_bytes::<Self>(bech32_str)?;

--- a/chain-vote/src/committee.rs
+++ b/chain-vote/src/committee.rs
@@ -77,6 +77,7 @@ impl ElectionPublicKey {
 
 impl Bech32 for ElectionPublicKey {
     const BECH32_HRP: &'static str = concatcp!(CURVE_HRP, "_votepk");
+    const BYTES_LEN: usize = PublicKey::BYTES_LEN;
 
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self, Error> {
         try_from_bech32_to_bytes::<Self>(bech32_str).and_then(|raw| {
@@ -192,6 +193,7 @@ impl MemberSecretKey {
 
 impl Bech32 for MemberSecretKey {
     const BECH32_HRP: &'static str = concatcp!(CURVE_HRP, "_membersk");
+    const BYTES_LEN: usize = SecretKey::BYTES_LEN;
 
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self, Error> {
         try_from_bech32_to_bytes::<Self>(bech32_str).and_then(|raw| {
@@ -219,6 +221,7 @@ impl MemberPublicKey {
 
 impl Bech32 for MemberPublicKey {
     const BECH32_HRP: &'static str = concatcp!(CURVE_HRP, "_memberpk");
+    const BYTES_LEN: usize = PublicKey::BYTES_LEN;
 
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self, Error> {
         try_from_bech32_to_bytes::<Self>(bech32_str).and_then(|raw| {
@@ -261,6 +264,7 @@ impl MemberCommunicationKey {
 
 impl Bech32 for MemberCommunicationKey {
     const BECH32_HRP: &'static str = concatcp!(CURVE_HRP, "_vcommsk");
+    const BYTES_LEN: usize = SecretKey::BYTES_LEN;
 
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self, Error> {
         try_from_bech32_to_bytes::<Self>(bech32_str).and_then(|raw| {
@@ -293,6 +297,7 @@ impl MemberCommunicationPublicKey {
 
 impl Bech32 for MemberCommunicationPublicKey {
     const BECH32_HRP: &'static str = concatcp!(CURVE_HRP, "_vcommpk");
+    const BYTES_LEN: usize = PublicKey::BYTES_LEN;
 
     fn try_from_bech32_str(bech32_str: &str) -> Result<Self, Error> {
         try_from_bech32_to_bytes::<Self>(bech32_str).and_then(|raw| {

--- a/chain-vote/src/cryptography/elgamal.rs
+++ b/chain-vote/src/cryptography/elgamal.rs
@@ -143,6 +143,8 @@ impl PublicKey {
 }
 
 impl SecretKey {
+    pub const BYTES_LEN: usize = Scalar::BYTES_LEN;
+
     pub fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let sk = Scalar::random(rng);
         Self { sk }


### PR DESCRIPTION
Record concerns about bech32m as comments.
The Bech32 weakness is unlikely to affect our use of it for keys and
addresses, all of which expect fixed data length.
The changes for the general-purpose decoding procedure make it
~accept both variants, but~ produce the original Bech32 from BIP-0173.
The fixed binary data length is reinforced through the `Bech32` trait and the functions of the `bech32` module, using a new associated const `BYTES_LEN`.
Address encoding and decoding is fixed to the original Bech32 to avoid
any ambiguity and preserve backward compatibility.