### PR TITLE
Add combinator to serialize option type with bytebuilder conveniently

### DIFF
--- a/typed-bytes/src/builder.rs
+++ b/typed-bytes/src/builder.rs
@@ -170,7 +170,7 @@ impl<T> ByteBuilder<T> {
     /// The following call:
     ///
     /// ```no_run
-    /// byte_builder.option_or_else(value, none_call, some_call, none_call);
+    /// byte_builder.option_or_else(value, none_call, some_call);
     /// ```
     ///
     /// equivalent to the construction:

--- a/typed-bytes/src/builder.rs
+++ b/typed-bytes/src/builder.rs
@@ -169,13 +169,13 @@ impl<T> ByteBuilder<T> {
     ///
     /// The following call:
     ///
-    /// ```no_run
+    /// ```ignore
     /// byte_builder.option_or_else(value, none_call, some_call);
     /// ```
     ///
     /// equivalent to the construction:
     ///
-    /// ```no_run
+    /// ```ignore
     /// if let Some(value) = value {
     ///    some_call(byte_builder, value)
     /// } else {

--- a/typed-bytes/src/builder.rs
+++ b/typed-bytes/src/builder.rs
@@ -184,8 +184,8 @@ impl<T> ByteBuilder<T> {
     /// ```
     pub fn option_or_else<F, G, V>(self, value: Option<V>, default: G, f: F) -> Self
     where
-        F: Fn(Self, V) -> Self,
-        G: Fn(Self) -> Self,
+        F: FnOnce(Self, V) -> Self,
+        G: FnOnce(Self) -> Self,
     {
         match value {
             None => default(self),

--- a/typed-bytes/src/builder.rs
+++ b/typed-bytes/src/builder.rs
@@ -153,6 +153,46 @@ impl<T> ByteBuilder<T> {
         self.bytes(&v.to_be_bytes())
     }
 
+    /// Call 'f' on bytebuilder and the value if the value is present, then return
+    /// the bytebuilder, otherwise just return the bytebuilder
+    pub fn option<F, V>(self, value: Option<V>, f: F) -> Self
+    where
+        F: Fn(Self, V) -> Self,
+    {
+        self.option_or_else(value, |bb| bb, f)
+    }
+
+    /// Run the first closure if the value is not present, or the second closure with
+    /// the present parameter.
+    ///
+    /// this is loosely based on Option::map_or_else
+    ///
+    /// The following call:
+    ///
+    /// ```no_run
+    /// byte_builder.option_or_else(value, none_call, some_call, none_call);
+    /// ```
+    ///
+    /// equivalent to the construction:
+    ///
+    /// ```no_run
+    /// if let Some(value) = value {
+    ///    some_call(byte_builder, value)
+    /// } else {
+    ///    none_call(byte_builder)
+    /// }
+    /// ```
+    pub fn option_or_else<F, G, V>(self, value: Option<V>, default: G, f: F) -> Self
+    where
+        F: Fn(Self, V) -> Self,
+        G: Fn(Self) -> Self,
+    {
+        match value {
+            None => default(self),
+            Some(v) => f(self, v),
+        }
+    }
+
     /// Finalize the buffer and return a fixed ByteArray of T
     pub fn finalize(self) -> ByteArray<T> {
         match self.expected {

--- a/typed-bytes/src/builder.rs
+++ b/typed-bytes/src/builder.rs
@@ -157,7 +157,7 @@ impl<T> ByteBuilder<T> {
     /// the bytebuilder, otherwise just return the bytebuilder
     pub fn option<F, V>(self, value: Option<V>, f: F) -> Self
     where
-        F: Fn(Self, V) -> Self,
+        F: FnOnce(Self, V) -> Self,
     {
         self.option_or_else(value, |bb| bb, f)
     }


### PR DESCRIPTION
this is loosely based on Option::map_or_else but specialized to the bytebuilder.

this allow replacement of this simple repeative construction:
 
``` 
if let Some(value) = value {
    some_call(byte_builder, value)
} else {
    none_call(byte_builder)
}
```

by:

```
byte_builder.option_or_else(value, none_call, some_call);
```
