### PR TITLE
Update LeaderPair struct, remove redundunt leader_id field

### DIFF
--- a/chain-impl-mockchain/src/leadership/mod.rs
+++ b/chain-impl-mockchain/src/leadership/mod.rs
@@ -315,7 +315,7 @@ mod tests {
     pub fn generate_ledger_with_bft_leaders_count(count: usize) -> (Vec<BftLeaderId>, Ledger) {
         let leaders: Vec<PublicKey<Ed25519>> = TestGen::leaders_pairs()
             .take(count)
-            .map(|x| x.leader_key.to_public())
+            .map(|x| x.key().to_public())
             .collect();
         generate_ledger_with_bft_leaders(leaders)
     }

--- a/chain-impl-mockchain/src/ledger/tests/certificate_tests/voting.rs
+++ b/chain-impl-mockchain/src/ledger/tests/certificate_tests/voting.rs
@@ -133,12 +133,12 @@ pub fn update_vote_is_not_allowed_in_block0() {
 
     let signed_update_proposal = SignedProposalBuilder::new()
         .with_proposal_update(update_proposal)
-        .with_proposer_id(leader_pair.leader_id.clone())
+        .with_proposer_id(leader_pair.id())
         .build();
 
     let fragment = Fragment::UpdateProposal(signed_update_proposal);
 
-    let signed_update_vote = build_vote(fragment.id(), leader_pair.leader_id);
+    let signed_update_vote = build_vote(fragment.id(), leader_pair.id());
 
     let fragment = Fragment::UpdateVote(signed_update_vote);
 
@@ -162,7 +162,7 @@ pub fn update_proposal_is_not_allowed_in_block0() {
         .build();
     let signed_update_proposal = SignedProposalBuilder::new()
         .with_proposal_update(update_proposal)
-        .with_proposer_id(leader_pair.leader_id)
+        .with_proposer_id(leader_pair.id())
         .build();
 
     let fragment = Fragment::UpdateProposal(signed_update_proposal);

--- a/chain-impl-mockchain/src/ledger/tests/ledger_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/ledger_tests.rs
@@ -131,7 +131,7 @@ pub fn ledger_new_no_block_start_time() {
     let header_id = TestGen::hash();
     let mut ie = ConfigParams::new();
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::SlotsPerEpoch(10u32));
     ie.push(ConfigParam::KesUpdateSpeed(3600));
@@ -150,7 +150,7 @@ pub fn ledger_new_dupicated_initial_fragments() {
     let header_id = TestGen::hash();
     let mut ie = ConfigParams::new();
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::SlotsPerEpoch(10u32));
     ie.push(ConfigParam::KesUpdateSpeed(3600));
@@ -173,7 +173,7 @@ pub fn ledger_new_duplicated_block0() {
     let header_id = TestGen::hash();
     let mut ie = ConfigParams::new();
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::SlotsPerEpoch(10u32));
     ie.push(ConfigParam::KesUpdateSpeed(3600));
@@ -190,7 +190,7 @@ pub fn ledger_new_duplicated_discrimination() {
     let mut ie = ConfigParams::new();
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::SlotsPerEpoch(10u32));
     ie.push(ConfigParam::KesUpdateSpeed(3600));
@@ -207,7 +207,7 @@ pub fn ledger_new_duplicated_consensus_version() {
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
     ie.push(ConfigParam::ConsensusVersion(ConsensusType::Bft));
     ie.push(ConfigParam::ConsensusVersion(ConsensusType::Bft));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::SlotsPerEpoch(10u32));
     ie.push(ConfigParam::KesUpdateSpeed(3600));
@@ -222,7 +222,7 @@ pub fn ledger_new_duplicated_slot_duration() {
     let header_id = TestGen::hash();
     let mut ie = ConfigParams::new();
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::SlotDuration(11u8));
     ie.push(ConfigParam::SlotsPerEpoch(10u32));
@@ -239,7 +239,7 @@ pub fn ledger_new_duplicated_epoch_stability_depth() {
     let mut ie = ConfigParams::new();
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
     ie.push(ConfigParam::ConsensusVersion(ConsensusType::Bft));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::EpochStabilityDepth(10u32));
     ie.push(ConfigParam::EpochStabilityDepth(11u32));
@@ -257,7 +257,7 @@ pub fn ledger_new_duplicated_active_slots_coeff() {
     let mut ie = ConfigParams::new();
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
     ie.push(ConfigParam::ConsensusVersion(ConsensusType::Bft));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(
         Milli::from_millis(500),
@@ -277,7 +277,7 @@ pub fn ledger_new_no_discrimination() {
     let leader_pair = TestGen::leader_pair();
     let header_id = TestGen::hash();
     let mut ie = ConfigParams::new();
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::Block0Date(crate::config::Block0Date(0)));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::SlotsPerEpoch(10u32));
@@ -297,7 +297,7 @@ pub fn ledger_new_no_slot_duration() {
     let header_id = TestGen::hash();
     let mut ie = ConfigParams::new();
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::Block0Date(crate::config::Block0Date(0)));
     ie.push(ConfigParam::SlotsPerEpoch(10u32));
     ie.push(ConfigParam::KesUpdateSpeed(3600));
@@ -316,7 +316,7 @@ pub fn ledger_new_no_slots_per_epoch() {
     let header_id = TestGen::hash();
     let mut ie = ConfigParams::new();
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::Block0Date(crate::config::Block0Date(0)));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::KesUpdateSpeed(3600));
@@ -335,7 +335,7 @@ pub fn ledger_new_no_kes_update_speed() {
     let header_id = TestGen::hash();
     let mut ie = ConfigParams::new();
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::Block0Date(crate::config::Block0Date(0)));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::SlotsPerEpoch(10u32));
@@ -382,7 +382,7 @@ pub fn wrong_fragment_at_block0(fragment: Fragment) -> TestResult {
     let leader_pair = TestGen::leader_pair();
     ie.push(ConfigParam::Block0Date(crate::config::Block0Date(0)));
     ie.push(ConfigParam::Discrimination(Discrimination::Test));
-    ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+    ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
     ie.push(ConfigParam::SlotDuration(10u8));
     ie.push(ConfigParam::SlotsPerEpoch(10u32));
     ie.push(ConfigParam::KesUpdateSpeed(3600));

--- a/chain-impl-mockchain/src/testing/data/leader.rs
+++ b/chain-impl-mockchain/src/testing/data/leader.rs
@@ -5,28 +5,24 @@ use std::fmt::{self, Debug};
 
 #[derive(Clone)]
 pub struct LeaderPair {
-    pub leader_id: BftLeaderId,
-    pub leader_key: SecretKey<Ed25519>,
+    leader_key: SecretKey<Ed25519>,
 }
 
 impl Debug for LeaderPair {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("LeaderPair")
-            .field("proposal", &self.id())
+            .field("leader id", &self.id())
             .finish()
     }
 }
 
 impl LeaderPair {
-    pub fn new(leader_id: BftLeaderId, leader_key: SecretKey<Ed25519>) -> Self {
-        LeaderPair {
-            leader_id,
-            leader_key,
-        }
+    pub fn new(leader_key: SecretKey<Ed25519>) -> Self {
+        LeaderPair { leader_key }
     }
 
     pub fn id(&self) -> BftLeaderId {
-        self.leader_id.clone()
+        BftLeaderId(self.leader_key.to_public())
     }
 
     pub fn key(&self) -> SecretKey<Ed25519> {
@@ -37,7 +33,6 @@ impl LeaderPair {
 impl Arbitrary for LeaderPair {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         LeaderPair {
-            leader_id: BftLeaderId::arbitrary(g),
             leader_key: KeyPair::<Ed25519>::arbitrary(g).private_key().clone(),
         }
     }

--- a/chain-impl-mockchain/src/testing/gen/mod.rs
+++ b/chain-impl-mockchain/src/testing/gen/mod.rs
@@ -15,7 +15,6 @@ use crate::{
     config::ConfigParam,
     fragment::config::ConfigParams,
     header::VrfProof,
-    key::BftLeaderId,
     ledger::Ledger,
     rewards::{Ratio, TaxType},
     setting::Settings,
@@ -82,12 +81,7 @@ impl TestGen {
         let leader_key = AddressData::generate_key_pair::<Ed25519>()
             .private_key()
             .clone();
-        let leader_id = BftLeaderId(
-            AddressData::generate_key_pair::<Ed25519>()
-                .public_key()
-                .clone(),
-        );
-        LeaderPair::new(leader_id, leader_key)
+        LeaderPair::new(leader_key)
     }
 
     pub fn secret_key() -> SecretKey<Ed25519> {
@@ -183,7 +177,7 @@ impl TestGen {
         let header_id = TestGen::hash();
         let mut ie = ConfigParams::new();
         ie.push(ConfigParam::Discrimination(Discrimination::Test));
-        ie.push(ConfigParam::AddBftLeader(leader_pair.leader_id));
+        ie.push(ConfigParam::AddBftLeader(leader_pair.id()));
         ie.push(ConfigParam::SlotDuration(10u8));
         ie.push(ConfigParam::SlotsPerEpoch(10u32));
         ie.push(ConfigParam::KesUpdateSpeed(3600));

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -493,7 +493,7 @@ mod tests {
 
         let signed_update_proposal = SignedProposalBuilder::new()
             .with_proposal_update(update_proposal)
-            .with_proposer_id(proposer.leader_id.clone())
+            .with_proposer_id(proposer.id())
             .build();
 
         update_state.apply_proposal(proposal_id, &signed_update_proposal, &settings, block_date)


### PR DESCRIPTION
This update should eliminate the possible mistake to create a LeaderPair instance with the two unrelated private and public keys, which actually has been done