### PR TITLE
Remove ivm-tests submodule, move ivm-test-suite into another repo/crate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,13 @@ jobs:
         name: Clean up cargo registry files
         run: rm -r -fo $env:UserProfile\.cargo\registry
 
+      - if: ${{ runner.os == 'Windows' }}
+        name: Allow long paths on Windows
+        shell: powershell
+        run: |
+          reg add HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f
+          git config --system core.longpaths true
+
       - name: Restore cargo registry index
         uses: actions/cache@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "evm-tests"]
-	path = evm-tests
-	url = https://github.com/ethereum/tests.git

--- a/chain-evm/Cargo.toml
+++ b/chain-evm/Cargo.toml
@@ -26,12 +26,11 @@ thiserror = "1.0"
 quickcheck = { version = "0.9", optional = true }
 
 [dev-dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 rand = "0.7.3"
 proptest = "1.0.0"
 test-strategy = "0.1"
 quickcheck = "0.9"
+evm-test-suite = { git = "https://github.com/input-output-hk/evm-test-suite.git"}
 
 [features]
 property-test-api = ["quickcheck"]

--- a/chain-evm/src/lib.rs
+++ b/chain-evm/src/lib.rs
@@ -4,4 +4,7 @@ pub mod machine;
 mod precompiles;
 pub mod state;
 
+#[cfg(test)]
+mod tests;
+
 pub use machine::{Address, BlockGasLimit, Config, Environment, GasLimit, GasPrice};

--- a/chain-evm/src/machine.rs
+++ b/chain-evm/src/machine.rs
@@ -438,13 +438,13 @@ impl<'a, State: EvmState> ApplyBackend for VirtualMachine<'a, State> {
 }
 
 #[cfg(any(test, feature = "property-test-api"))]
-mod test {
+pub mod test {
     use super::*;
 
-    struct TestEvmState {
-        environment: Environment,
-        accounts: AccountTrie,
-        logs: LogsState,
+    pub struct TestEvmState {
+        pub environment: Environment,
+        pub accounts: AccountTrie,
+        pub logs: LogsState,
     }
 
     impl EvmState for TestEvmState {

--- a/chain-evm/src/tests.rs
+++ b/chain-evm/src/tests.rs
@@ -1,26 +1,33 @@
 use crate::machine::test::TestEvmState;
-use crate::machine::{Value, VirtualMachine};
-use crate::state::{ByteCode, Key};
-use crate::{
-    primitive_types::{H160, H256, U256},
-    state::{Account, Trie},
-    Address, Config,
-};
-use serde::Deserialize;
-use std::collections::{BTreeMap, BTreeSet};
-use std::io::BufReader;
-use std::mem::size_of;
-use std::path::PathBuf;
-use std::str::FromStr;
+use crate::machine::VirtualMachine;
+use crate::{state::Account, Config};
+use evm_test_suite::{AccountState, BlockHeader, CallTransaction, NetworkType};
+use primitive_types::{H160, U256};
+use std::collections::BTreeSet;
 
 struct TestEvmLedger {
     state: TestEvmState,
     config: Config,
-    coinbase_addresses: BTreeSet<String>,
+    coinbase_addresses: BTreeSet<H160>,
 }
 
-impl TestEvmLedger {
-    fn new() -> Self {
+impl TryFrom<AccountState> for Account {
+    type Error = String;
+    fn try_from(val: AccountState) -> Result<Self, Self::Error> {
+        Ok(Self {
+            nonce: val.nonce,
+            balance: val
+                .balance
+                .try_into()
+                .map_err(|_| "can not convert balance")?,
+            storage: val.storage.into_iter().collect(),
+            code: val.code,
+        })
+    }
+}
+
+impl evm_test_suite::TestEvmState for TestEvmLedger {
+    fn init_state() -> Self {
         Self {
             state: TestEvmState {
                 environment: Default::default(),
@@ -31,142 +38,20 @@ impl TestEvmLedger {
             coinbase_addresses: Default::default(),
         }
     }
-}
-
-impl TestEvmLedger {
-    fn set_evm_config(mut self, config: Config) -> Self {
-        self.config = config;
-        self
-    }
-
-    fn set_account(mut self, address: Address, account: Account) -> Self {
-        self.state.accounts = self.state.accounts.put(address, account);
-        self
-    }
-
-    fn set_chain_id(mut self, chain_id: U256) -> Self {
-        self.state.environment.chain_id = chain_id;
-        self
-    }
-}
-
-impl TestEvmLedger {
-    fn try_apply_network(self, network: String) -> Result<Self, String> {
-        println!("Network type: {}", network);
-        match network.as_str() {
-            "Istanbul" => Ok(self.set_evm_config(Config::Istanbul)),
-            "Berlin" => Ok(self.set_evm_config(Config::Berlin)),
-            "London" => Ok(self.set_evm_config(Config::London)),
-            network => Err(format!("Not known network type, {}", network)),
-        }
-    }
-
-    fn try_apply_account(self, address: String, account: TestAccountState) -> Result<Self, String> {
-        Ok(self.set_account(
-            H160::from_str(&address).map_err(|_| "Can not parse address")?,
-            account.try_into()?,
-        ))
-    }
-
-    fn try_apply_accounts<I>(mut self, iter: I) -> Result<Self, String>
-    where
-        I: Iterator<Item = (String, TestAccountState)>,
-    {
-        for (address, account) in iter {
-            self = self.try_apply_account(address, account)?;
-        }
-        Ok(self)
-    }
-
-    fn try_apply_block_header(mut self, block_header: TestBlockHeader) -> Result<Self, String> {
-        self.state.environment.block_gas_limit =
-            U256::from_str(&block_header.gas_limit).map_err(|_| "Can not parse gas limit")?;
-        self.state.environment.block_number =
-            U256::from_str(&block_header.number).map_err(|_| "Can not parse number")?;
-        self.state.environment.block_timestamp =
-            U256::from_str(&block_header.timestamp).map_err(|_| "Can not parse timestamp")?;
-        self.state.environment.block_difficulty =
-            U256::from_str(&block_header.difficulty).map_err(|_| "Can not parse difficulty")?;
-        self.state.environment.block_coinbase =
-            H160::from_str(&block_header.coinbase).map_err(|_| "Can not parse coinbase")?;
-
-        self.state
-            .environment
-            .block_hashes
-            .push(H256::from_str(&block_header.hash).expect("Can not parse hash"));
-
-        self.coinbase_addresses.insert(block_header.coinbase);
-
-        Ok(self)
-    }
-
-    fn try_apply_transaction(mut self, tx: TestEvmTransaction) -> Result<Self, String> {
-        let gas_price =
-            U256::from_str(&tx.gas_price).map_err(|_| "Can not parse transaction gas limit")?;
-
-        self.state.environment.gas_price = gas_price;
-
-        let mut vm = VirtualMachine::new(&mut self.state);
-        let tx: EvmTransaction = tx.try_into().unwrap();
-        vm.transact_call(
-            self.config,
-            tx.caller,
-            tx.address,
-            tx.value,
-            tx.data,
-            tx.gas_limit,
-            tx.access_list,
-            true,
-        )
-        .map_err(|e| format!("can not run transaction, err: {}", e))?;
-
-        Ok(self)
-    }
-
-    fn try_apply_block(mut self, block: TestBlock) -> Result<Self, String> {
-        self = self.try_apply_block_header(block.block_header)?;
-        for transaction in block.transactions {
-            self = self.try_apply_transaction(transaction)?;
-        }
-
-        Ok(self)
-    }
-
-    fn try_apply_blocks<I>(mut self, iter: I) -> Result<Self, String>
-    where
-        I: Iterator<Item = TestBlock>,
-    {
-        for block in iter {
-            self = self.try_apply_block(block)?;
-        }
-        Ok(self)
-    }
-}
-
-impl TestEvmLedger {
-    fn validate_accounts<I>(&self, iter: I) -> Result<(), String>
-    where
-        I: Iterator<Item = (String, TestAccountState)>,
-    {
-        for (address, account) in iter {
-            self.validate_account(address, account)?;
-        }
-        Ok(())
-    }
 
     fn validate_account(
         &self,
-        address: String,
-        expected_state: TestAccountState,
+        address: H160,
+        expected_account: AccountState,
     ) -> Result<(), String> {
-        // skip coinbase accounts
         if !self.coinbase_addresses.contains(&address) {
             let account = self
                 .state
                 .accounts
-                .get(&H160::from_str(&address).map_err(|_| "Can not parse address")?)
+                .get(&address)
                 .ok_or("Can not find account")?;
-            let expected_account: Account = expected_state.try_into()?;
+
+            let expected_account = expected_account.try_into()?;
 
             if &expected_account != account {
                 let storage_info = |account: &Account| {
@@ -202,200 +87,68 @@ impl TestEvmLedger {
             Ok(())
         }
     }
-}
 
-#[derive(Deserialize)]
-struct TestAccountState {
-    balance: String,
-    code: String,
-    nonce: String,
-    storage: BTreeMap<String, String>,
-}
-
-impl TryFrom<TestAccountState> for Account {
-    type Error = String;
-    fn try_from(account: TestAccountState) -> Result<Self, Self::Error> {
-        let mut storage = Trie::default();
-        for (k, v) in account.storage {
-            let feel_zeros = |mut val: String| -> Result<String, String> {
-                val = val[0..2]
-                    .eq("0x")
-                    .then(|| val[2..].to_string())
-                    .ok_or("Missing '0x' prefix for hex data")?;
-
-                while val.len() < size_of::<H256>() * 2 {
-                    val = "00".to_string() + &val;
-                }
-                val = "0x".to_string() + &val;
-                Ok(val)
-            };
-            storage = storage.put(
-                H256::from_str(&feel_zeros(k)?).map_err(|_| "Can not parse account storage key")?,
-                H256::from_str(&feel_zeros(v)?).map_err(|_| "Can not parse account storage key")?,
-            );
-        }
-        Ok(Self {
-            nonce: U256::from_str(&account.nonce).map_err(|_| "Can not parse nonce")?,
-            balance: U256::from_str(&account.balance)
-                .map_err(|_| "Can not parse balance")?
-                .try_into()?,
-            storage,
-            code: hex::decode(
-                account.code[0..2]
-                    .eq("0x")
-                    .then(|| account.code[2..].to_string())
-                    .expect("Missing '0x' prefix for hex data"),
-            )
-            .map_err(|_| "Can not parse code")?,
-        })
+    fn try_apply_chain_id(mut self, id: U256) -> Result<Self, String> {
+        self.state.environment.chain_id = id;
+        Ok(self)
     }
-}
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct TestEvmTransaction {
-    data: String,
-    gas_limit: String,
-    gas_price: String,
-    sender: String,
-    to: String,
-    value: String,
-}
+    fn try_apply_network_type(mut self, net_type: NetworkType) -> Result<Self, String> {
+        match net_type {
+            NetworkType::Berlin => self.config = Config::Berlin,
+            NetworkType::Istanbul => self.config = Config::Istanbul,
+            NetworkType::London => self.config = Config::London,
+        }
+        Ok(self)
+    }
 
-struct EvmTransaction {
-    caller: Address,
-    address: Address,
-    value: Value,
-    data: ByteCode,
-    gas_limit: u64,
-    access_list: Vec<(Address, Vec<Key>)>,
-}
+    fn try_apply_account(mut self, address: H160, account: AccountState) -> Result<Self, String> {
+        self.state.accounts = self.state.accounts.put(address, account.try_into()?);
+        Ok(self)
+    }
 
-impl TryFrom<TestEvmTransaction> for EvmTransaction {
-    type Error = String;
-    fn try_from(tx: TestEvmTransaction) -> Result<Self, Self::Error> {
-        let gas_limit = U256::from_str(&tx.gas_limit)
-            .map_err(|_| "Can not parse transaction gas limit")?
-            .as_u64();
-        let value = U256::from_str(&tx.value).map_err(|_| "Can not parse transaction value")?;
-        let data = hex::decode(
-            tx.data[0..2]
-                .eq("0x")
-                .then(|| tx.data[2..].to_string())
-                .expect("Missing '0x' prefix for hex data"),
+    fn try_apply_block_header(mut self, block_header: BlockHeader) -> Result<Self, String> {
+        self.state.environment.block_gas_limit = block_header.gas_limit;
+        self.state.environment.block_number = block_header.number;
+        self.state.environment.block_timestamp = block_header.timestamp;
+        self.state.environment.block_difficulty = block_header.difficulty;
+        self.state.environment.block_coinbase = block_header.coinbase;
+
+        self.state.environment.block_hashes.push(block_header.hash);
+
+        self.coinbase_addresses.insert(block_header.coinbase);
+
+        Ok(self)
+    }
+
+    fn try_apply_transaction(mut self, tx: CallTransaction) -> Result<Self, String> {
+        self.state.environment.gas_price = tx.gas_price;
+
+        let mut vm = VirtualMachine::new(&mut self.state);
+        vm.transact_call(
+            self.config,
+            tx.sender,
+            tx.to,
+            tx.value,
+            tx.data,
+            tx.gas_limit.as_u64(),
+            Vec::new(),
+            true,
         )
-        .map_err(|_| "Can not parse transaction data")?;
-        let caller = H160::from_str(&tx.sender).map_err(|_| "Can not parse transaction sender")?;
-        let address = H160::from_str(&tx.to).map_err(|_| "Can not parse transaction to")?;
+        .map_err(|e| format!("can not run transaction, err: {}", e))?;
 
-        Ok(Self {
-            address,
-            gas_limit,
-            value,
-            data,
-            caller,
-            access_list: Vec::new(),
-        })
-    }
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct TestBlockHeader {
-    coinbase: String,
-    difficulty: String,
-    gas_limit: String,
-    hash: String,
-    number: String,
-    timestamp: String,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct TestBlock {
-    block_header: TestBlockHeader,
-    transactions: Vec<TestEvmTransaction>,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct TestCase {
-    pre: BTreeMap<String, TestAccountState>,
-    network: String,
-    genesis_block_header: TestBlockHeader,
-    blocks: Vec<TestBlock>,
-    post_state: BTreeMap<String, TestAccountState>,
-}
-
-pub fn run_evm_test(path: PathBuf) {
-    println!(
-        "\n----------- Running tests: {} -----------",
-        path.file_name().unwrap().to_str().unwrap()
-    );
-
-    let file = std::fs::File::open(path).expect("Open file failed");
-    let reader = BufReader::new(file);
-
-    let test: BTreeMap<String, TestCase> =
-        serde_json::from_reader(reader).expect("Parse test cases failed");
-
-    for (test_name, test_case) in test {
-        println!("\nRunning test case: {} ...", test_name);
-        let evm_state_builder = TestEvmLedger::new()
-            .set_chain_id(U256::from_str("0xff").unwrap())
-            .try_apply_network(test_case.network)
-            .unwrap()
-            .try_apply_accounts(test_case.pre.into_iter())
-            .unwrap()
-            .try_apply_block_header(test_case.genesis_block_header)
-            .unwrap()
-            .try_apply_blocks(test_case.blocks.into_iter())
-            .unwrap();
-
-        evm_state_builder
-            .validate_accounts(test_case.post_state.into_iter())
-            .unwrap();
-    }
-}
-
-#[test]
-fn run_evm_tests() {
-    let vm_tests_dir = std::fs::read_dir("../evm-tests/BlockchainTests/GeneralStateTests/VMTests")
-        .expect("Can not find vm tests directory");
-
-    for vm_test_dir in vm_tests_dir {
-        let vm_test_dir = vm_test_dir.expect("Can not open vm tests dir entry");
-        println!(
-            "Running {} tests ...",
-            vm_test_dir.file_name().to_str().unwrap()
-        );
-
-        // Heavy perfomance tests, so we just skip them
-        if vm_test_dir.file_name().to_str().unwrap() == "vmPerformance" {
-            println!("Skipping");
-            continue;
-        }
-
-        for vm_test in std::fs::read_dir(vm_test_dir.path()).unwrap() {
-            let vm_test = vm_test.expect("Can not open vm test entry");
-            // "jumpToPush.json" has a different structure it is does not have a 'postState' field
-            // as a final state which we would have as a result of the test execution.
-            // "jumpToPush.json" test has only "postStateHash" which should be equal to the Ethereum "stateRoot"
-            // which we dont need to implement in our implementation currently as we are not emulating Ethereum blockchain structure
-            if vm_test.file_name().to_str().unwrap() == "jumpToPush.json" {
-                println!("Skipping");
-                continue;
-            }
-            run_evm_test(vm_test.path());
-        }
+        Ok(self)
     }
 }
 
 // This was left for the convinience to run and debug a separate test case
 #[test]
 #[ignore]
-fn evm_test() {
-    run_evm_test(PathBuf::from(
-        "../evm-tests/BlockchainTests/GeneralStateTests/VMTests/vmIOandFlowOperations/loop_stacklimit.json"
-    ));
+fn run_evm_test() {
+    evm_test_suite::run_evm_test::<TestEvmLedger>(evm_test_suite::arithmetic::ADD);
+}
+
+#[test]
+fn run_evm_tests() {
+    evm_test_suite::run_evm_tests::<TestEvmLedger>();
 }

--- a/chain-impl-mockchain/src/ledger/tests/mod.rs
+++ b/chain-impl-mockchain/src/ledger/tests/mod.rs
@@ -3,8 +3,6 @@ mod macros;
 pub mod apply_block_tests;
 pub mod certificate_tests;
 pub mod discrimination_tests;
-#[cfg(feature = "evm")]
-pub mod evm_tests;
 pub mod initial_funds_tests;
 pub mod ledger_tests;
 pub mod transaction_tests;


### PR DESCRIPTION
- Moved evm_tests into the `chain-evm` crate, it is needed to isolate all these tests only for our VM integration and be agnostic to any jormungandr ledger implementation.
- Moved evm-test-suite with into another crate/repo https://github.com/input-output-hk/evm-test-suite, it is allow remove evm-tests submodule