### PR TITLE
Fix early validation issue for update proposal

### DIFF
--- a/chain-impl-mockchain/src/ledger/iter.rs
+++ b/chain-impl-mockchain/src/ledger/iter.rs
@@ -356,7 +356,7 @@ impl<'a> std::iter::FromIterator<Entry<'a>> for Result<Ledger, Error> {
             utxos: utxos.into_iter().collect(),
             oldutxos: oldutxos.into_iter().collect(),
             accounts: accounts.into_iter().collect(),
-            settings: setting::Settings::new().apply(&config_params)?,
+            settings: setting::Settings::new().try_apply(&config_params)?,
             updates,
             multisig: multisig::Ledger::restore(multisig_accounts, multisig_declarations),
             delegation,

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -433,7 +433,7 @@ impl Ledger {
 
             let era = TimeEra::new(slot0, TimeEpoch(0), slots_per_epoch);
 
-            let settings = setting::Settings::new().apply(&regular_ents)?;
+            let settings = setting::Settings::new().try_apply(&regular_ents)?;
 
             if settings.bft_leaders.is_empty() {
                 return Err(Error::Block0(
@@ -787,11 +787,10 @@ impl Ledger {
         }
 
         // Process Update proposals if needed
-        let (updates, settings) = new_ledger.updates.process_proposals(
-            new_ledger.settings,
-            new_ledger.date,
-            block_date,
-        )?;
+        let (updates, settings) =
+            new_ledger
+                .updates
+                .process_proposals(new_ledger.settings, new_ledger.date, block_date);
         new_ledger.updates = updates;
         new_ledger.settings = settings;
 
@@ -1050,7 +1049,7 @@ impl Ledger {
     }
 
     pub fn apply_update(mut self, update: &UpdateProposal) -> Result<Self, Error> {
-        self.settings = self.settings.apply(update.changes())?;
+        self.settings = self.settings.try_apply(update.changes())?;
         Ok(self)
     }
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -136,7 +136,7 @@ impl Settings {
         self.linear_fees
     }
 
-    pub fn apply(&self, changes: &ConfigParams) -> Result<Self, update::Error> {
+    pub fn try_apply(&self, changes: &ConfigParams) -> Result<Self, update::Error> {
         let mut new_state = self.clone();
         let mut per_certificate_fees = None;
         let mut per_vote_certificate_fees = None;
@@ -284,7 +284,7 @@ impl Settings {
             None => (),
         };
 
-        debug_assert_eq!(self, &Settings::new().apply(&params).unwrap());
+        debug_assert_eq!(self, &Settings::new().try_apply(&params).unwrap());
 
         params
     }

--- a/chain-impl-mockchain/src/testing/gen/mod.rs
+++ b/chain-impl-mockchain/src/testing/gen/mod.rs
@@ -116,7 +116,7 @@ impl TestGen {
         for leader_id in leaders.iter().cloned().map(|x| x.id()) {
             config_params.push(ConfigParam::AddBftLeader(leader_id));
         }
-        settings.apply(&config_params).unwrap()
+        settings.try_apply(&config_params).unwrap()
     }
 
     pub fn vrf_proof(stake_pool: &StakePool) -> VrfProof {

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -229,6 +229,7 @@ impl From<ActiveSlotsCoeffError> for Error {
 mod tests {
     use super::*;
     use crate::certificate::UpdateProposal;
+    #[cfg(test)]
     use crate::milli::Milli;
     #[cfg(test)]
     use crate::testing::serialization::serialization_bijection;

--- a/chain-impl-mockchain/src/update.rs
+++ b/chain-impl-mockchain/src/update.rs
@@ -26,6 +26,8 @@ impl UpdateState {
     ) -> Result<Self, Error> {
         let proposer_id = proposal.proposer_id();
 
+        settings.try_apply(proposal.changes())?;
+
         if !settings.bft_leaders.contains(proposer_id) {
             return Err(Error::BadProposer(proposal_id, proposer_id.clone()));
         }
@@ -78,7 +80,7 @@ impl UpdateState {
         mut settings: Settings,
         prev_date: BlockDate,
         new_date: BlockDate,
-    ) -> Result<(Self, Settings), Error> {
+    ) -> (Self, Settings) {
         let mut expired_ids = vec![];
 
         assert!(prev_date < new_date);
@@ -101,7 +103,9 @@ impl UpdateState {
                 // If a majority of BFT leaders voted for the
                 // proposal, then apply it.
                 if proposal_state.votes.size() > settings.bft_leaders.len() / 2 {
-                    settings = settings.apply(proposal_state.proposal.changes())?;
+                    settings = settings
+                        .try_apply(proposal_state.proposal.changes())
+                        .unwrap();
                     expired_ids.push(*proposal_id);
                 } else if proposal_state.proposal_date.epoch + settings.proposal_expiration
                     < new_date.epoch
@@ -118,7 +122,7 @@ impl UpdateState {
             }
         }
 
-        Ok((self, settings))
+        (self, settings)
     }
 }
 
@@ -225,6 +229,7 @@ impl From<ActiveSlotsCoeffError> for Error {
 mod tests {
     use super::*;
     use crate::certificate::UpdateProposal;
+    use crate::milli::Milli;
     #[cfg(test)]
     use crate::testing::serialization::serialization_bijection;
     #[cfg(test)]
@@ -443,8 +448,8 @@ mod tests {
     }
 
     #[test]
-    fn process_proposals_for_readonly_setting_should_return_error() {
-        let mut update_state = UpdateState::new();
+    fn apply_for_readonly_setting_should_return_error() {
+        let update_state = UpdateState::new();
         let proposal_id = TestGen::hash();
         let proposer = TestGen::leader_pair();
         let block_date = BlockDate::first();
@@ -452,23 +457,43 @@ mod tests {
 
         let settings = TestGen::settings(vec![proposer.clone()]);
 
-        update_state = apply_update_proposal(
-            update_state,
-            proposal_id,
-            readonly_setting,
-            &proposer,
-            &settings,
-            block_date,
-        )
-        .expect("failed while applying proposal");
+        assert_eq!(
+            apply_update_proposal(
+                update_state,
+                proposal_id,
+                readonly_setting,
+                &proposer,
+                &settings,
+                block_date,
+            ),
+            Err(Error::ReadOnlySetting)
+        );
+    }
 
-        // Apply vote
-        update_state = apply_update_vote(update_state, proposal_id, &proposer, &settings)
-            .expect("failed while applying vote");
+    #[test]
+    fn apply_for_invalid_active_slot_coeff_should_return_error() {
+        let update_state = UpdateState::new();
+        let proposal_id = TestGen::hash();
+        let proposer = TestGen::leader_pair();
+        let block_date = BlockDate::first();
+        let overflow_milli = Milli::from_millis(Milli::ONE.to_millis() + 1);
+        let invalid_active_slot_coeff =
+            ConfigParam::ConsensusGenesisPraosActiveSlotsCoeff(overflow_milli);
+
+        let settings = TestGen::settings(vec![proposer.clone()]);
 
         assert_eq!(
-            update_state.process_proposals(settings, block_date, block_date.next_epoch()),
-            Err(Error::ReadOnlySetting)
+            apply_update_proposal(
+                update_state,
+                proposal_id,
+                invalid_active_slot_coeff,
+                &proposer,
+                &settings,
+                block_date,
+            ),
+            Err(Error::BadConsensusGenesisPraosActiveSlotsCoeff(
+                ActiveSlotsCoeffError::InvalidValue(overflow_milli)
+            ))
         );
     }
 
@@ -531,9 +556,8 @@ mod tests {
         )
         .expect("failed while applying vote");
 
-        let (update_state, settings) = update_state
-            .process_proposals(settings, block_date, block_date.next_epoch())
-            .expect("error while processing proposal");
+        let (update_state, settings) =
+            update_state.process_proposals(settings, block_date, block_date.next_epoch());
 
         match first_proposal_id.cmp(&second_proposal_id) {
             std::cmp::Ordering::Less => assert_eq!(settings.slots_per_epoch, 200),
@@ -607,13 +631,11 @@ mod tests {
         )
         .expect("failed while applying vote");
 
-        let (update_state, settings) = update_state
-            .process_proposals(
-                settings,
-                first_proposal_block_date,
-                first_proposal_block_date.next_epoch(),
-            )
-            .expect("error while processing proposal");
+        let (update_state, settings) = update_state.process_proposals(
+            settings,
+            first_proposal_block_date,
+            first_proposal_block_date.next_epoch(),
+        );
 
         assert_eq!(settings.slots_per_epoch, 200);
 
@@ -687,14 +709,11 @@ mod tests {
         // if proposal expiration period is not exceeded after that
         // proposal should be removed from proposal collection
         for _i in 0..expiry_block_data.get_last_epoch() {
-            let (update_state, _settings) = update_state
-                .clone()
-                .process_proposals(
-                    settings.clone(),
-                    current_block_date,
-                    current_block_date.next_epoch(),
-                )
-                .expect("error while processing proposal");
+            let (update_state, _settings) = update_state.clone().process_proposals(
+                settings.clone(),
+                current_block_date,
+                current_block_date.next_epoch(),
+            );
 
             if proposal_date.epoch + proposal_expiration <= current_block_date.epoch {
                 assert_eq!(update_state.proposals.size(), 0);


### PR DESCRIPTION
Fix issue for the UpdateProposal. Add validation of the `ConfigParams` during the applying update proposal into the ledger. Also update `process_proposals` function, it is not return an error anymore we assume that all update_proposals should be valid at this point.