### PR TITLE
EVM balance overflows return runtime error

### DIFF
--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -146,6 +146,15 @@ impl CappedU256 {
     pub fn zero() -> Self {
         CappedU256(0u64)
     }
+    /// Checked addition of `U256` types. Returns `Some(balance)` or `None` if overflow
+    /// occurred.
+    pub fn checked_add(self, other: U256) -> Option<CappedU256> {
+        if let Ok(other) = other.try_into() {
+            self.0.checked_add(other).map(CappedU256)
+        } else {
+            None
+        }
+    }
     /// Checked substraction of `U256` types. Returns `Some(balance)` or `None` if overflow
     /// occurred.
     pub fn checked_sub(self, other: U256) -> Option<CappedU256> {

--- a/chain-evm/src/state/account.rs
+++ b/chain-evm/src/state/account.rs
@@ -1,63 +1,15 @@
-use crate::state::{storage::Storage, trie::Trie, Error as StateError};
-use crate::Address;
+use crate::{
+    machine::CappedU256,
+    state::{storage::Storage, trie::Trie},
+    Address,
+};
 
 use primitive_types::U256;
 
 pub type Nonce = U256;
 
 /// Ethereum account balance which uses the least 64 significant bits of the `U256` type.
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd)]
-pub struct Balance(U256);
-
-impl std::fmt::Display for Balance {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl TryFrom<U256> for Balance {
-    type Error = StateError;
-    fn try_from(other: U256) -> Result<Self, Self::Error> {
-        match other {
-            U256([_, 0, 0, 0]) => Ok(Balance(other)),
-            _ => Err(StateError::BalanceOverflow),
-        }
-    }
-}
-
-impl TryFrom<Balance> for u64 {
-    type Error = StateError;
-    fn try_from(other: Balance) -> Result<Self, Self::Error> {
-        match other {
-            Balance(U256([value, 0, 0, 0])) => Ok(value),
-            _ => Err(StateError::BalanceOverflow),
-        }
-    }
-}
-
-impl From<u64> for Balance {
-    fn from(other: u64) -> Self {
-        Balance(U256([other, 0, 0, 0]))
-    }
-}
-
-impl From<Balance> for U256 {
-    fn from(other: Balance) -> U256 {
-        other.0
-    }
-}
-
-impl Balance {
-    /// Zero (additive identity) of this type.
-    pub fn zero() -> Self {
-        Balance(U256::zero())
-    }
-    /// Checked substraction of `U256` types. Returns `Some(balance)` or `None` if overflow
-    /// occurred.
-    pub fn checked_sub(self, other: U256) -> Option<Balance> {
-        self.0.checked_sub(other).map(Balance)
-    }
-}
+pub type Balance = CappedU256;
 
 /// Smart-contract bytecode, such as the one compiled from Solidity code, for example.
 pub type ByteCode = Vec<u8>;
@@ -110,33 +62,48 @@ impl AccountTrie {
 mod test {
     use super::*;
 
+    const MAX_SIZE: u64 = u64::MAX;
+
     #[test]
-    fn account_balance_zero() {
-        assert_eq!(Balance::zero(), Balance(U256([0, 0, 0, 0])));
+    fn capped_u256_zero() {
+        assert_eq!(CappedU256::zero(), CappedU256(0u64));
     }
 
     #[test]
-    fn account_balance_checked_sub() {
+    fn capped_u256_checked_add() {
         let val = 100u64;
         assert_eq!(
-            Balance::from(val).checked_sub(U256::from(0u64)),
-            Some(Balance(U256([val, 0, 0, 0])))
+            CappedU256::from(val).checked_add(U256::from(0u64)),
+            Some(CappedU256(val))
         );
-        assert_eq!(Balance::from(0u64).checked_sub(U256::from(1u64)), None);
+        assert_eq!(
+            CappedU256::from(MAX_SIZE).checked_add(U256::from(1u64)),
+            None
+        );
     }
 
     #[test]
-    fn account_balance_can_never_use_more_than_64_bits() {
+    fn capped_u256_checked_sub() {
+        let val = 100u64;
+        assert_eq!(
+            CappedU256::from(val).checked_sub(U256::from(0u64)),
+            Some(CappedU256(val))
+        );
+        assert_eq!(CappedU256::from(0u64).checked_sub(U256::from(1u64)), None);
+    }
+
+    #[test]
+    fn capped_u256_can_never_use_more_than_64_bits() {
         // convert from u64
-        assert_eq!(Balance::from(u64::MAX), Balance(U256([u64::MAX, 0, 0, 0])));
+        assert_eq!(CappedU256::from(MAX_SIZE), CappedU256(MAX_SIZE));
         // try to convert from U256
-        assert!(Balance::try_from(U256::from(u64::MAX)).is_ok());
-        assert!(Balance::try_from(U256::from(u64::MAX) + U256::from(1_u64)).is_err());
+        assert!(CappedU256::try_from(U256::from(MAX_SIZE)).is_ok());
+        assert!(CappedU256::try_from(U256::from(MAX_SIZE) + U256::from(1_u64)).is_err());
 
         // Anything larger than the least significant 64 bits
         // returns error
-        assert!(Balance::try_from(U256([0, 1, 0, 0])).is_err());
-        assert!(Balance::try_from(U256([0, 0, 1, 0])).is_err());
-        assert!(Balance::try_from(U256([0, 0, 0, 1])).is_err());
+        assert!(CappedU256::try_from(U256([0, 1, 0, 0])).is_err());
+        assert!(CappedU256::try_from(U256([0, 0, 1, 0])).is_err());
+        assert!(CappedU256::try_from(U256([0, 0, 0, 1])).is_err());
     }
 }

--- a/chain-evm/src/state/account.rs
+++ b/chain-evm/src/state/account.rs
@@ -1,6 +1,5 @@
 use crate::{
-    machine::CappedU256,
-    state::{storage::Storage, trie::Trie},
+    state::{storage::Storage, trie::Trie, Error},
     Address,
 };
 
@@ -9,7 +8,59 @@ use primitive_types::U256;
 pub type Nonce = U256;
 
 /// Ethereum account balance which uses the least 64 significant bits of the `U256` type.
-pub type Balance = CappedU256;
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd)]
+pub struct Balance(U256);
+
+impl std::fmt::Display for Balance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl TryFrom<U256> for Balance {
+    type Error = Error;
+    fn try_from(other: U256) -> Result<Self, Self::Error> {
+        match other {
+            U256([_, 0, 0, 0]) => Ok(Balance(other)),
+            _ => Err(Error::ValueOverflow),
+        }
+    }
+}
+
+impl From<u64> for Balance {
+    fn from(other: u64) -> Self {
+        Balance(other.into())
+    }
+}
+
+impl From<Balance> for U256 {
+    fn from(other: Balance) -> U256 {
+        other.0
+    }
+}
+
+impl Balance {
+    /// Zero (additive identity) of this type.
+    pub fn zero() -> Self {
+        Balance(U256::zero())
+    }
+    /// Checked addition of `U256` types. Returns `Some(balance)` or `None` if overflow
+    /// occurred.
+    pub fn checked_add(self, other: U256) -> Option<Balance> {
+        match self.0.checked_add(other) {
+            Some(U256([v, 0, 0, 0])) => Some(Balance::from(v)),
+            _ => None,
+        }
+    }
+    /// Checked substraction of `U256` types. Returns `Some(balance)` or `None` if overflow
+    /// occurred.
+    pub fn checked_sub(self, other: U256) -> Option<Balance> {
+        match self.0.checked_sub(other) {
+            Some(U256([v, 0, 0, 0])) => Some(Balance::from(v)),
+            _ => None,
+        }
+    }
+}
 
 /// Smart-contract bytecode, such as the one compiled from Solidity code, for example.
 pub type ByteCode = Vec<u8>;
@@ -65,45 +116,45 @@ mod test {
     const MAX_SIZE: u64 = u64::MAX;
 
     #[test]
-    fn capped_u256_zero() {
-        assert_eq!(CappedU256::zero(), CappedU256(0u64));
+    fn account_balance_u256_zero() {
+        assert_eq!(Balance::zero(), Balance(U256::zero()));
     }
 
     #[test]
-    fn capped_u256_checked_add() {
+    fn account_balance_u256_checked_add() {
         let val = 100u64;
         assert_eq!(
-            CappedU256::from(val).checked_add(U256::from(0u64)),
-            Some(CappedU256(val))
+            Balance::from(val).checked_add(U256::from(0u64)),
+            Some(Balance(val.into()))
         );
         assert_eq!(
-            CappedU256::from(MAX_SIZE).checked_add(U256::from(1u64)),
+            Balance(U256([MAX_SIZE, 0, 0, 0])).checked_add(U256::from(1u64)),
             None
         );
     }
 
     #[test]
-    fn capped_u256_checked_sub() {
+    fn account_balance_u256_checked_sub() {
         let val = 100u64;
         assert_eq!(
-            CappedU256::from(val).checked_sub(U256::from(0u64)),
-            Some(CappedU256(val))
+            Balance::from(val).checked_sub(U256::from(0u64)),
+            Some(Balance(val.into()))
         );
-        assert_eq!(CappedU256::from(0u64).checked_sub(U256::from(1u64)), None);
+        assert_eq!(Balance::from(0u64).checked_sub(U256::from(1u64)), None);
     }
 
     #[test]
-    fn capped_u256_can_never_use_more_than_64_bits() {
+    fn account_balance_u256_can_never_use_more_than_64_bits() {
         // convert from u64
-        assert_eq!(CappedU256::from(MAX_SIZE), CappedU256(MAX_SIZE));
+        assert_eq!(Balance::from(MAX_SIZE), Balance(MAX_SIZE.into()));
         // try to convert from U256
-        assert!(CappedU256::try_from(U256::from(MAX_SIZE)).is_ok());
-        assert!(CappedU256::try_from(U256::from(MAX_SIZE) + U256::from(1_u64)).is_err());
+        assert!(Balance::try_from(U256::from(MAX_SIZE)).is_ok());
+        assert!(Balance::try_from(U256::from(MAX_SIZE) + U256::from(1_u64)).is_err());
 
         // Anything larger than the least significant 64 bits
         // returns error
-        assert!(CappedU256::try_from(U256([0, 1, 0, 0])).is_err());
-        assert!(CappedU256::try_from(U256([0, 0, 1, 0])).is_err());
-        assert!(CappedU256::try_from(U256([0, 0, 0, 1])).is_err());
+        assert!(Balance::try_from(U256([0, 1, 0, 0])).is_err());
+        assert!(Balance::try_from(U256([0, 0, 1, 0])).is_err());
+        assert!(Balance::try_from(U256([0, 0, 0, 1])).is_err());
     }
 }

--- a/chain-evm/src/state/mod.rs
+++ b/chain-evm/src/state/mod.rs
@@ -10,7 +10,9 @@ mod storage;
 mod trie;
 
 pub use account::{Account, AccountTrie, Balance, ByteCode, Nonce};
+use evm::ExitError;
 pub use logs::LogsState;
+use std::borrow::Cow;
 pub use storage::{Key, Storage, Value};
 pub use trie::Trie;
 
@@ -23,7 +25,7 @@ pub enum Error {
 
 impl From<Error> for crate::machine::Error {
     fn from(other: Error) -> Self {
-        Self::StateError(other)
+        Self::TransactionError(ExitError::Other(Cow::from(String::from(other))))
     }
 }
 

--- a/chain-evm/src/state/mod.rs
+++ b/chain-evm/src/state/mod.rs
@@ -17,8 +17,8 @@ pub use trie::Trie;
 /// Definition for state-related errors.
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
 pub enum Error {
-    #[error("account balance values cannot exceed 64 significant bits")]
-    BalanceOverflow,
+    #[error("EVM values cannot exceed 64 significant bits")]
+    ValueOverflow,
 }
 
 impl From<Error> for crate::machine::Error {


### PR DESCRIPTION
Handle account balance overflow by returning a runtime error.

Currently, only external account balances can be checked before transaction execution. Contract account balances remain `U256` values.

If contract account balances need to be restricted, we need to have our custom implementation of the `StackState` trait from SputnikVM