### PR TITLE
update evm to v0.35

### DIFF
--- a/chain-evm/Cargo.toml
+++ b/chain-evm/Cargo.toml
@@ -22,7 +22,8 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 byte-slice-cast = { version = "1.0", default-features = false }
 thiserror = "1.0"
 quickcheck = { version = "0.9", optional = true }
-evm = { version = "0.34.0" }
+evm = { version = "0.35.0" }
+ethereum = { version = "0.12.0" }
 ethereum-types = { version = "0.13.1", features = ["rlp"] }
 
 [dev-dependencies]

--- a/chain-evm/Cargo.toml
+++ b/chain-evm/Cargo.toml
@@ -23,7 +23,6 @@ byte-slice-cast = { version = "1.0", default-features = false }
 thiserror = "1.0"
 quickcheck = { version = "0.9", optional = true }
 evm = { version = "0.35.0" }
-ethereum = { version = "0.12.0" }
 ethereum-types = { version = "0.13.1", features = ["rlp"] }
 
 [dev-dependencies]


### PR DESCRIPTION
updates dependencies to ethereum/ethereum-types needed for https://github.com/input-output-hk/chain-libs/pull/786