### PR TITLE
move Environment field from EvmConfigParams to Ledger

### DIFF
--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -101,7 +101,7 @@ fn precompiles(fork: HardFork) -> Precompiles {
 impl<'runtime> VirtualMachine<'runtime> {
     /// Creates a new `VirtualMachine` given configuration parameters.
     pub fn new(config: &'runtime Config, environment: &'runtime Environment) -> Self {
-        Self::new_with_state(config, environment, Default::default())
+        Self::new_with_state(config, environment, Default::default(), Default::default())
     }
 
     /// Creates a new `VirtualMachine` given configuration params and a given account storage.
@@ -109,13 +109,14 @@ impl<'runtime> VirtualMachine<'runtime> {
         config: &'runtime Config,
         environment: &'runtime Environment,
         state: AccountTrie,
+        logs: LogsState,
     ) -> Self {
         Self {
             config,
             environment,
             precompiles: precompiles(HardFork::Berlin),
             state,
-            logs: Default::default(),
+            logs,
         }
     }
 

--- a/chain-impl-mockchain/src/ledger/evm.rs
+++ b/chain-impl-mockchain/src/ledger/evm.rs
@@ -5,26 +5,49 @@ use chain_evm::{
     state::{AccountTrie, Balance, LogsState},
 };
 
-#[derive(Default, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Ledger {
     pub(crate) accounts: AccountTrie,
     pub(crate) logs: LogsState,
+    pub(crate) environment: Environment,
+}
+
+impl Default for Ledger {
+    fn default() -> Self {
+        Self {
+            accounts: Default::default(),
+            logs: Default::default(),
+            environment: Environment {
+                gas_price: Default::default(),
+                origin: Default::default(),
+                chain_id: Default::default(),
+                block_hashes: Default::default(),
+                block_number: Default::default(),
+                block_coinbase: Default::default(),
+                block_timestamp: Default::default(),
+                block_difficulty: Default::default(),
+                block_gas_limit: Default::default(),
+                block_base_fee_per_gas: Default::default(),
+            },
+        }
+    }
 }
 
 impl Ledger {
     pub fn new() -> Self {
-        Self {
-            accounts: Default::default(),
-            logs: Default::default(),
-        }
+        Default::default()
     }
     pub fn run_transaction<'runtime>(
         &mut self,
         contract: EvmTransaction,
         config: &'runtime Config,
-        environment: &'runtime Environment,
     ) -> Result<(), Error> {
-        let mut vm = self.virtual_machine(config, environment);
+        let mut vm = VirtualMachine::new_with_state(
+            config,
+            &self.environment,
+            self.accounts.clone(),
+            self.logs.clone(),
+        );
         match contract {
             EvmTransaction::Create {
                 caller,
@@ -84,14 +107,6 @@ impl Ledger {
                 Ok(())
             }
         }
-    }
-
-    pub(crate) fn virtual_machine<'runtime>(
-        &self,
-        config: &'runtime Config,
-        environment: &'runtime Environment,
-    ) -> VirtualMachine<'runtime> {
-        VirtualMachine::new_with_state(config, environment, self.accounts.clone())
     }
 }
 

--- a/chain-impl-mockchain/src/ledger/evm.rs
+++ b/chain-impl-mockchain/src/ledger/evm.rs
@@ -37,10 +37,10 @@ impl Ledger {
     pub fn new() -> Self {
         Default::default()
     }
-    pub fn run_transaction<'runtime>(
+    pub fn run_transaction(
         &mut self,
         contract: EvmTransaction,
-        config: &'runtime Config,
+        config: &Config,
     ) -> Result<(), Error> {
         let mut vm = VirtualMachine::new_with_state(
             config,

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -522,8 +522,7 @@ impl Ledger {
                     {
                         let tx = _tx.as_slice().payload().into_payload();
                         let config = &ledger.settings.evm_params.config.into();
-                        let environment = &ledger.settings.evm_params.environment;
-                        ledger.evm.run_transaction(tx, config, environment)?;
+                        ledger.evm.run_transaction(tx, config)?;
                     }
                     #[cfg(not(feature = "evm"))]
                     {
@@ -1044,8 +1043,7 @@ impl Ledger {
                 {
                     let tx = _tx.as_slice().payload().into_payload();
                     let config = &new_ledger.settings.evm_params.config.into();
-                    let environment = &new_ledger.settings.evm_params.environment;
-                    new_ledger.evm.run_transaction(tx, config, environment)?;
+                    new_ledger.evm.run_transaction(tx, config)?;
                 }
                 #[cfg(not(feature = "evm"))]
                 {

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -521,7 +521,7 @@ impl Ledger {
                     #[cfg(feature = "evm")]
                     {
                         let tx = _tx.as_slice().payload().into_payload();
-                        let config = &ledger.settings.evm_params.config.into();
+                        let config = &ledger.settings.evm_params.into();
                         ledger.evm.run_transaction(tx, config)?;
                     }
                     #[cfg(not(feature = "evm"))]
@@ -1042,7 +1042,7 @@ impl Ledger {
                 #[cfg(feature = "evm")]
                 {
                     let tx = _tx.as_slice().payload().into_payload();
-                    let config = &new_ledger.settings.evm_params.config.into();
+                    let config = &new_ledger.settings.evm_params.into();
                     new_ledger.evm.run_transaction(tx, config)?;
                 }
                 #[cfg(not(feature = "evm"))]

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -2,7 +2,7 @@
 //!
 
 #[cfg(feature = "evm")]
-use crate::config::EvmConfigParams;
+use crate::config::EvmConfig;
 use crate::fragment::{config::ConfigParams, BlockContentSize};
 use crate::milli::Milli;
 use crate::update;
@@ -44,7 +44,7 @@ pub struct Settings {
     pub committees: Arc<[CommitteeId]>,
     pub transaction_max_expiry_epochs: u8,
     #[cfg(feature = "evm")]
-    pub evm_params: EvmConfigParams,
+    pub evm_params: EvmConfig,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -133,7 +133,7 @@ impl Settings {
             committees: Arc::new([]),
             transaction_max_expiry_epochs: 1,
             #[cfg(feature = "evm")]
-            evm_params: EvmConfigParams::default(),
+            evm_params: EvmConfig::default(),
         }
     }
 
@@ -246,7 +246,7 @@ impl Settings {
                 }
                 #[cfg(feature = "evm")]
                 ConfigParam::EvmParams(evm_config_params) => {
-                    new_state.evm_params = *evm_config_params.clone();
+                    new_state.evm_params = evm_config_params.clone();
                 }
             }
         }
@@ -293,7 +293,7 @@ impl Settings {
             None => (),
         };
         #[cfg(feature = "evm")]
-        params.push(ConfigParam::EvmParams(Box::new(self.evm_params.clone())));
+        params.push(ConfigParam::EvmParams(self.evm_params.clone()));
 
         debug_assert_eq!(self, &Settings::new().try_apply(&params).unwrap());
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -246,7 +246,7 @@ impl Settings {
                 }
                 #[cfg(feature = "evm")]
                 ConfigParam::EvmParams(evm_config_params) => {
-                    new_state.evm_params = evm_config_params.clone();
+                    new_state.evm_params = *evm_config_params;
                 }
             }
         }
@@ -293,7 +293,7 @@ impl Settings {
             None => (),
         };
         #[cfg(feature = "evm")]
-        params.push(ConfigParam::EvmParams(self.evm_params.clone()));
+        params.push(ConfigParam::EvmParams(self.evm_params));
 
         debug_assert_eq!(self, &Settings::new().try_apply(&params).unwrap());
 

--- a/chain-impl-mockchain/src/testing/ledger.rs
+++ b/chain-impl-mockchain/src/testing/ledger.rs
@@ -32,11 +32,6 @@ use crate::{
 };
 use chain_addr::{Address, Discrimination};
 use chain_crypto::*;
-#[cfg(feature = "evm")]
-use chain_evm::machine::{
-    BlockCoinBase, BlockDifficulty, BlockHashes, BlockNumber, BlockTimestamp, ChainId, Environment,
-    GasLimit, GasPrice, Origin,
-};
 use chain_time::TimeEra;
 use std::{
     collections::HashMap,
@@ -112,22 +107,6 @@ impl ConfigBuilder {
             #[cfg(feature = "evm")]
             evm_params: EvmConfigParams {
                 config: EvmConfig::Istanbul,
-                environment: Environment {
-                    // FIXME: need to set a real price
-                    gas_price: GasPrice::default(),
-                    // Define the origin address with a random H160 address
-                    origin: Origin::random(),
-                    chain_id: ChainId::zero(),
-                    block_hashes: BlockHashes::new(),
-                    block_number: BlockNumber::zero(),
-                    block_coinbase: BlockCoinBase::zero(),
-                    block_timestamp: BlockTimestamp::zero() + 1,
-                    block_difficulty: BlockDifficulty::from(131_072),
-                    // FIXME: need to set a real limit
-                    block_gas_limit: GasLimit::max_value(),
-                    // FIXME: adequate base fee
-                    block_base_fee_per_gas: 1u32.into(),
-                },
             },
         }
     }

--- a/chain-impl-mockchain/src/testing/ledger.rs
+++ b/chain-impl-mockchain/src/testing/ledger.rs
@@ -1,7 +1,7 @@
 use quickcheck::{Arbitrary, Gen};
 
 #[cfg(feature = "evm")]
-use crate::config::{EvmConfig, EvmConfigParams};
+use crate::config::EvmConfig;
 use crate::{
     account::Ledger as AccountLedger,
     block::Block,
@@ -61,7 +61,7 @@ pub struct ConfigBuilder {
     pool_capping_ratio: Ratio,
     transaction_max_expiry_epochs: Option<u8>,
     #[cfg(feature = "evm")]
-    evm_params: EvmConfigParams,
+    evm_params: EvmConfig,
 }
 
 impl Default for ConfigBuilder {
@@ -105,9 +105,7 @@ impl ConfigBuilder {
             consensus_version: ConsensusVersion::Bft,
             transaction_max_expiry_epochs: None,
             #[cfg(feature = "evm")]
-            evm_params: EvmConfigParams {
-                config: EvmConfig::Istanbul,
-            },
+            evm_params: EvmConfig::Istanbul,
         }
     }
 
@@ -222,7 +220,7 @@ impl ConfigBuilder {
     }
 
     #[cfg(feature = "evm")]
-    pub fn with_evm_params(mut self, params: EvmConfigParams) -> Self {
+    pub fn with_evm_params(mut self, params: EvmConfig) -> Self {
         self.evm_params = params;
         self
     }


### PR DESCRIPTION
It is more relevant to store Environment field in the Ledger , because Environment describes the current state of the which is needed for the EVM.