### PR TITLE
Update EVM VirtualMachine struct, remove redundant usage of the evm state fields 

### DIFF
--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -223,6 +223,7 @@ impl<'a, State: EvmState> VirtualMachine<'a, State> {
     }
 
     /// Execute a CREATE transaction
+    #[allow(clippy::too_many_arguments)]
     pub fn transact_create(
         &mut self,
         config: Config,

--- a/chain-impl-mockchain/src/ledger/evm.rs
+++ b/chain-impl-mockchain/src/ledger/evm.rs
@@ -6,7 +6,7 @@ use chain_evm::{
     machine::{
         BlockHash, BlockNumber, BlockTimestamp, Config, Environment, EvmState, VirtualMachine,
     },
-    primitive_types::{H160, U256},
+    primitive_types::U256,
     state::{AccountTrie, LogsState},
 };
 
@@ -37,16 +37,12 @@ impl EvmState for Ledger {
         &self.logs
     }
 
-    fn update_state(&mut self, state: AccountTrie) {
-        self.accounts = state;
+    fn update_accounts(&mut self, accounts: AccountTrie) {
+        self.accounts = accounts;
     }
 
     fn update_logs(&mut self, logs: LogsState) {
         self.logs = logs;
-    }
-
-    fn update_env_origin(&mut self, origin: H160) {
-        self.environment.origin = origin;
     }
 }
 
@@ -65,7 +61,6 @@ impl Ledger {
             logs: Default::default(),
             environment: Environment {
                 gas_price: Default::default(),
-                origin: Default::default(),
                 chain_id: Default::default(),
                 block_hashes: Default::default(),
                 block_number: Default::default(),

--- a/chain-impl-mockchain/src/ledger/evm.rs
+++ b/chain-impl-mockchain/src/ledger/evm.rs
@@ -15,7 +15,6 @@ pub struct Ledger {
     pub(crate) accounts: AccountTrie,
     pub(crate) logs: LogsState,
     pub(crate) environment: Environment,
-    pub(crate) config: Config,
     pub(crate) current_epoch: BlockEpoch,
 }
 
@@ -30,11 +29,7 @@ impl EvmState for Ledger {
         &self.environment
     }
 
-    fn config(&self) -> &Config {
-        &self.config
-    }
-
-    fn state(&self) -> &AccountTrie {
+    fn accounts(&self) -> &AccountTrie {
         &self.accounts
     }
 
@@ -80,7 +75,6 @@ impl Ledger {
                 block_gas_limit: Default::default(),
                 block_base_fee_per_gas: Default::default(),
             },
-            config: Default::default(),
             current_epoch: BlockEpoch {
                 epoch: 0,
                 epoch_start: BlockTimestamp::default(),
@@ -94,7 +88,6 @@ impl Ledger {
         contract: EvmTransaction,
         config: Config,
     ) -> Result<(), Error> {
-        self.config = config;
         let mut vm = VirtualMachine::new(self);
         match contract {
             EvmTransaction::Create {
@@ -104,7 +97,15 @@ impl Ledger {
                 gas_limit,
                 access_list,
             } => {
-                vm.transact_create(caller, value, init_code, gas_limit, access_list, true)?;
+                vm.transact_create(
+                    config,
+                    caller,
+                    value,
+                    init_code,
+                    gas_limit,
+                    access_list,
+                    true,
+                )?;
             }
             EvmTransaction::Create2 {
                 caller,
@@ -114,7 +115,16 @@ impl Ledger {
                 gas_limit,
                 access_list,
             } => {
-                vm.transact_create2(caller, value, init_code, salt, gas_limit, access_list, true)?;
+                vm.transact_create2(
+                    config,
+                    caller,
+                    value,
+                    init_code,
+                    salt,
+                    gas_limit,
+                    access_list,
+                    true,
+                )?;
             }
             EvmTransaction::Call {
                 caller,
@@ -124,8 +134,16 @@ impl Ledger {
                 gas_limit,
                 access_list,
             } => {
-                let _byte_code_msg =
-                    vm.transact_call(caller, address, value, data, gas_limit, access_list, true)?;
+                let _byte_code_msg = vm.transact_call(
+                    config,
+                    caller,
+                    address,
+                    value,
+                    data,
+                    gas_limit,
+                    access_list,
+                    true,
+                )?;
             }
         }
         Ok(())


### PR DESCRIPTION
This update is one from the "EVM mapping" feature implementation.
Purpose of this PR is to remove redundant evm state fields as `AccountTrie`, `LogsState`, `Environment` and leave them only inside `Ledger` struct:
```
pub struct Ledger {
    pub(crate) accounts: AccountTrie,
    pub(crate) logs: LogsState,
    pub(crate) environment: Environment,
    pub(crate) current_epoch: BlockEpoch,
}
```