### PR TITLE
make hamt #[must_use]

### DIFF
--- a/chain-impl-mockchain/src/ledger/iter.rs
+++ b/chain-impl-mockchain/src/ledger/iter.rs
@@ -332,7 +332,7 @@ impl<'a> std::iter::FromIterator<Entry<'a>> for Result<Ledger, Error> {
                     multisig_declarations.push((id.clone(), decl.clone()));
                 }
                 Entry::StakePool((pool_id, pool_state)) => {
-                    delegation
+                    let _ = delegation
                         .stake_pools
                         .insert(pool_id.clone(), pool_state.clone())
                         .unwrap();

--- a/imhamt/Cargo.toml
+++ b/imhamt/Cargo.toml
@@ -14,6 +14,7 @@ test-strategy = { version = "0.1", optional = true }
 criterion = "0.3.0"
 proptest = { git = "https://github.com/input-output-hk/proptest.git" }
 test-strategy = "0.1"
+trybuild = "1"
 
 [target.'cfg(unix)'.dev-dependencies]
 jemalloc-ctl = "0.3"

--- a/imhamt/Cargo.toml
+++ b/imhamt/Cargo.toml
@@ -30,3 +30,6 @@ name = "imhamt"
 
 [features]
 property-test-api = ["proptest", "test-strategy"]
+
+[build-dependencies]
+rustc_version = "0.4"

--- a/imhamt/build.rs
+++ b/imhamt/build.rs
@@ -1,0 +1,8 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // if compiling with a nightly compiler, enable the "nightly" feature
+    if version_meta().unwrap().channel == Channel::Nightly {
+        println!("cargo:rustc-cfg=feature=\"nightly\"");
+    }
+}

--- a/imhamt/src/hamt.rs
+++ b/imhamt/src/hamt.rs
@@ -13,6 +13,7 @@ use std::mem::swap;
 use std::slice;
 
 #[derive(Debug, Clone)]
+#[must_use = "`Hamt`s are not modified in place, instead modified copies are returned`"]
 pub struct Hamt<H: Hasher + Default, K: PartialEq + Eq + Hash, V> {
     root: Node<K, V>,
     hasher: PhantomData<H>,

--- a/imhamt/src/lib.rs
+++ b/imhamt/src/lib.rs
@@ -35,6 +35,12 @@ mod tests {
     }
 
     #[test]
+    fn ui_test() {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("testing/ui/fail/*.rs");
+    }
+
+    #[test]
     fn insert_lookup() {
         let h: Hamt<DefaultHasher, String, u32> = Hamt::new();
 

--- a/imhamt/src/lib.rs
+++ b/imhamt/src/lib.rs
@@ -35,6 +35,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "nightly", ignore)]
     fn ui_test() {
         let t = trybuild::TestCases::new();
         t.compile_fail("testing/ui/fail/*.rs");

--- a/imhamt/testing/ui/fail/ignored_must_use.rs
+++ b/imhamt/testing/ui/fail/ignored_must_use.rs
@@ -1,0 +1,37 @@
+#![allow(dead_code)]
+#![deny(warnings)]
+
+use imhamt::*;
+use std::collections::hash_map::DefaultHasher;
+
+fn main() {}
+
+fn check_insert(map: Hamt<DefaultHasher, i32, i32>) {
+    map.insert(1, 2).unwrap();
+}
+fn check_remove(map: Hamt<DefaultHasher, i32, i32>) {
+    map.remove(&1).unwrap();
+}
+fn check_remove_match(map: Hamt<DefaultHasher, i32, i32>) {
+    map.remove_match(&1, &2).unwrap();
+}
+fn check_replace(map: Hamt<DefaultHasher, i32, i32>) {
+    map.replace(&1, 2).unwrap();
+}
+fn check_update(map: Hamt<DefaultHasher, i32, i32>) {
+    map.update(&1, update).unwrap();
+}
+fn check_insert_or_update(map: Hamt<DefaultHasher, i32, i32>) {
+    map.insert_or_update(1, 2, update).unwrap();
+}
+// fn check_insert_or_update_simple(map: Hamt<DefaultHasher, i32, i32>) {
+//     map.insert_or_update_simple(1, 2, update_simple);
+// }
+
+fn update(x: &i32) -> Result<Option<i32>, std::io::Error> {
+    Ok(Some(*x))
+}
+
+fn update_simple(x: &i32) -> Option<i32> {
+    Some(*x)
+}

--- a/imhamt/testing/ui/fail/ignored_must_use.stderr
+++ b/imhamt/testing/ui/fail/ignored_must_use.stderr
@@ -1,0 +1,53 @@
+error: unused `imhamt::Hamt` that must be used
+  --> testing/ui/fail/ignored_must_use.rs:10:5
+   |
+10 |     map.insert(1, 2).unwrap();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> testing/ui/fail/ignored_must_use.rs:2:9
+   |
+2  | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(unused_must_use)]` implied by `#[deny(warnings)]`
+   = note: `Hamt`s are not modified in place, instead modified copies are returned`
+
+error: unused `imhamt::Hamt` that must be used
+  --> testing/ui/fail/ignored_must_use.rs:13:5
+   |
+13 |     map.remove(&1).unwrap();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Hamt`s are not modified in place, instead modified copies are returned`
+
+error: unused `imhamt::Hamt` that must be used
+  --> testing/ui/fail/ignored_must_use.rs:16:5
+   |
+16 |     map.remove_match(&1, &2).unwrap();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Hamt`s are not modified in place, instead modified copies are returned`
+
+error: unused `imhamt::Hamt` in tuple element 0 that must be used
+  --> testing/ui/fail/ignored_must_use.rs:19:5
+   |
+19 |     map.replace(&1, 2).unwrap();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Hamt`s are not modified in place, instead modified copies are returned`
+
+error: unused `imhamt::Hamt` that must be used
+  --> testing/ui/fail/ignored_must_use.rs:22:5
+   |
+22 |     map.update(&1, update).unwrap();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Hamt`s are not modified in place, instead modified copies are returned`
+
+error: unused `imhamt::Hamt` that must be used
+  --> testing/ui/fail/ignored_must_use.rs:25:5
+   |
+25 |     map.insert_or_update(1, 2, update).unwrap();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Hamt`s are not modified in place, instead modified copies are returned`


### PR DESCRIPTION
Makes the `Hamt` type `#[must_use]`. All operations that modify a hamt return a new copy, so statements like:
```rust
hamt.insert(1, 2).unwrap();
```
are no-ops, and probably bugs. These will now produce warnings

Also adds `trybuild` to test that this warning is actually given