### PR TITLE
Retrofit cryptoxide 0.3 to catalyst-fund3 branch

### DIFF
--- a/cardano-legacy-address/Cargo.toml
+++ b/cardano-legacy-address/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [build-dependencies]
 
 [dependencies]
-cryptoxide = "0.2"
+cryptoxide = "0.3"
 cbor_event = "^2.1.3"
 ed25519-bip32 = "^0.3.0"
 chain-ser = {path = "../chain-ser"}

--- a/chain-addr/Cargo.toml
+++ b/chain-addr/Cargo.toml
@@ -13,7 +13,7 @@ property-test-api = ["quickcheck"]
 bech32 = "0.7"
 chain-core = { path = "../chain-core" }
 chain-crypto = { path = "../chain-crypto" }
-cryptoxide = "0.2"
+cryptoxide = "0.3"
 cfg-if = "1.0"
 quickcheck = { version = "0.9", optional = true }
 

--- a/chain-crypto/Cargo.toml
+++ b/chain-crypto/Cargo.toml
@@ -8,7 +8,7 @@ keywords = [ "Crypto", "VRF", "Ed25519", "MMM" ]
 
 [dependencies]
 bech32 = "0.7"
-cryptoxide = "0.2"
+cryptoxide = "0.3"
 curve25519-dalek = "3.0"
 ed25519-dalek = "1.0"
 sha2 = "0.9"

--- a/chain-vote/Cargo.toml
+++ b/chain-vote/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 rand_core = "0.5"
-cryptoxide = "0.2"
+cryptoxide = "0.3"
 eccoxide = { version = "0.3", optional = true }
 zerocaf = { version = "0.2", optional = true }
 


### PR DESCRIPTION
Allows the catalyst-fund3 node and jcli to be compiled with current versions of Rust.