### PR TITLE
Update EVM block timestamp params

### DIFF
--- a/chain-impl-mockchain/src/accounting/account/mod.rs
+++ b/chain-impl-mockchain/src/accounting/account/mod.rs
@@ -271,16 +271,16 @@ mod tests {
             let mut ledger = Ledger::new();
 
             // Add all arbitrary accounts
-            for account_id in arbitrary_accounts_ids.iter().cloned() {
+            for account_id in arbitrary_accounts_ids.iter() {
                 ledger = ledger
-                    .add_account(&account_id, AverageValue::arbitrary(gen).into(), ())
+                    .add_account(account_id, AverageValue::arbitrary(gen).into(), ())
                     .unwrap();
 
                 for token in &arbitrary_voting_tokens {
                     // TODO: maybe less probability is better (for performance)
                     if bool::arbitrary(gen) {
                         ledger = ledger
-                            .token_add(&account_id, token.clone(), Value::arbitrary(gen))
+                            .token_add(account_id, token.clone(), Value::arbitrary(gen))
                             .unwrap();
                     }
                 }

--- a/chain-impl-mockchain/src/config.rs
+++ b/chain-impl-mockchain/src/config.rs
@@ -110,7 +110,7 @@ pub enum RewardParams {
 }
 
 #[cfg(feature = "evm")]
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 /// Settings for EVM Environment
 pub struct EvmEnvSettings {
     pub gas_price: GasPrice,

--- a/chain-impl-mockchain/src/ledger/evm.rs
+++ b/chain-impl-mockchain/src/ledger/evm.rs
@@ -11,10 +11,24 @@ pub struct Ledger {
     pub(crate) accounts: AccountTrie,
     pub(crate) logs: LogsState,
     pub(crate) environment: Environment,
+    pub(crate) current_epoch: BlockEpoch,
 }
 
 impl Default for Ledger {
     fn default() -> Self {
+        Ledger::new()
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct BlockEpoch {
+    epoch: u32,
+    slots_per_epoch: u32,
+    slot_duration: u8,
+}
+
+impl Ledger {
+    pub fn new() -> Self {
         Self {
             accounts: Default::default(),
             logs: Default::default(),
@@ -30,13 +44,12 @@ impl Default for Ledger {
                 block_gas_limit: Default::default(),
                 block_base_fee_per_gas: Default::default(),
             },
+            current_epoch: BlockEpoch {
+                epoch: 0,
+                slots_per_epoch: 1,
+                slot_duration: 10,
+            },
         }
-    }
-}
-
-impl Ledger {
-    pub fn new() -> Self {
-        Default::default()
     }
     pub fn run_transaction(
         &mut self,

--- a/chain-impl-mockchain/src/ledger/iter.rs
+++ b/chain-impl-mockchain/src/ledger/iter.rs
@@ -377,7 +377,7 @@ impl<'a> std::iter::FromIterator<Entry<'a>> for Result<Ledger, Error> {
             token_totals,
         };
         #[cfg(feature = "evm")]
-        let ledger = ledger.set_evm_block0();
+        let ledger = ledger.set_evm_block0().set_evm_environment();
         Ok(ledger)
     }
 }

--- a/chain-impl-mockchain/src/ledger/iter.rs
+++ b/chain-impl-mockchain/src/ledger/iter.rs
@@ -356,7 +356,7 @@ impl<'a> std::iter::FromIterator<Entry<'a>> for Result<Ledger, Error> {
 
         let globals = globals.ok_or(Error::IncompleteLedger)?;
 
-        Ok(Ledger {
+        let ledger = Ledger {
             utxos: utxos.into_iter().collect(),
             oldutxos: oldutxos.into_iter().collect(),
             accounts: accounts.into_iter().collect(),
@@ -375,7 +375,10 @@ impl<'a> std::iter::FromIterator<Entry<'a>> for Result<Ledger, Error> {
             #[cfg(feature = "evm")]
             evm,
             token_totals,
-        })
+        };
+        #[cfg(feature = "evm")]
+        let ledger = ledger.set_evm_block0();
+        Ok(ledger)
     }
 }
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -303,7 +303,7 @@ impl Settings {
         #[cfg(feature = "evm")]
         params.push(ConfigParam::EvmConfiguration(self.evm_config));
         #[cfg(feature = "evm")]
-        params.push(ConfigParam::EvmEnvironment(self.evm_environment.clone()));
+        params.push(ConfigParam::EvmEnvironment(self.evm_environment));
 
         debug_assert_eq!(self, &Settings::new().try_apply(&params).unwrap());
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -254,7 +254,7 @@ impl Settings {
                 }
                 #[cfg(feature = "evm")]
                 ConfigParam::EvmEnvironment(evm_env_params) => {
-                    new_state.evm_environment = evm_env_params.clone();
+                    new_state.evm_environment = *evm_env_params;
                 }
             }
         }

--- a/chain-impl-mockchain/src/testing/arbitrary/utils.rs
+++ b/chain-impl-mockchain/src/testing/arbitrary/utils.rs
@@ -25,7 +25,7 @@ where
     let mut matrix: Vec<Vec<T>> = (0..number_of_splits)
         .map(|_| Vec::with_capacity(number_of_splits))
         .collect();
-    for x in source.iter().cloned() {
+    for x in source.iter() {
         let index = usize::arbitrary(gen) % number_of_splits;
         matrix.get_mut(index).unwrap().push(x.clone());
     }

--- a/chain-network/src/grpc/server.rs
+++ b/chain-network/src/grpc/server.rs
@@ -167,8 +167,8 @@ where
         let res = proto::node::PeersResponse {
             peers: peers
                 .nodes
-                .to_vec()
-                .into_iter()
+                .iter()
+                .cloned()
                 .map(|node| node.into_bytes())
                 .collect(),
         };

--- a/chain-vote/src/math/babystep.rs
+++ b/chain-vote/src/math/babystep.rs
@@ -167,7 +167,7 @@ mod tests {
         run(|ctx| {
             forall(fe_vec_generator().and(table_generator_default()))
                 .ensure(|(points, table)| {
-                    let (points, ks): (Vec<_>, Vec<_>) = points.to_vec().into_iter().unzip();
+                    let (points, ks): (Vec<_>, Vec<_>) = points.iter().cloned().unzip();
 
                     property::equal(
                         ks,
@@ -177,7 +177,7 @@ mod tests {
                 .test(ctx);
             forall(fe_vec_generator().and(table_generator_with_balance()))
                 .ensure(|(points, table)| {
-                    let (points, ks): (Vec<_>, Vec<_>) = points.to_vec().into_iter().unzip();
+                    let (points, ks): (Vec<_>, Vec<_>) = points.iter().cloned().unzip();
                     property::equal(
                         ks,
                         baby_step_giant_step(points.to_vec(), u16::MAX.into(), table).unwrap(),


### PR DESCRIPTION
Uses the `BlockDate` and ledger settings such as `slots_per_epoch`, and `slot_duration`, as well as the `Block0Date` value to calculate the appropriate timestamp each time `apply_block` is called.