### PR TITLE
Add TallyDecryptShare elements size validation

### DIFF
--- a/chain-vote/src/tally.rs
+++ b/chain-vote/src/tally.rs
@@ -648,6 +648,43 @@ mod tests {
     }
 
     #[test]
+    fn tally_wrong_elements_size() {
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+
+        let shared_string =
+            b"Example of a shared string. This should be VotePlan.to_id()".to_owned();
+        let h = Crs::from_hash(&shared_string);
+
+        let mc = MemberCommunicationKey::new(&mut rng);
+        let mc = [mc.to_public()];
+
+        let threshold = 1;
+
+        let m = MemberState::new(&mut rng, threshold, &h, &mc, 0);
+
+        let participants = vec![m.public_key()];
+        let ek = ElectionPublicKey::from_participants(&participants);
+
+        println!("encrypting vote");
+
+        let vote_options = 2;
+        let e = get_encrypted_ballot(&mut rng, &ek, &h, Vote::new(vote_options, 0));
+
+        println!("tallying");
+
+        let mut encrypted_tally = EncryptedTally::new(vote_options, ek, h);
+        encrypted_tally.add(&e, 1);
+
+        let mut tds = encrypted_tally.partial_decrypt(&mut rng, m.secret_key());
+
+        println!("corrupt tally share, add extra element");
+
+        tds.elements.push(tds.elements.last().unwrap().clone());
+
+        assert!(!tds.verify(&encrypted_tally, &m.public_key()))
+    }
+
+    #[test]
     fn zero_encrypted_tally_serialization_sanity() {
         let election_key = ElectionPublicKey(PublicKey {
             pk: GroupElement::from_hash(&[1u8]),


### PR DESCRIPTION
Adding elements size validation for the TallyDecryptShare, elements size should be equal to the Tally options amount.
Related to this issue: https://github.com/input-output-hk/chain-libs/issues/522. 
