### PR TITLE
add EVM environment params to ledger settings

### DIFF
--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -26,10 +26,7 @@ use crate::{
 };
 
 /// Export EVM types
-pub use evm::{
-    backend::{Log, MemoryVicinity as Environment},
-    Config, ExitReason,
-};
+pub use evm::{backend::Log, Config, ExitReason};
 
 /// An address of an EVM account.
 pub type Address = H160;
@@ -55,6 +52,9 @@ pub type BlockDifficulty = U256;
 /// A block's gas limit.
 pub type BlockGasLimit = U256;
 
+/// A block's base fee per gas.
+pub type BlockBaseFeePerGas = U256;
+
 /// A block's origin
 pub type Origin = H160;
 
@@ -69,6 +69,21 @@ pub type GasPrice = U256;
 
 /// Gas limit for EVM operations.
 pub type GasLimit = U256;
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+/// EVM Environment parameters needed for execution.
+pub struct Environment {
+    pub gas_price: GasPrice,
+    pub origin: Origin,
+    pub chain_id: ChainId,
+    pub block_hashes: BlockHashes,
+    pub block_number: BlockNumber,
+    pub block_coinbase: BlockCoinBase,
+    pub block_timestamp: BlockTimestamp,
+    pub block_difficulty: BlockDifficulty,
+    pub block_gas_limit: BlockGasLimit,
+    pub block_base_fee_per_gas: BlockBaseFeePerGas,
+}
 
 /// Integer of the value sent with an EVM transaction.
 pub type Value = U256;

--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -90,7 +90,7 @@ pub enum ConfigParam {
     #[cfg(feature = "evm")]
     EvmConfiguration(EvmConfig),
     #[cfg(feature = "evm")]
-    EvmEnvironment(Environment),
+    EvmEnvironment(EvmEnvironment),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -135,6 +135,11 @@ impl Default for EvmConfig {
         EvmConfig::Berlin
     }
 }
+
+#[cfg(feature = "evm")]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+/// EVM Environment parameters needed for execution.
+pub struct EvmEnvironment(pub(crate) Environment);
 
 // Discriminants can NEVER be 1024 or higher
 #[derive(AsRefStr, Clone, Copy, Debug, EnumIter, EnumString, PartialEq)]
@@ -830,22 +835,22 @@ impl ConfigParamVariant for EvmConfig {
 }
 
 #[cfg(feature = "evm")]
-impl ConfigParamVariant for Environment {
+impl ConfigParamVariant for EvmEnvironment {
     fn to_payload(&self) -> Vec<u8> {
         use crate::evm::{serialize_address, serialize_h256, serialize_u256};
         let bb: ByteBuilder<Environment> = ByteBuilder::new();
-        let bb = serialize_u256(bb, &self.gas_price);
-        let bb = serialize_address(bb, &self.origin);
-        let bb = serialize_u256(bb, &self.chain_id);
+        let bb = serialize_u256(bb, &self.0.gas_price);
+        let bb = serialize_address(bb, &self.0.origin);
+        let bb = serialize_u256(bb, &self.0.chain_id);
         let bb = bb
-            .u64(self.block_hashes.len() as u64)
-            .fold(self.block_hashes.iter(), serialize_h256);
-        let bb = serialize_u256(bb, &self.block_number);
-        let bb = serialize_address(bb, &self.block_coinbase);
-        let bb = serialize_u256(bb, &self.block_timestamp);
-        let bb = serialize_u256(bb, &self.block_difficulty);
-        let bb = serialize_u256(bb, &self.block_gas_limit);
-        let bb = serialize_u256(bb, &self.block_base_fee_per_gas);
+            .u64(self.0.block_hashes.len() as u64)
+            .fold(self.0.block_hashes.iter(), serialize_h256);
+        let bb = serialize_u256(bb, &self.0.block_number);
+        let bb = serialize_address(bb, &self.0.block_coinbase);
+        let bb = serialize_u256(bb, &self.0.block_timestamp);
+        let bb = serialize_u256(bb, &self.0.block_difficulty);
+        let bb = serialize_u256(bb, &self.0.block_gas_limit);
+        let bb = serialize_u256(bb, &self.0.block_base_fee_per_gas);
         bb.finalize_as_vec()
     }
 
@@ -866,7 +871,7 @@ impl ConfigParamVariant for Environment {
         let block_gas_limit = read_u256(&mut buf)?;
         let block_base_fee_per_gas = read_u256(&mut buf)?;
         buf.expect_end()?;
-        Ok(Self {
+        Ok(Self(Environment {
             gas_price,
             origin,
             chain_id,
@@ -877,7 +882,7 @@ impl ConfigParamVariant for Environment {
             block_difficulty,
             block_gas_limit,
             block_base_fee_per_gas,
-        })
+        }))
     }
 }
 

--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -194,6 +194,7 @@ pub enum Tag {
     #[cfg(feature = "evm")]
     #[strum(to_string = "evm-config-params")]
     EvmConfiguration = 30,
+    #[cfg(feature = "evm")]
     #[strum(to_string = "evm-environment-params")]
     EvmEnvironment = 31,
 }

--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -849,9 +849,34 @@ impl ConfigParamVariant for Environment {
     }
 
     fn from_payload(payload: &[u8]) -> Result<Self, Error> {
-        //let mut _rb = ReadBuf::from(payload);
-
-        todo!("fields need to be defined");
+        use crate::evm::{read_address, read_h256, read_u256};
+        let mut buf = ReadBuf::from(payload);
+        let gas_price = read_u256(&mut buf)?;
+        let origin = read_address(&mut buf)?;
+        let chain_id = read_u256(&mut buf)?;
+        let block_hashes_len = buf.get_u64()?;
+        let block_hashes = (0..block_hashes_len)
+            .map(|_| read_h256(&mut buf).unwrap())
+            .collect();
+        let block_number = read_u256(&mut buf)?;
+        let block_coinbase = read_address(&mut buf)?;
+        let block_timestamp = read_u256(&mut buf)?;
+        let block_difficulty = read_u256(&mut buf)?;
+        let block_gas_limit = read_u256(&mut buf)?;
+        let block_base_fee_per_gas = read_u256(&mut buf)?;
+        buf.expect_end()?;
+        Ok(Self {
+            gas_price,
+            origin,
+            chain_id,
+            block_hashes,
+            block_number,
+            block_coinbase,
+            block_timestamp,
+            block_difficulty,
+            block_gas_limit,
+            block_base_fee_per_gas,
+        })
     }
 }
 

--- a/chain-impl-mockchain/src/evm/mod.rs
+++ b/chain-impl-mockchain/src/evm/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 #[cfg(feature = "evm")]
-pub use chain_evm::machine::{Config, Environment};
+pub use chain_evm::machine::{BlockGasLimit, Config, Environment, GasPrice};
 
 /// Variants of supported EVM transactions
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/chain-impl-mockchain/src/evm/mod.rs
+++ b/chain-impl-mockchain/src/evm/mod.rs
@@ -15,6 +15,9 @@ use crate::{
     transaction::{Payload, PayloadAuthData, PayloadData},
 };
 
+#[cfg(feature = "evm")]
+pub use chain_evm::machine::{Config, Environment};
+
 /// Variants of supported EVM transactions
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EvmTransaction {
@@ -107,28 +110,22 @@ impl EvmTransaction {
 }
 
 #[cfg(feature = "evm")]
-fn serialize_address(
-    bb: ByteBuilder<EvmTransaction>,
-    caller: &Address,
-) -> ByteBuilder<EvmTransaction> {
+/// Serializes H160 types as fixed bytes.
+pub fn serialize_address<T>(bb: ByteBuilder<T>, caller: &Address) -> ByteBuilder<T> {
     bb.bytes(caller.as_fixed_bytes())
 }
 
 #[cfg(feature = "evm")]
-fn serialize_u256(
-    bb: ByteBuilder<EvmTransaction>,
-    value: &primitive_types::U256,
-) -> ByteBuilder<EvmTransaction> {
+/// Serializes U256 types as fixed bytes.
+pub fn serialize_u256<T>(bb: ByteBuilder<T>, value: &primitive_types::U256) -> ByteBuilder<T> {
     let mut value_bytes = [0u8; 32];
     value.to_big_endian(&mut value_bytes);
     bb.bytes(&value_bytes)
 }
 
 #[cfg(feature = "evm")]
-fn serialize_h256(
-    bb: ByteBuilder<EvmTransaction>,
-    value: &primitive_types::H256,
-) -> ByteBuilder<EvmTransaction> {
+/// Serializes H256 types as fixed bytes.
+pub fn serialize_h256<T>(bb: ByteBuilder<T>, value: &primitive_types::H256) -> ByteBuilder<T> {
     bb.bytes(value.as_fixed_bytes())
 }
 

--- a/chain-impl-mockchain/src/ledger/evm.rs
+++ b/chain-impl-mockchain/src/ledger/evm.rs
@@ -99,7 +99,11 @@ impl Ledger {
                 self.logs = new_logs.clone();
             }
         }
-        // update the environment
+
+        self.update_environment();
+        Ok(())
+    }
+    fn update_environment(&mut self) {
         let next_number = self.environment.block_number + BlockNumber::one();
         // this is a simplified block hash calculation
         let next_hash: BlockHash = <[u8; 32]>::from(next_number).into();
@@ -110,7 +114,6 @@ impl Ledger {
         );
         self.environment.block_number = next_number;
         // TODO: update block timestamp
-        Ok(())
     }
 }
 

--- a/chain-impl-mockchain/src/ledger/evm.rs
+++ b/chain-impl-mockchain/src/ledger/evm.rs
@@ -99,11 +99,10 @@ impl Ledger {
                 self.logs = new_logs.clone();
             }
         }
-
-        self.update_environment();
         Ok(())
     }
-    fn update_environment(&mut self) {
+    /// Updates EVM environment
+    pub fn update_environment(&mut self) {
         let next_number = self.environment.block_number + BlockNumber::one();
         // this is a simplified block hash calculation
         let next_hash: BlockHash = <[u8; 32]>::from(next_number).into();

--- a/chain-impl-mockchain/src/ledger/evm.rs
+++ b/chain-impl-mockchain/src/ledger/evm.rs
@@ -1,3 +1,4 @@
+use crate::chaineval::HeaderContentEvalContext;
 use crate::evm::EvmTransaction;
 use crate::ledger::Error;
 use chain_evm::{
@@ -101,17 +102,12 @@ impl Ledger {
         }
         Ok(())
     }
-    /// Updates EVM environment
-    pub fn update_environment(&mut self) {
-        let next_number = self.environment.block_number + BlockNumber::one();
-        // this is a simplified block hash calculation
-        let next_hash: BlockHash = <[u8; 32]>::from(next_number).into();
+    /// Updates block values for EVM environment
+    pub fn update_block_environment(&mut self, metadata: &HeaderContentEvalContext) {
+        // use content hash from the apply block as the EVM block hash
+        let next_hash: BlockHash = <[u8; 32]>::from(metadata.content_hash).into();
         self.environment.block_hashes.insert(0, next_hash);
-        assert_eq!(
-            BlockNumber::from(self.environment.block_hashes.len()),
-            next_number
-        );
-        self.environment.block_number = next_number;
+        self.environment.block_number = BlockNumber::from(self.environment.block_hashes.len());
         // TODO: update block timestamp
     }
 }

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -1723,6 +1723,9 @@ impl ApplyBlockLedger {
             }
         };
 
+        #[cfg(feature = "evm")]
+        new_ledger.evm.update_environment();
+
         new_ledger
     }
 }

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -1054,7 +1054,7 @@ impl Ledger {
                 #[cfg(feature = "evm")]
                 {
                     let tx = _tx.as_slice().payload().into_payload();
-                    let config = &new_ledger.settings.evm_params.into();
+                    let config = &new_ledger.settings.evm_config.into();
                     new_ledger.evm.run_transaction(tx, config)?;
                 }
                 #[cfg(not(feature = "evm"))]

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -524,7 +524,7 @@ impl Ledger {
                     #[cfg(feature = "evm")]
                     {
                         let tx = _tx.as_slice().payload().into_payload();
-                        let config = &ledger.settings.evm_params.into();
+                        let config = &ledger.settings.evm_config.into();
                         ledger.evm.run_transaction(tx, config)?;
                     }
                     #[cfg(not(feature = "evm"))]

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -813,6 +813,20 @@ impl Ledger {
         new_ledger.updates = updates;
         new_ledger.settings = settings;
 
+        #[cfg(feature = "evm")]
+        {
+            // Set EVM environment values derived from block0 values
+            new_ledger.evm.environment.chain_id =
+                <[u8; 32]>::from(new_ledger.static_params.block0_initial_hash).into();
+            // TODO: set Origin, coinbase, and set block timestamp when
+            // they are defined. Using default values meanwhile.
+
+            // Set EVM environment values from settings
+            new_ledger.evm.environment.gas_price = new_ledger.settings.evm_environment.gas_price;
+            new_ledger.evm.environment.block_gas_limit =
+                new_ledger.settings.evm_environment.block_gas_limit;
+        }
+
         Ok(ApplyBlockLedger {
             ledger_params: new_ledger.get_ledger_parameters(),
             ledger: new_ledger,

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -2,7 +2,7 @@
 //!
 
 #[cfg(feature = "evm")]
-use crate::config::EvmConfig;
+use crate::config::{EvmConfig, EvmEnvironment};
 use crate::fragment::{config::ConfigParams, BlockContentSize};
 use crate::milli::Milli;
 use crate::update;
@@ -44,7 +44,9 @@ pub struct Settings {
     pub committees: Arc<[CommitteeId]>,
     pub transaction_max_expiry_epochs: u8,
     #[cfg(feature = "evm")]
-    pub evm_params: EvmConfig,
+    pub evm_config: EvmConfig,
+    #[cfg(feature = "evm")]
+    pub evm_environment: EvmEnvironment,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -133,7 +135,9 @@ impl Settings {
             committees: Arc::new([]),
             transaction_max_expiry_epochs: 1,
             #[cfg(feature = "evm")]
-            evm_params: EvmConfig::default(),
+            evm_config: EvmConfig::default(),
+            #[cfg(feature = "evm")]
+            evm_environment: EvmEnvironment::default(),
         }
     }
 
@@ -245,8 +249,12 @@ impl Settings {
                     new_state.transaction_max_expiry_epochs = *max_expiry_epochs;
                 }
                 #[cfg(feature = "evm")]
-                ConfigParam::EvmParams(evm_config_params) => {
-                    new_state.evm_params = *evm_config_params;
+                ConfigParam::EvmConfiguration(evm_config_params) => {
+                    new_state.evm_config = *evm_config_params;
+                }
+                #[cfg(feature = "evm")]
+                ConfigParam::EvmEnvironment(evm_env_params) => {
+                    new_state.evm_environment = *evm_env_params;
                 }
             }
         }
@@ -293,7 +301,7 @@ impl Settings {
             None => (),
         };
         #[cfg(feature = "evm")]
-        params.push(ConfigParam::EvmParams(self.evm_params));
+        params.push(ConfigParam::EvmConfiguration(self.evm_config));
 
         debug_assert_eq!(self, &Settings::new().try_apply(&params).unwrap());
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -256,7 +256,7 @@ impl Settings {
                 }
                 #[cfg(feature = "evm")]
                 ConfigParam::EvmEnvironment(evm_env_params) => {
-                    new_state.evm_environment = evm_env_params.clone();
+                    new_state.evm_environment = evm_env_params.0.clone();
                 }
             }
         }

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -2,7 +2,7 @@
 //!
 
 #[cfg(feature = "evm")]
-use crate::config::EvmConfig;
+use crate::config::{EvmConfig, EvmEnvironment};
 use crate::fragment::{config::ConfigParams, BlockContentSize};
 use crate::milli::Milli;
 use crate::update;
@@ -15,8 +15,6 @@ use crate::{
     rewards,
     vote::CommitteeId,
 };
-#[cfg(feature = "evm")]
-use chain_evm::machine::Environment as EvmEnvironment;
 use std::error::Error;
 use std::fmt;
 use std::num::NonZeroU32;
@@ -256,7 +254,7 @@ impl Settings {
                 }
                 #[cfg(feature = "evm")]
                 ConfigParam::EvmEnvironment(evm_env_params) => {
-                    new_state.evm_environment = evm_env_params.0.clone();
+                    new_state.evm_environment = *evm_env_params.clone();
                 }
             }
         }
@@ -304,6 +302,10 @@ impl Settings {
         };
         #[cfg(feature = "evm")]
         params.push(ConfigParam::EvmConfiguration(self.evm_config));
+        #[cfg(feature = "evm")]
+        params.push(ConfigParam::EvmEnvironment(Box::new(EvmEnvironment(
+            self.evm_environment.0.clone(),
+        ))));
 
         debug_assert_eq!(self, &Settings::new().try_apply(&params).unwrap());
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -2,7 +2,7 @@
 //!
 
 #[cfg(feature = "evm")]
-use crate::config::{EvmConfig, EvmEnvironment};
+use crate::config::{EvmConfig, EvmEnvSettings};
 use crate::fragment::{config::ConfigParams, BlockContentSize};
 use crate::milli::Milli;
 use crate::update;
@@ -46,7 +46,7 @@ pub struct Settings {
     #[cfg(feature = "evm")]
     pub evm_config: EvmConfig,
     #[cfg(feature = "evm")]
-    pub evm_environment: EvmEnvironment,
+    pub evm_environment: EvmEnvSettings,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -137,7 +137,7 @@ impl Settings {
             #[cfg(feature = "evm")]
             evm_config: EvmConfig::default(),
             #[cfg(feature = "evm")]
-            evm_environment: EvmEnvironment::default(),
+            evm_environment: EvmEnvSettings::default(),
         }
     }
 
@@ -254,7 +254,7 @@ impl Settings {
                 }
                 #[cfg(feature = "evm")]
                 ConfigParam::EvmEnvironment(evm_env_params) => {
-                    new_state.evm_environment = *evm_env_params.clone();
+                    new_state.evm_environment = evm_env_params.clone();
                 }
             }
         }
@@ -303,9 +303,7 @@ impl Settings {
         #[cfg(feature = "evm")]
         params.push(ConfigParam::EvmConfiguration(self.evm_config));
         #[cfg(feature = "evm")]
-        params.push(ConfigParam::EvmEnvironment(Box::new(EvmEnvironment(
-            self.evm_environment.0.clone(),
-        ))));
+        params.push(ConfigParam::EvmEnvironment(self.evm_environment.clone()));
 
         debug_assert_eq!(self, &Settings::new().try_apply(&params).unwrap());
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -2,7 +2,7 @@
 //!
 
 #[cfg(feature = "evm")]
-use crate::config::{EvmConfig, EvmEnvironment};
+use crate::config::EvmConfig;
 use crate::fragment::{config::ConfigParams, BlockContentSize};
 use crate::milli::Milli;
 use crate::update;
@@ -15,6 +15,8 @@ use crate::{
     rewards,
     vote::CommitteeId,
 };
+#[cfg(feature = "evm")]
+use chain_evm::machine::Environment as EvmEnvironment;
 use std::error::Error;
 use std::fmt;
 use std::num::NonZeroU32;
@@ -254,7 +256,7 @@ impl Settings {
                 }
                 #[cfg(feature = "evm")]
                 ConfigParam::EvmEnvironment(evm_env_params) => {
-                    new_state.evm_environment = *evm_env_params;
+                    new_state.evm_environment = evm_env_params.clone();
                 }
             }
         }


### PR DESCRIPTION
EVM environment parameters evolve along with the current block state in the EVM ledger, and are used by the virtual machine to perform calculations.

This is separate from the configurations defined by the Hard-Fork in use.

This branch is a work in progress.