### PR TITLE
chain-time: migrate to proptest and expose proptest APIs

### DIFF
--- a/chain-time/Cargo.toml
+++ b/chain-time/Cargo.toml
@@ -6,16 +6,17 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cfg-if = "1.0"
-quickcheck = { version = "0.9", optional = true }
-quickcheck_macros = { version = "0.9", optional = true }
 chain-ser = { path = "../chain-ser" }
 chain-core = { path = "../chain-core" }
 
+quickcheck = { version = "0.9", optional = true }
+proptest = { git = "https://github.com/input-output-hk/proptest.git", optional = true }
+test-strategy = { version = "0.1", optional = true }
 
 [features]
-property-test-api = ["quickcheck", "quickcheck_macros"]
+property-test-api = ["quickcheck", "proptest", "test-strategy"]
 
 [dev-dependencies]
 quickcheck = "0.9"
-quickcheck_macros = "0.9"
+proptest = { git = "https://github.com/input-output-hk/proptest.git" }
+test-strategy = "0.1"

--- a/chain-time/src/lib.rs
+++ b/chain-time/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate cfg_if;
-
 pub mod era;
 pub mod timeframe;
 pub mod timeline;
@@ -11,12 +8,5 @@ pub use timeframe::{Slot, SlotDuration, TimeFrame};
 pub use timeline::{TimeOffsetSeconds, Timeline};
 pub use units::DurationSeconds;
 
-cfg_if! {
-   if #[cfg(test)] {
-        extern crate quickcheck_macros;
-
-        pub mod testing;
-    } else if #[cfg(feature = "property-test-api")] {
-        pub mod testing;
-    }
-}
+#[cfg(any(test, feature = "property-test-api"))]
+pub mod testing;

--- a/chain-time/src/timeframe.rs
+++ b/chain-time/src/timeframe.rs
@@ -6,6 +6,10 @@ use std::time::{Duration, SystemTime};
 /// The slots are not comparable to others slots made on a
 /// different time frame
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    any(test, feature = "property-test-api"),
+    derive(test_strategy::Arbitrary)
+)]
 pub struct Slot(pub(crate) u64);
 
 impl From<u64> for Slot {


### PR DESCRIPTION
quickcheck remains in place for the time being as a compatibility
measure. It should be removed once all crates are using proptest.