### PR TITLE
ledger: add voting distribution getters

### DIFF
--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -1194,8 +1194,7 @@ impl Ledger {
 
         let mut actions = Vec::new();
 
-        let token_distribution =
-            TokenDistribution::new(self.token_totals.clone(), self.accounts.clone());
+        let token_distribution = self.token_distribution();
 
         self.votes = self.votes.apply_committee_result(
             self.date(),
@@ -1237,8 +1236,7 @@ impl Ledger {
             return Err(Error::VoteTallyProofFailed);
         }
 
-        let token_distribution =
-            TokenDistribution::new(self.token_totals.clone(), self.accounts.clone());
+        let token_distribution = self.token_distribution();
 
         self.votes = self.votes.apply_encrypted_vote_tally(
             self.date(),
@@ -1395,6 +1393,14 @@ impl Ledger {
 
     pub fn accounts(&self) -> &account::Ledger {
         &self.accounts
+    }
+
+    pub fn token_totals(&self) -> &TokenTotals {
+        &self.token_totals
+    }
+
+    pub fn token_distribution(&self) -> TokenDistribution<()> {
+        TokenDistribution::new(self.token_totals.clone(), self.accounts.clone())
     }
 
     pub fn get_ledger_parameters(&self) -> LedgerParameters {


### PR DESCRIPTION
mainly as helpers for test data generation in catalyst-toolbox

This is actually for the same reason that I did #735, only to realize that it's not really enough because `TokenTotals` doesn't have a public constructor. But after giving it a bit more thought, just being able to get them from the ledger is enough.

https://github.com/input-output-hk/catalyst-toolbox/blob/5fe5408fb99764709f20febeda32bae089677c6b/tests/tally/generator.rs#L176

That's the code that we need to replace, and we already have a ledger, so we just need to be able to access the state.