### PR TITLE
make token_distribution pub instead of pub(crate)

### DIFF
--- a/chain-impl-mockchain/src/ledger/mod.rs
+++ b/chain-impl-mockchain/src/ledger/mod.rs
@@ -10,7 +10,7 @@ pub mod ledger;
 mod pots;
 pub mod recovery;
 mod reward_info;
-pub(crate) mod token_distribution;
+pub mod token_distribution;
 
 pub use iter::*;
 pub use leaderlog::LeadersParticipationRecord;


### PR DESCRIPTION
Given that start_private_tally and public_tally need it and are public, being able to call the constructors is needed too.

These functions are used at least in catalyst-toolbox, so there is at least one place where those constructors are needed.