### PR TITLE
update evm mapping cert

### DIFF
--- a/chain-impl-mockchain/src/certificate/evm_mapping.rs
+++ b/chain-impl-mockchain/src/certificate/evm_mapping.rs
@@ -6,6 +6,8 @@ use chain_core::{
 use chain_evm::Address;
 use typed_bytes::{ByteArray, ByteBuilder};
 
+#[cfg(feature = "evm")]
+use crate::transaction::UnspecifiedAccountIdentifier;
 use crate::transaction::{
     Payload, PayloadAuthData, PayloadData, PayloadSlice, SingleAccountBindingSignature,
 };
@@ -15,13 +17,18 @@ use super::CertificateSlice;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EvmMapping {
     #[cfg(feature = "evm")]
-    evm_address: Address,
+    pub account_id: UnspecifiedAccountIdentifier,
+    #[cfg(feature = "evm")]
+    pub evm_address: Address,
 }
 
 impl EvmMapping {
     #[cfg(feature = "evm")]
-    pub fn new(evm_address: Address) -> Self {
-        Self { evm_address }
+    pub fn new(evm_address: Address, account_id: UnspecifiedAccountIdentifier) -> Self {
+        Self {
+            account_id,
+            evm_address,
+        }
     }
 
     #[cfg(feature = "evm")]
@@ -29,10 +36,16 @@ impl EvmMapping {
         &self.evm_address
     }
 
+    #[cfg(feature = "evm")]
+    pub fn account_id(&self) -> &UnspecifiedAccountIdentifier {
+        &self.account_id
+    }
+
     pub fn serialize_in(&self, bb: ByteBuilder<Self>) -> ByteBuilder<Self> {
         #[cfg(feature = "evm")]
         {
-            bb.bytes(self.evm_address.as_bytes())
+            bb.bytes(self.account_id().as_ref())
+                .bytes(self.evm_address.as_bytes())
         }
         #[cfg(not(feature = "evm"))]
         bb
@@ -79,6 +92,7 @@ impl property::Serialize for EvmMapping {
         #[cfg(feature = "evm")]
         {
             let mut codec = chain_core::packer::Codec::new(_writer);
+            codec.put_bytes(self.account_id.as_ref())?;
             codec.put_bytes(self.evm_address.as_bytes())?;
         }
         Ok(())
@@ -91,13 +105,22 @@ impl property::Deserialize for EvmMapping {
         #[cfg(feature = "evm")]
         {
             let mut codec = chain_core::packer::Codec::new(_reader);
-            let bytes = codec.get_bytes(Address::len_bytes())?;
+            let buf: [u8; crate::transaction::INPUT_PTR_SIZE] = codec
+                .get_bytes(crate::transaction::INPUT_PTR_SIZE)?
+                .try_into()
+                .unwrap();
+            let evm_address = codec.get_bytes(Address::len_bytes())?;
+
             Ok(Self {
-                evm_address: Address::from_slice(bytes.as_slice()),
+                account_id: buf.into(),
+                evm_address: Address::from_slice(evm_address.as_slice()),
             })
         }
         #[cfg(not(feature = "evm"))]
-        unimplemented!()
+        Err(Self::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "evm transactions are not supported in this build",
+        ))
     }
 }
 
@@ -106,11 +129,14 @@ impl Readable for EvmMapping {
         #[cfg(feature = "evm")]
         {
             Ok(Self {
+                account_id: <[u8; crate::transaction::INPUT_PTR_SIZE]>::read(_buf)?.into(),
                 evm_address: Address::from_slice(_buf.get_slice(Address::len_bytes())?),
             })
         }
         #[cfg(not(feature = "evm"))]
-        unimplemented!()
+        Err(ReadError::InvalidData(
+            "evm transactions are not supported in this build".into(),
+        ))
     }
 }
 
@@ -122,6 +148,7 @@ mod test {
     impl Arbitrary for EvmMapping {
         fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
             Self {
+                account_id: [u8::arbitrary(g); crate::transaction::INPUT_PTR_SIZE].into(),
                 evm_address: [u8::arbitrary(g); Address::len_bytes()].into(),
             }
         }


### PR DESCRIPTION
Add the relevant jormungandr account internally to the certificate, so that it's not necessary for the sender of the transaction to be involved in it. However, this increases the transaction size a bit in case a user is doing it for themselves. If that use-case is of particular importance, we could introduce a variant of this certificate similar to `StakeDelegation` and `OwnerStakeDelegation`.

Also removes panics from deserialization impl of the certificate, since that could have been used to crash a node which was not compiled with the evm feature