### PR TITLE
Update add_account() function interface

### DIFF
--- a/chain-impl-mockchain/src/accounting/account/mod.rs
+++ b/chain-impl-mockchain/src/accounting/account/mod.rs
@@ -75,12 +75,12 @@ impl<ID: Clone + Eq + Hash, Extra: Clone> Ledger<ID, Extra> {
     /// If the identifier is already present, error out.
     pub fn add_account(
         &self,
-        identifier: &ID,
+        identifier: ID,
         initial_value: Value,
         extra: Extra,
     ) -> Result<Self, LedgerError> {
         self.0
-            .insert(identifier.clone(), AccountState::new(initial_value, extra))
+            .insert(identifier, AccountState::new(initial_value, extra))
             .map(Ledger)
             .map_err(|e| e.into())
     }
@@ -296,7 +296,7 @@ mod tests {
             // Add all arbitrary accounts
             for account_id in arbitrary_accounts_ids.iter() {
                 ledger = ledger
-                    .add_account(account_id, AverageValue::arbitrary(gen).into(), ())
+                    .add_account(account_id.clone(), AverageValue::arbitrary(gen).into(), ())
                     .unwrap();
 
                 for token in &arbitrary_voting_tokens {
@@ -340,7 +340,7 @@ mod tests {
         let initial_total_value = ledger.get_total_value().unwrap();
 
         // add new account
-        ledger = match ledger.add_account(&account_id, value, ()) {
+        ledger = match ledger.add_account(account_id.clone(), value, ()) {
             Ok(ledger) => ledger,
             Err(err) => {
                 return TestResult::error(format!(
@@ -351,7 +351,7 @@ mod tests {
         };
 
         // add account again should throw an error
-        if ledger.add_account(&account_id, value, ()).is_ok() {
+        if ledger.add_account(account_id.clone(), value, ()).is_ok() {
             return TestResult::error(format!(
                 "Account with id {} again should should",
                 account_id
@@ -559,7 +559,9 @@ mod tests {
         value_to_remove: Value,
     ) -> TestResult {
         let mut ledger = Ledger::new();
-        ledger = ledger.add_account(&id, account_state.value(), ()).unwrap();
+        ledger = ledger
+            .add_account(id.clone(), account_state.value(), ())
+            .unwrap();
         let result = ledger.remove_value(&id, SpendingCounter::zero(), value_to_remove);
         let expected_result = account_state.value() - value_to_remove;
         match (result, expected_result) {
@@ -588,7 +590,9 @@ mod tests {
         account_state: AccountState<()>,
     ) -> TestResult {
         let mut ledger = Ledger::new();
-        ledger = ledger.add_account(&id, account_state.value(), ()).unwrap();
+        ledger = ledger
+            .add_account(id.clone(), account_state.value(), ())
+            .unwrap();
         let result = ledger.remove_account(&id);
         let expected_zero = account_state.value() == Value::zero();
         match (result, expected_zero) {

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -1568,15 +1568,14 @@ impl Ledger {
                     let account_id = account_id.clone().into();
                     // TODO: probably faster to just call add_account and check for already exists error
                     if !self.accounts.exists(&account_id) {
-                        self.accounts =
-                            self.accounts.add_account(&account_id, Value::zero(), ())?;
+                        self.accounts = self.accounts.add_account(account_id, Value::zero(), ())?;
                     }
                     new_utxos.push((index as u8, output.clone()));
                 }
                 Kind::Account(identifier) => {
                     // don't have a way to make a newtype ref from the ref so .clone()
                     let account = identifier.clone().into();
-                    self.add_value_or_create_account(&account, output.value)?;
+                    self.add_value_or_create_account(account, output.value)?;
                 }
                 Kind::Multisig(identifier) => {
                     let identifier = multisig::Identifier::from(*identifier);
@@ -1596,10 +1595,10 @@ impl Ledger {
 
     fn add_value_or_create_account(
         &mut self,
-        account: &account::Identifier,
+        account: account::Identifier,
         value: Value,
     ) -> Result<(), Error> {
-        self.accounts = match self.accounts.add_value(account, value) {
+        self.accounts = match self.accounts.add_value(&account, value) {
             Ok(accounts) => accounts,
             Err(account::LedgerError::NonExistent) => {
                 self.accounts.add_account(account, value, ())?
@@ -2043,7 +2042,7 @@ mod tests {
     ) -> TestResult {
         let mut account_ledger = account::Ledger::new();
         account_ledger = account_ledger
-            .add_account(&id, account_state.value(), ())
+            .add_account(id.clone(), account_state.value(), ())
             .unwrap();
         let result = super::input_single_account_verify(
             account_ledger,
@@ -2089,7 +2088,9 @@ mod tests {
     fn account_ledger_with_initials(initials: &[(Identifier, Value)]) -> account::Ledger {
         let mut account_ledger = account::Ledger::new();
         for (id, initial_value) in initials {
-            account_ledger = account_ledger.add_account(id, *initial_value, ()).unwrap();
+            account_ledger = account_ledger
+                .add_account(id.clone(), *initial_value, ())
+                .unwrap();
         }
         account_ledger
     }
@@ -2397,7 +2398,7 @@ mod tests {
 
         let account = AddressData::account(Discrimination::Test);
         accounts = accounts
-            .add_account(&account.to_id(), Value(100), ())
+            .add_account(account.to_id(), Value(100), ())
             .unwrap();
 
         let delegation = AddressData::delegation_for(&account);
@@ -2471,7 +2472,7 @@ mod tests {
 
         let account = AddressData::account(Discrimination::Test);
         accounts = accounts
-            .add_account(&account.to_id(), Value(100), ())
+            .add_account(account.to_id(), Value(100), ())
             .unwrap();
 
         let ledger = build_ledger(utxos, accounts, multisig_ledger, params.static_params());

--- a/chain-impl-mockchain/src/multisig/ledger.rs
+++ b/chain-impl-mockchain/src/multisig/ledger.rs
@@ -74,7 +74,7 @@ impl Ledger {
         let new_decls = self
             .declarations
             .insert(identifier.clone(), declaration.clone())?;
-        let new_accts = self.accounts.add_account(&identifier, Value::zero(), ())?;
+        let new_accts = self.accounts.add_account(identifier, Value::zero(), ())?;
         Ok(Self {
             accounts: new_accts,
             declarations: new_decls,

--- a/chain-impl-mockchain/src/stake/distribution.rs
+++ b/chain-impl-mockchain/src/stake/distribution.rs
@@ -421,7 +421,7 @@ mod tests {
             };
             accounts = accounts
                 .add_account(
-                    &Identifier::from(account_public_key.clone()),
+                    Identifier::from(account_public_key.clone()),
                     Value::zero(),
                     (),
                 )
@@ -445,12 +445,12 @@ mod tests {
 
         // add accounts without delegation
         for (id, value) in stake_distribution_data.unassigned_accounts.iter().cloned() {
-            accounts = accounts.add_account(&id, value, ()).unwrap();
+            accounts = accounts.add_account(id, value, ()).unwrap();
         }
 
         // add accounts with delegation
         for (id, value) in stake_distribution_data.assigned_accounts.iter().cloned() {
-            accounts = accounts.add_account(&id, value, ()).unwrap();
+            accounts = accounts.add_account(id.clone(), value, ()).unwrap();
             accounts = accounts
                 .set_delegation(&id, &DelegationType::Full(id_active_pool.clone()))
                 .unwrap();
@@ -459,7 +459,7 @@ mod tests {
         // add accounts with delegation as a target for delegation addresses
         let single_account = stake_distribution_data.single_account.clone();
         accounts = accounts
-            .add_account(&single_account.0, single_account.1, ())
+            .add_account(single_account.0.clone(), single_account.1, ())
             .unwrap();
         accounts = accounts
             .set_delegation(&single_account.0, &DelegationType::Full(id_active_pool))
@@ -467,7 +467,7 @@ mod tests {
 
         // add accounts with retired stake pool
         for (id, value) in stake_distribution_data.dangling_accounts.iter().cloned() {
-            accounts = accounts.add_account(&id, value, ()).unwrap();
+            accounts = accounts.add_account(id.clone(), value, ()).unwrap();
             accounts = accounts
                 .set_delegation(&id, &DelegationType::Full(id_retired_pool.clone()))
                 .unwrap();

--- a/chain-impl-mockchain/src/vote/manager.rs
+++ b/chain-impl-mockchain/src/vote/manager.rs
@@ -911,7 +911,7 @@ mod tests {
             .unwrap();
 
         let account_ledger = account::Ledger::default()
-            .add_account(&identifier, Value(0), ())
+            .add_account(identifier.clone(), Value(0), ())
             .unwrap()
             .token_add(&identifier, vote_plan.voting_token().clone(), Value(100))
             .unwrap();
@@ -1586,7 +1586,7 @@ mod tests {
         };
         let value = Value(51);
         let account_ledger = account::Ledger::new()
-            .add_account(&wallet.clone().into(), Value(0), ())
+            .add_account(wallet.clone().into(), Value(0), ())
             .unwrap()
             .token_add(&wallet.into(), token.clone(), value)
             .unwrap();
@@ -1618,7 +1618,7 @@ mod tests {
             .unwrap();
 
         let account_ledger = account::Ledger::default()
-            .add_account(&identifier, Value(0), ())
+            .add_account(identifier.clone(), Value(0), ())
             .unwrap()
             .token_add(&identifier, vote_plan.voting_token().clone(), Value(100))
             .unwrap();
@@ -1687,7 +1687,7 @@ mod tests {
             .unwrap();
 
         let account_ledger = account::Ledger::default()
-            .add_account(&identifier, Value(0), ())
+            .add_account(identifier.clone(), Value(0), ())
             .unwrap()
             .token_add(&identifier, vote_plan.voting_token().clone(), Value(100))
             .unwrap();
@@ -1870,7 +1870,7 @@ mod tests {
         let account = TestGen::identifier();
         let token_totals = Default::default();
         let account_ledger = account::Ledger::default()
-            .add_account(&account, Value(1_000), ())
+            .add_account(account.clone(), Value(1_000), ())
             .unwrap()
             .token_add(&account, token_id, Value(1_000))
             .unwrap();
@@ -1909,7 +1909,7 @@ mod tests {
         let account = TestGen::identifier();
         let token_totals = Default::default();
         let account_ledger = account::Ledger::default()
-            .add_account(&account, Value(1_000), ())
+            .add_account(account.clone(), Value(1_000), ())
             .unwrap();
 
         let token_distribution = TokenDistribution::new(&token_totals, &account_ledger);


### PR DESCRIPTION
Remove implicit `clone()` execution inside, so in some places we can get rid of uneeded copy operations.