### PR TITLE
test_ecverify add missing borrow

### DIFF
--- a/chain-evm/src/precompiles/secp256k1.rs
+++ b/chain-evm/src/precompiles/secp256k1.rs
@@ -131,7 +131,7 @@ mod tests {
                 .unwrap().try_into().unwrap();
         let signer =
             Address::from_slice(&hex::decode("1563915e194D8CfBA1943570603F7606A3115508").unwrap());
-        assert!(ecverify(hash, signature, signer));
+        assert!(ecverify(hash, &signature, signer));
     }
 
     #[test]


### PR DESCRIPTION
this fixes a compilation error introduced by mistake while merging two
branches

more specifically, #719 changed `ecverify` signature and I didn't rebase #720 before merging (because there were no conflicts, as it is a different line), so now code is not compiling.