### PR TITLE
Remove evm tests submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "evm-tests"]
-	path = evm-tests
-	url = https://github.com/ethereum/tests.git

--- a/chain-impl-mockchain/src/ledger/tests/evm_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/evm_tests.rs
@@ -346,6 +346,7 @@ pub fn run_evm_test(path: PathBuf) {
 }
 
 #[test]
+#[ignore]
 fn run_evm_tests() {
     let vm_tests_dir = std::fs::read_dir("../evm-tests/BlockchainTests/GeneralStateTests/VMTests")
         .expect("Can not find vm tests directory");


### PR DESCRIPTION
Prior to refactoring evm-tests into another crate, it needs to be removed and the corresponding tests ignored.