### PR TITLE
Refactor ledger config, remove redundant LedgerParameters

### DIFF
--- a/chain-impl-mockchain/benches/tally.rs
+++ b/chain-impl-mockchain/benches/tally.rs
@@ -171,7 +171,6 @@ fn tally_benchmark(
     });
 
     let alice = controller.wallet(ALICE).unwrap();
-    let parameters = ledger.parameters.clone();
 
     // benchmark producing decryption
     let vote_plans = ledger.ledger.active_vote_plans();
@@ -258,7 +257,7 @@ fn tally_benchmark(
         b.iter(|| {
             ledger
                 .ledger
-                .apply_fragment(&parameters, &fragment, ledger.date())
+                .apply_fragment(&fragment, ledger.date())
                 .unwrap();
         })
     });

--- a/chain-impl-mockchain/src/fee.rs
+++ b/chain-impl-mockchain/src/fee.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroU64;
 
 /// Linear fee using the basic affine formula
 /// `COEFFICIENT * bytes(COUNT(tx.inputs) + COUNT(tx.outputs)) + CONSTANT + CERTIFICATE*COUNT(certificates)`.
-#[derive(PartialEq, Eq, PartialOrd, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Debug, Clone)]
 pub struct LinearFee {
     pub constant: u64,
     pub coefficient: u64,

--- a/chain-impl-mockchain/src/leadership/bft.rs
+++ b/chain-impl-mockchain/src/leadership/bft.rs
@@ -2,7 +2,6 @@ use crate::block::{BftProof, BlockDate, Header, Proof};
 use crate::{
     key::BftLeaderId,
     leadership::{Error, ErrorKind, Verification},
-    ledger::Ledger,
 };
 use std::sync::Arc;
 
@@ -17,13 +16,13 @@ pub struct LeadershipData {
 
 impl LeadershipData {
     /// Create a new BFT leadership
-    pub fn new(ledger: &Ledger) -> Option<Self> {
-        if ledger.settings.bft_leaders.len() == 0 {
+    pub fn new(leaders: &Arc<[BftLeaderId]>) -> Option<Self> {
+        if leaders.len() == 0 {
             return None;
         }
 
         Some(LeadershipData {
-            leaders: Arc::clone(&ledger.settings.bft_leaders),
+            leaders: Arc::clone(leaders),
         })
     }
 
@@ -88,7 +87,7 @@ mod tests {
     use crate::header::HeaderBuilderNew;
     use crate::leadership::tests::generate_ledger_with_bft_leaders;
     use crate::leadership::tests::generate_ledger_with_bft_leaders_count;
-    use crate::ledger::Pots;
+    use crate::ledger::{Ledger, Pots};
     use crate::setting::Settings;
     use crate::testing::data::AddressData;
     use crate::testing::TestGen;
@@ -108,15 +107,15 @@ mod tests {
             TestGen::time_era(),
             Pots::zero(),
         );
-        assert!(LeadershipData::new(&ledger).is_none());
+        assert!(LeadershipData::new(&ledger.settings.bft_leaders).is_none());
     }
 
     #[test]
     fn getters() {
         let leaders_size = 5;
         let (leaders, ledger) = generate_ledger_with_bft_leaders_count(leaders_size);
-        let leadership_data =
-            LeadershipData::new(&ledger).expect("leaders ids collection is empty");
+        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+            .expect("leaders ids collection is empty");
         assert_eq!(leadership_data.number_of_leaders(), leaders_size);
         assert_eq!(&leaders, leadership_data.leaders());
     }
@@ -125,8 +124,8 @@ mod tests {
     fn round_robin_returns_correct_index() {
         let leaders_size = 5;
         let (leaders, ledger) = generate_ledger_with_bft_leaders_count(leaders_size);
-        let leadership_data =
-            LeadershipData::new(&ledger).expect("leaders ids collection is empty");
+        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+            .expect("leaders ids collection is empty");
 
         for i in 0..leaders_size * 2 {
             assert_eq!(
@@ -146,8 +145,8 @@ mod tests {
             .private_key()
             .clone();
         let (_, ledger) = generate_ledger_with_bft_leaders(vec![leader_key.to_public()]);
-        let leadership_data =
-            LeadershipData::new(&ledger).expect("leaders ids collection is empty");
+        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+            .expect("leaders ids collection is empty");
 
         assert!(leadership_data.verify(&header).failure());
     }
@@ -157,8 +156,8 @@ mod tests {
         let wrong_leader_key = TestGen::secret_key();
         let leader_key = TestGen::secret_key();
         let (_, ledger) = generate_ledger_with_bft_leaders(vec![leader_key.to_public()]);
-        let leadership_data =
-            LeadershipData::new(&ledger).expect("leaders ids collection is empty");
+        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+            .expect("leaders ids collection is empty");
 
         let header = HeaderBuilderNew::new(BlockVersion::Ed25519Signed, &Contents::empty())
             .set_parent(&TestGen::hash(), ChainLength(1))
@@ -176,8 +175,8 @@ mod tests {
         let wrong_leader_key = TestGen::secret_key();
         let leader_key = TestGen::secret_key();
         let (_, ledger) = generate_ledger_with_bft_leaders(vec![leader_key.to_public()]);
-        let leadership_data =
-            LeadershipData::new(&ledger).expect("leaders ids collection is empty");
+        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+            .expect("leaders ids collection is empty");
 
         let header = HeaderBuilderNew::new(BlockVersion::Ed25519Signed, &Contents::empty())
             .set_parent(&TestGen::hash(), ChainLength(1))
@@ -194,8 +193,8 @@ mod tests {
     fn verify_correct_verification() {
         let leader_key = TestGen::secret_key();
         let (_, ledger) = generate_ledger_with_bft_leaders(vec![leader_key.to_public()]);
-        let leadership_data =
-            LeadershipData::new(&ledger).expect("leaders ids collection is empty");
+        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+            .expect("leaders ids collection is empty");
 
         let header = HeaderBuilderNew::new(BlockVersion::Ed25519Signed, &Contents::empty())
             .set_parent(&TestGen::hash(), ChainLength(1))

--- a/chain-impl-mockchain/src/leadership/bft.rs
+++ b/chain-impl-mockchain/src/leadership/bft.rs
@@ -16,14 +16,12 @@ pub struct LeadershipData {
 
 impl LeadershipData {
     /// Create a new BFT leadership
-    pub fn new(leaders: &Arc<[BftLeaderId]>) -> Option<Self> {
+    pub fn new(leaders: Arc<[BftLeaderId]>) -> Option<Self> {
         if leaders.len() == 0 {
             return None;
         }
 
-        Some(LeadershipData {
-            leaders: Arc::clone(leaders),
-        })
+        Some(LeadershipData { leaders })
     }
 
     #[inline]
@@ -107,14 +105,14 @@ mod tests {
             TestGen::time_era(),
             Pots::zero(),
         );
-        assert!(LeadershipData::new(&ledger.settings.bft_leaders).is_none());
+        assert!(LeadershipData::new(ledger.settings.bft_leaders).is_none());
     }
 
     #[test]
     fn getters() {
         let leaders_size = 5;
         let (leaders, ledger) = generate_ledger_with_bft_leaders_count(leaders_size);
-        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+        let leadership_data = LeadershipData::new(ledger.settings.bft_leaders)
             .expect("leaders ids collection is empty");
         assert_eq!(leadership_data.number_of_leaders(), leaders_size);
         assert_eq!(&leaders, leadership_data.leaders());
@@ -124,7 +122,7 @@ mod tests {
     fn round_robin_returns_correct_index() {
         let leaders_size = 5;
         let (leaders, ledger) = generate_ledger_with_bft_leaders_count(leaders_size);
-        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+        let leadership_data = LeadershipData::new(ledger.settings.bft_leaders)
             .expect("leaders ids collection is empty");
 
         for i in 0..leaders_size * 2 {
@@ -145,7 +143,7 @@ mod tests {
             .private_key()
             .clone();
         let (_, ledger) = generate_ledger_with_bft_leaders(vec![leader_key.to_public()]);
-        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+        let leadership_data = LeadershipData::new(ledger.settings.bft_leaders)
             .expect("leaders ids collection is empty");
 
         assert!(leadership_data.verify(&header).failure());
@@ -156,7 +154,7 @@ mod tests {
         let wrong_leader_key = TestGen::secret_key();
         let leader_key = TestGen::secret_key();
         let (_, ledger) = generate_ledger_with_bft_leaders(vec![leader_key.to_public()]);
-        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+        let leadership_data = LeadershipData::new(ledger.settings.bft_leaders)
             .expect("leaders ids collection is empty");
 
         let header = HeaderBuilderNew::new(BlockVersion::Ed25519Signed, &Contents::empty())
@@ -175,7 +173,7 @@ mod tests {
         let wrong_leader_key = TestGen::secret_key();
         let leader_key = TestGen::secret_key();
         let (_, ledger) = generate_ledger_with_bft_leaders(vec![leader_key.to_public()]);
-        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+        let leadership_data = LeadershipData::new(ledger.settings.bft_leaders)
             .expect("leaders ids collection is empty");
 
         let header = HeaderBuilderNew::new(BlockVersion::Ed25519Signed, &Contents::empty())
@@ -193,7 +191,7 @@ mod tests {
     fn verify_correct_verification() {
         let leader_key = TestGen::secret_key();
         let (_, ledger) = generate_ledger_with_bft_leaders(vec![leader_key.to_public()]);
-        let leadership_data = LeadershipData::new(&ledger.settings.bft_leaders)
+        let leadership_data = LeadershipData::new(ledger.settings.bft_leaders)
             .expect("leaders ids collection is empty");
 
         let header = HeaderBuilderNew::new(BlockVersion::Ed25519Signed, &Contents::empty())

--- a/chain-impl-mockchain/src/leadership/mod.rs
+++ b/chain-impl-mockchain/src/leadership/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     chaintypes::ConsensusType,
     date::Epoch,
     key::BftLeaderId,
-    ledger::{Ledger, LedgerParameters},
+    ledger::Ledger,
     stake::StakeDistribution,
 };
 use chain_crypto::{Ed25519, RistrettoGroup2HashDh, SecretKey, SumEd25519_12};
@@ -94,8 +94,6 @@ pub struct Leadership {
     era: TimeEra,
     // Consensus specific metadata required for verifying/evaluating leaders
     inner: LeadershipConsensus,
-    // Ledger evaluation parameters fixed for a given epoch
-    ledger_parameters: LedgerParameters,
 }
 
 impl LeadershipConsensus {
@@ -163,7 +161,6 @@ impl Leadership {
             epoch,
             era: ledger.era.clone(),
             inner,
-            ledger_parameters: ledger.get_ledger_parameters(),
         }
     }
 
@@ -202,12 +199,6 @@ impl Leadership {
     /// get the consensus associated with the `Leadership`
     pub fn consensus(&self) -> &LeadershipConsensus {
         &self.inner
-    }
-
-    /// access the ledger parameter for the current leadership
-    #[inline]
-    pub fn ledger_parameters(&self) -> &LedgerParameters {
-        &self.ledger_parameters
     }
 
     /// Verify whether this header has been produced by a leader that fits with the leadership

--- a/chain-impl-mockchain/src/leadership/mod.rs
+++ b/chain-impl-mockchain/src/leadership/mod.rs
@@ -151,7 +151,7 @@ impl Leadership {
     pub fn new(epoch: Epoch, ledger: &Ledger) -> Self {
         let inner = match ledger.settings.consensus_version {
             ConsensusType::Bft => LeadershipConsensus::Bft(
-                bft::LeadershipData::new(&ledger.settings.bft_leaders).unwrap(),
+                bft::LeadershipData::new(ledger.settings.bft_leaders.clone()).unwrap(),
             ),
             ConsensusType::GenesisPraos => {
                 LeadershipConsensus::GenesisPraos(genesis::LeadershipData::new(
@@ -342,7 +342,7 @@ mod tests {
     fn consensus_verify_version_for_bft() {
         let ledger = TestGen::ledger();
 
-        let data = bft::LeadershipData::new(&ledger.settings.bft_leaders)
+        let data = bft::LeadershipData::new(ledger.settings.bft_leaders)
             .expect("Couldn't build leadership data");
 
         let bft_leadership_consensus = LeadershipConsensus::Bft(data);
@@ -362,7 +362,7 @@ mod tests {
     fn consensus_leader_for_bft() {
         let leader_key = AddressData::generate_key_pair::<Ed25519>();
         let (_, ledger) = generate_ledger_with_bft_leaders(vec![leader_key.public_key().clone()]);
-        let leadership_data = bft::LeadershipData::new(&ledger.settings.bft_leaders)
+        let leadership_data = bft::LeadershipData::new(ledger.settings.bft_leaders)
             .expect("leaders ids collection is empty");
         let bft_leadership_consensus = LeadershipConsensus::Bft(leadership_data);
         let header = generate_header_for_leader(leader_key.private_key().clone(), 0);
@@ -376,7 +376,7 @@ mod tests {
             TestGen::secret_keys().take(leaders_count).collect();
         let (leaders, ledger) =
             generate_ledger_with_bft_leaders(leaders_keys.iter().map(|x| x.to_public()).collect());
-        let leadership_data = bft::LeadershipData::new(&ledger.settings.bft_leaders)
+        let leadership_data = bft::LeadershipData::new(ledger.settings.bft_leaders)
             .expect("leaders ids collection is empty");
         let bft_leadership_consensus = LeadershipConsensus::Bft(leadership_data);
 
@@ -404,7 +404,7 @@ mod tests {
         let (_, ledger) =
             generate_ledger_with_bft_leaders(leaders_keys.iter().map(|x| x.to_public()).collect());
 
-        let leadership_data = bft::LeadershipData::new(&ledger.settings.bft_leaders)
+        let leadership_data = bft::LeadershipData::new(ledger.settings.bft_leaders)
             .expect("leaders ids collection is empty");
         let bft_leadership_consensus = LeadershipConsensus::Bft(leadership_data);
 
@@ -424,7 +424,7 @@ mod tests {
     fn is_leader_empty() {
         let ledger = TestGen::ledger();
 
-        let leadership_data = bft::LeadershipData::new(&ledger.settings.bft_leaders)
+        let leadership_data = bft::LeadershipData::new(ledger.settings.bft_leaders)
             .expect("leaders ids collection is empty");
         let bft_leadership_consensus = LeadershipConsensus::Bft(leadership_data);
 

--- a/chain-impl-mockchain/src/ledger/iter.rs
+++ b/chain-impl-mockchain/src/ledger/iter.rs
@@ -197,7 +197,7 @@ impl<'a> Iterator for LedgerIterator<'a> {
             },
             IterState::Accounts(iter) => match iter.next() {
                 None => {
-                    self.state = IterState::ConfigParams(self.ledger.settings.to_config_params().0);
+                    self.state = IterState::ConfigParams(self.ledger.settings.config_params().0);
                     self.next()
                 }
                 Some(x) => Some(Entry::Account(x)),

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -19,7 +19,7 @@ use crate::evm::EvmTransaction;
 use crate::fee::{FeeAlgorithm, LinearFee};
 use crate::fragment::{BlockContentHash, Contents, Fragment, FragmentId};
 use crate::rewards;
-use crate::setting::ActiveSlotsCoeffError;
+use crate::setting::{ActiveSlotsCoeffError, Settings};
 use crate::stake::{PercentStake, PoolError, PoolStakeInformation, PoolsState, StakeDistribution};
 use crate::tokens::identifier::TokenIdentifier;
 use crate::tokens::minting_policy::MintingPolicyViolation;
@@ -627,13 +627,8 @@ impl Ledger {
 
         // Take treasury cut
         total_reward = {
-            let treasury_distr = rewards::tax_cut(
-                total_reward,
-                &self
-                    .settings
-                    .treasury_params
-                    .unwrap_or_else(rewards::TaxType::zero),
-            )?;
+            let treasury_distr =
+                rewards::tax_cut(total_reward, &self.settings.to_treasury_params())?;
             new_ledger.pots.treasury_add(treasury_distr.taxed)?;
             treasury_distr.after_tax
         };
@@ -1763,6 +1758,10 @@ impl ApplyBlockLedger {
         };
 
         new_ledger
+    }
+
+    pub fn settings(&self) -> &Settings {
+        &self.ledger.settings
     }
 }
 

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -598,7 +598,7 @@ impl Ledger {
 
         let expected_epoch_reward = rewards::rewards_contribution_calculation(
             epoch,
-            &self.settings.to_reward_params(),
+            &self.settings.reward_params(),
             &system_info,
         );
 
@@ -627,8 +627,7 @@ impl Ledger {
 
         // Take treasury cut
         total_reward = {
-            let treasury_distr =
-                rewards::tax_cut(total_reward, &self.settings.to_treasury_params())?;
+            let treasury_distr = rewards::tax_cut(total_reward, &self.settings.treasury_params())?;
             new_ledger.pots.treasury_add(treasury_distr.taxed)?;
             treasury_distr.after_tax
         };
@@ -639,7 +638,7 @@ impl Ledger {
 
         if total_reward > Value::zero() {
             // pool capping only exists if there's enough participants
-            let pool_capper = match self.settings.to_reward_params().pool_participation_capping {
+            let pool_capper = match self.settings.reward_params().pool_participation_capping {
                 None => None,
                 Some((threshold, expected_nb_pools)) => {
                     let nb_participants = leaders_log.nb_participants();

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -17,7 +17,7 @@ use crate::config::{self, ConfigParam};
 use crate::date::{BlockDate, Epoch};
 use crate::evm::EvmTransaction;
 use crate::fee::{FeeAlgorithm, LinearFee};
-use crate::fragment::{BlockContentHash, BlockContentSize, Contents, Fragment, FragmentId};
+use crate::fragment::{BlockContentHash, Contents, Fragment, FragmentId};
 use crate::rewards;
 use crate::setting::ActiveSlotsCoeffError;
 use crate::stake::{PercentStake, PoolError, PoolStakeInformation, PoolsState, StakeDistribution};
@@ -26,7 +26,7 @@ use crate::tokens::minting_policy::MintingPolicyViolation;
 use crate::transaction::*;
 use crate::treasury::Treasury;
 use crate::value::*;
-use crate::vote::{CommitteeId, VotePlanLedger, VotePlanLedgerError, VotePlanStatus};
+use crate::vote::{VotePlanLedger, VotePlanLedgerError, VotePlanStatus};
 use crate::{account, certificate, legacy, multisig, setting, stake, update, utxo};
 use crate::{
     certificate::{
@@ -51,28 +51,6 @@ pub struct LedgerStaticParameters {
     pub block0_start_time: config::Block0Date,
     pub discrimination: Discrimination,
     pub kes_update_speed: u32,
-}
-
-// parameters to validate ledger
-#[derive(Debug, Clone)]
-pub struct LedgerParameters {
-    /// Fees expected for transactions and certificates
-    pub fees: LinearFee,
-    /// Tax cut of the treasury which is applied straight after the reward pot
-    /// is fully known
-    pub treasury_tax: rewards::TaxType,
-    /// Reward contribution parameters for this epoch
-    pub reward_params: rewards::Parameters,
-    /// the block content's max size in bytes
-    pub block_content_max_size: BlockContentSize,
-    /// the epoch stability parameter, the depth, number of blocks, to which
-    /// we consider the blockchain to be stable and prevent rollback beyond
-    /// that depth.
-    pub epoch_stability_depth: u32,
-    /// Where the fees get transfered to during the rewards
-    pub fees_goes_to: setting::FeesGoesTo,
-    /// List of committee members
-    pub committees: Arc<[CommitteeId]>,
 }
 
 /// Overall ledger structure.
@@ -107,7 +85,6 @@ pub struct Ledger {
 #[derive(Debug, Clone)]
 pub struct ApplyBlockLedger {
     ledger: Ledger,
-    ledger_params: LedgerParameters,
     block_date: BlockDate,
 }
 
@@ -337,12 +314,6 @@ pub enum Error {
     EvmError(#[from] evm::Error),
 }
 
-impl LedgerParameters {
-    pub fn treasury_tax(&self) -> rewards::TaxType {
-        self.treasury_tax
-    }
-}
-
 impl Ledger {
     pub(crate) fn empty(
         settings: setting::Settings,
@@ -464,8 +435,6 @@ impl Ledger {
             Ledger::empty(settings, static_params, era, pots)
         };
 
-        let params = ledger.get_ledger_parameters();
-
         for content in content_iter {
             let fragment_id = content.hash();
             match content {
@@ -516,7 +485,6 @@ impl Ledger {
                         &tx,
                         cur_date,
                         tx.payload().into_payload(),
-                        &params,
                         tx.payload_auth().into_payload_auth(),
                     )?;
                 }
@@ -605,10 +573,9 @@ impl Ledger {
     ///
     /// * Reset the leaders log
     /// * Distribute the contribution (rewards + fees) to pools and their delegatees
-    pub fn distribute_rewards<'a>(
-        &'a self,
+    pub fn distribute_rewards(
+        &self,
         distribution: &StakeDistribution,
-        ledger_params: &LedgerParameters,
         rewards_info_params: RewardsInfoParameters,
     ) -> Result<(Self, EpochRewardsInfo), Error> {
         let mut new_ledger = self.clone();
@@ -631,7 +598,7 @@ impl Ledger {
 
         let expected_epoch_reward = rewards::rewards_contribution_calculation(
             epoch,
-            &ledger_params.reward_params,
+            &self.settings.to_reward_params(),
             &system_info,
         );
 
@@ -648,7 +615,7 @@ impl Ledger {
 
         // Move fees in the rewarding pots for distribution or depending on settings
         // to the treasury directly
-        match ledger_params.fees_goes_to {
+        match self.settings.fees_goes_to {
             setting::FeesGoesTo::Rewards => {
                 total_reward = (total_reward + new_ledger.pots.siphon_fees()).unwrap();
             }
@@ -660,7 +627,13 @@ impl Ledger {
 
         // Take treasury cut
         total_reward = {
-            let treasury_distr = rewards::tax_cut(total_reward, &ledger_params.treasury_tax)?;
+            let treasury_distr = rewards::tax_cut(
+                total_reward,
+                &self
+                    .settings
+                    .treasury_params
+                    .unwrap_or_else(rewards::TaxType::zero),
+            )?;
             new_ledger.pots.treasury_add(treasury_distr.taxed)?;
             treasury_distr.after_tax
         };
@@ -671,7 +644,7 @@ impl Ledger {
 
         if total_reward > Value::zero() {
             // pool capping only exists if there's enough participants
-            let pool_capper = match ledger_params.reward_params.pool_participation_capping {
+            let pool_capper = match self.settings.to_reward_params().pool_participation_capping {
                 None => None,
                 Some((threshold, expected_nb_pools)) => {
                     let nb_participants = leaders_log.nb_participants();
@@ -856,7 +829,6 @@ impl Ledger {
         new_ledger.settings = settings;
 
         Ok(ApplyBlockLedger {
-            ledger_params: new_ledger.get_ledger_parameters(),
             ledger: new_ledger,
             block_date,
         })
@@ -865,16 +837,15 @@ impl Ledger {
     /// Try to apply messages to a State, and return the new State if successful
     pub fn apply_block(
         &self,
-        ledger_params: LedgerParameters,
         contents: &Contents,
         metadata: &HeaderContentEvalContext,
     ) -> Result<Self, Error> {
         let (content_hash, content_size) = contents.compute_hash_size();
 
-        if content_size > ledger_params.block_content_max_size {
+        if content_size > self.settings.block_content_max_size {
             return Err(Error::InvalidContentSize {
                 actual: content_size,
-                max: ledger_params.block_content_max_size,
+                max: self.settings.block_content_max_size,
             });
         }
 
@@ -903,12 +874,7 @@ impl Ledger {
     /// this does not _advance_ the state to the new _state_ but apply a simple fragment
     /// of block to the current context.
     ///
-    pub fn apply_fragment(
-        &self,
-        ledger_params: &LedgerParameters,
-        content: &Fragment,
-        block_date: BlockDate,
-    ) -> Result<Self, Error> {
+    pub fn apply_fragment(&self, content: &Fragment, block_date: BlockDate) -> Result<Self, Error> {
         let mut new_ledger = self.clone();
 
         let fragment_id = content.hash();
@@ -918,7 +884,7 @@ impl Ledger {
             Fragment::Transaction(tx) => {
                 let tx = tx.as_slice();
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
                 new_ledger = new_ledger_;
             }
             Fragment::OwnerStakeDelegation(tx) => {
@@ -926,7 +892,7 @@ impl Ledger {
                 // this is a lightweight check, do this early to avoid doing any unnecessary computation
                 check::valid_stake_owner_delegation_transaction(&tx)?;
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
 
                 // we've just verified that this is a valid transaction (i.e. contains 1 input and 1 witness)
                 let (account_id, witness) = match tx.inputs().iter().next().unwrap().to_enum() {
@@ -968,13 +934,13 @@ impl Ledger {
                 }
 
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
                 new_ledger = new_ledger_.apply_stake_delegation(&payload)?;
             }
             Fragment::PoolRegistration(tx) => {
                 let tx = tx.as_slice();
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
                 new_ledger = new_ledger_.apply_pool_registration_signcheck(
                     &tx.payload().into_payload(),
                     &tx.transaction_binding_auth_data(),
@@ -985,7 +951,7 @@ impl Ledger {
                 let tx = tx.as_slice();
 
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
                 new_ledger = new_ledger_.apply_pool_retirement(
                     &tx.payload().into_payload(),
                     &tx.transaction_binding_auth_data(),
@@ -996,7 +962,7 @@ impl Ledger {
                 let tx = tx.as_slice();
 
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
                 new_ledger = new_ledger_.apply_pool_update(
                     &tx.payload().into_payload(),
                     &tx.transaction_binding_auth_data(),
@@ -1006,7 +972,7 @@ impl Ledger {
             Fragment::UpdateProposal(tx) => {
                 let tx = tx.as_slice();
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
                 new_ledger = new_ledger_.apply_update_proposal(
                     fragment_id,
                     tx.payload().into_payload(),
@@ -1018,7 +984,7 @@ impl Ledger {
             Fragment::UpdateVote(tx) => {
                 let tx = tx.as_slice();
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
                 new_ledger = new_ledger_.apply_update_vote(
                     &tx.payload().into_payload(),
                     &tx.transaction_binding_auth_data(),
@@ -1028,12 +994,11 @@ impl Ledger {
             Fragment::VotePlan(tx) => {
                 let tx = tx.as_slice();
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
                 new_ledger = new_ledger_.apply_vote_plan(
                     &tx,
                     block_date,
                     tx.payload().into_payload(),
-                    ledger_params,
                     tx.payload_auth().into_payload_auth(),
                 )?;
             }
@@ -1042,7 +1007,7 @@ impl Ledger {
                 // this is a lightweight check, do this early to avoid doing any unnecessary computation
                 check::valid_vote_cast(&tx)?;
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
 
                 // we've just verified that this is a valid transaction (i.e. contains 1 input and 1 witness)
                 let account_id = match tx
@@ -1068,7 +1033,7 @@ impl Ledger {
                 let tx = tx.as_slice();
 
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
 
                 new_ledger = new_ledger_.apply_vote_tally(
                     &tx.payload().into_payload(),
@@ -1080,7 +1045,7 @@ impl Ledger {
                 let tx = tx.as_slice();
 
                 let (new_ledger_, _fee) =
-                    new_ledger.apply_transaction(&fragment_id, &tx, block_date, ledger_params)?;
+                    new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
 
                 new_ledger = new_ledger_.mint_token(tx.payload().into_payload())?;
             }
@@ -1103,12 +1068,8 @@ impl Ledger {
                 #[cfg(feature = "evm")]
                 {
                     let tx = _tx.as_slice();
-                    (new_ledger, _) = new_ledger.apply_transaction(
-                        &fragment_id,
-                        &tx,
-                        block_date,
-                        ledger_params,
-                    )?;
+                    (new_ledger, _) =
+                        new_ledger.apply_transaction(&fragment_id, &tx, block_date)?;
 
                     new_ledger = new_ledger.apply_map_accounts(
                         &tx.payload().into_payload(),
@@ -1131,7 +1092,6 @@ impl Ledger {
         fragment_id: &FragmentId,
         tx: &TransactionSlice<'a, Extra>,
         cur_date: BlockDate,
-        dyn_params: &LedgerParameters,
     ) -> Result<(Self, Value), Error>
     where
         Extra: Payload,
@@ -1139,7 +1099,7 @@ impl Ledger {
     {
         check::valid_transaction_ios_number(tx)?;
         check::valid_transaction_date(&self.settings, tx.valid_until(), cur_date)?;
-        let fee = calculate_fee(tx, dyn_params);
+        let fee = calculate_fee(tx, &self.settings.linear_fees);
         tx.verify_strictly_balanced(fee)?;
         self = self.apply_tx_inputs(tx)?;
         self = self.apply_tx_outputs(*fragment_id, tx.outputs())?;
@@ -1185,12 +1145,11 @@ impl Ledger {
         Ok(self)
     }
 
-    pub fn apply_vote_plan<'a>(
+    pub fn apply_vote_plan(
         mut self,
-        tx: &TransactionSlice<'a, VotePlan>,
+        tx: &TransactionSlice<VotePlan>,
         cur_date: BlockDate,
         vote_plan: VotePlan,
-        dyn_params: &LedgerParameters,
         sig: certificate::VotePlanProof,
     ) -> Result<Self, Error> {
         if sig.verify(&tx.transaction_binding_auth_data()) == Verification::Failed {
@@ -1214,7 +1173,7 @@ impl Ledger {
                 }
             }
         }
-        committee.extend(dyn_params.committees.iter());
+        committee.extend(self.settings.committees.iter());
 
         if !committee.contains(&sig.id) {
             return Err(Error::VotePlanProofInvalidCommittee);
@@ -1458,21 +1417,6 @@ impl Ledger {
 
     pub fn token_distribution(&self) -> TokenDistribution<()> {
         TokenDistribution::new(&self.token_totals, &self.accounts)
-    }
-
-    pub fn get_ledger_parameters(&self) -> LedgerParameters {
-        LedgerParameters {
-            fees: self.settings.linear_fees,
-            treasury_tax: self
-                .settings
-                .treasury_params
-                .unwrap_or_else(rewards::TaxType::zero),
-            reward_params: self.settings.to_reward_params(),
-            block_content_max_size: self.settings.block_content_max_size,
-            epoch_stability_depth: self.settings.epoch_stability_depth,
-            fees_goes_to: self.settings.fees_goes_to,
-            committees: self.settings.committees.clone(),
-        }
     }
 
     pub fn consensus_version(&self) -> ConsensusType {
@@ -1782,9 +1726,7 @@ impl ApplyBlockLedger {
     }
 
     pub fn apply_fragment(&self, fragment: &Fragment) -> Result<Self, Error> {
-        let ledger = self
-            .ledger
-            .apply_fragment(&self.ledger_params, fragment, self.block_date)?;
+        let ledger = self.ledger.apply_fragment(fragment, self.block_date)?;
         Ok(ApplyBlockLedger {
             ledger,
             ..self.clone()
@@ -1842,11 +1784,8 @@ fn apply_old_declaration(
     Ok(utxos)
 }
 
-fn calculate_fee<'a, Extra: Payload>(
-    tx: &TransactionSlice<'a, Extra>,
-    dyn_params: &LedgerParameters,
-) -> Value {
-    dyn_params.fees.calculate_tx(tx)
+fn calculate_fee<'a, Extra: Payload>(tx: &TransactionSlice<'a, Extra>, fees: &LinearFee) -> Value {
+    fees.calculate_tx(tx)
 }
 
 pub enum MatchingIdentifierWitness<'a> {
@@ -1944,7 +1883,7 @@ mod tests {
         key::Hash,
         multisig,
         //reward::RewardParams,
-        setting::{FeesGoesTo, Settings},
+        setting::Settings,
         testing::{
             address::ArbitraryAddressDataValueVec,
             builders::{
@@ -1970,21 +1909,6 @@ mod tests {
                 block0_start_time: Arbitrary::arbitrary(g),
                 discrimination: Arbitrary::arbitrary(g),
                 kes_update_speed: Arbitrary::arbitrary(g),
-            }
-        }
-    }
-
-    impl Arbitrary for LedgerParameters {
-        fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            let committees: Vec<CommitteeId> = Arbitrary::arbitrary(g);
-            LedgerParameters {
-                fees: Arbitrary::arbitrary(g),
-                treasury_tax: Arbitrary::arbitrary(g),
-                reward_params: Arbitrary::arbitrary(g),
-                block_content_max_size: Arbitrary::arbitrary(g),
-                epoch_stability_depth: Arbitrary::arbitrary(g),
-                fees_goes_to: Arbitrary::arbitrary(g),
-                committees: committees.into(),
             }
         }
     }
@@ -2037,7 +1961,7 @@ mod tests {
         let contents = Contents::empty();
         context.content_hash = contents.compute_hash();
 
-        let result = ledger.apply_block(ledger.get_ledger_parameters(), &contents, &context);
+        let result = ledger.apply_block(&contents, &context);
         match (result, should_succeed) {
             (Ok(_), true) => TestResult::passed(),
             (Ok(_), false) => TestResult::error("should pass"),
@@ -2404,35 +2328,23 @@ mod tests {
 
     #[derive(Clone, Debug)]
     pub struct InternalApplyTransactionTestParams {
-        pub dyn_params: LedgerParameters,
         pub static_params: LedgerStaticParameters,
         pub transaction_id: Hash,
     }
 
     impl InternalApplyTransactionTestParams {
         pub fn new() -> Self {
-            InternalApplyTransactionTestParams::new_with_fee(LinearFee::new(0, 0, 0))
+            InternalApplyTransactionTestParams::new_with_fee()
         }
 
-        pub fn new_with_fee(fees: LinearFee) -> Self {
+        pub fn new_with_fee() -> Self {
             let static_params = LedgerStaticParameters {
                 block0_initial_hash: TestGen::hash(),
                 block0_start_time: config::Block0Date(0),
                 discrimination: Discrimination::Test,
                 kes_update_speed: 100,
             };
-
-            let dyn_params = LedgerParameters {
-                fees,
-                treasury_tax: rewards::TaxType::zero(),
-                reward_params: rewards::Parameters::zero(),
-                block_content_max_size: 10_240,
-                epoch_stability_depth: 1000,
-                fees_goes_to: FeesGoesTo::Rewards,
-                committees: Arc::new([]),
-            };
             InternalApplyTransactionTestParams {
-                dyn_params,
                 static_params,
                 transaction_id: TestGen::hash(),
             }

--- a/chain-impl-mockchain/src/ledger/tests/certificate_tests/update.rs
+++ b/chain-impl-mockchain/src/ledger/tests/certificate_tests/update.rs
@@ -59,7 +59,7 @@ pub fn ledger_adopt_settings_from_update_proposal(
         .unwrap();
 
     // assert
-    let actual_params = testledger.ledger.settings.to_config_params();
+    let actual_params = testledger.ledger.settings.config_params();
     let expected_params = update_proposal_data.proposal_settings();
 
     let mut all_settings_equal = true;

--- a/chain-impl-mockchain/src/ledger/tests/ledger_tests.rs
+++ b/chain-impl-mockchain/src/ledger/tests/ledger_tests.rs
@@ -61,7 +61,7 @@ pub fn total_funds_are_const_in_ledger(
 ) -> TestResult {
     let config = ConfigBuilder::new()
         .with_discrimination(Discrimination::Test)
-        .with_fee(transaction_data.fee);
+        .with_fee(transaction_data.fee.clone());
 
     let mut ledger = LedgerBuilder::from_config(config)
         .initial_funds(&transaction_data.addresses)

--- a/chain-impl-mockchain/src/multiverse.rs
+++ b/chain-impl-mockchain/src/multiverse.rs
@@ -255,13 +255,7 @@ mod test {
             let block = store.get(hash).unwrap();
             let header_meta = block.header().get_content_eval_context();
             let state = state_ref.state();
-            let state = state
-                .apply_block(
-                    state.get_ledger_parameters(),
-                    block.contents(),
-                    &header_meta,
-                )
-                .unwrap();
+            let state = state.apply_block(block.contents(), &header_meta).unwrap();
             state_ref = multiverse.add(*hash, state);
         }
 
@@ -273,11 +267,7 @@ mod test {
             assert_eq!(state.chain_length().0 + 1, block.header().chain_length().0);
         }
         state
-            .apply_block(
-                state.get_ledger_parameters(),
-                block.contents(),
-                &block.header().get_content_eval_context(),
-            )
+            .apply_block(block.contents(), &block.header().get_content_eval_context())
             .unwrap()
     }
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -142,10 +142,6 @@ impl Settings {
         }
     }
 
-    pub fn linear_fees(&self) -> LinearFee {
-        self.linear_fees
-    }
-
     pub fn try_apply(&self, changes: &ConfigParams) -> Result<Self, update::Error> {
         let mut new_state = self.clone();
         let mut per_certificate_fees = None;
@@ -200,7 +196,7 @@ impl Settings {
                         .into();
                 }
                 ConfigParam::LinearFee(d) => {
-                    new_state.linear_fees = *d;
+                    new_state.linear_fees = d.clone();
                 }
                 ConfigParam::ProposalExpiration(d) => {
                     new_state.proposal_expiration = *d;
@@ -287,7 +283,7 @@ impl Settings {
         for bft_leader in self.bft_leaders.iter() {
             params.push(ConfigParam::AddBftLeader(bft_leader.clone()));
         }
-        params.push(ConfigParam::LinearFee(self.linear_fees));
+        params.push(ConfigParam::LinearFee(self.linear_fees.clone()));
         params.push(ConfigParam::ProposalExpiration(self.proposal_expiration));
         params.push(ConfigParam::TransactionMaxExpiryEpochs(
             self.transaction_max_expiry_epochs,

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -267,7 +267,7 @@ impl Settings {
         Ok(new_state)
     }
 
-    pub fn to_config_params(&self) -> ConfigParams {
+    pub fn config_params(&self) -> ConfigParams {
         let mut params = ConfigParams::new();
 
         params.push(ConfigParam::ConsensusVersion(self.consensus_version));
@@ -307,11 +307,11 @@ impl Settings {
         params
     }
 
-    pub fn to_treasury_params(&self) -> TaxType {
+    pub fn treasury_params(&self) -> TaxType {
         self.treasury_params.unwrap_or_else(rewards::TaxType::zero)
     }
 
-    pub fn to_reward_params(&self) -> rewards::Parameters {
+    pub fn reward_params(&self) -> rewards::Parameters {
         let reward_drawing_limit_max = self.rewards_limit.clone();
         let pool_participation_capping = self.pool_participation_capping;
 

--- a/chain-impl-mockchain/src/setting.rs
+++ b/chain-impl-mockchain/src/setting.rs
@@ -5,6 +5,7 @@
 use crate::config::EvmEnvSettings;
 use crate::fragment::{config::ConfigParams, BlockContentSize};
 use crate::milli::Milli;
+use crate::rewards::TaxType;
 use crate::update;
 use crate::{
     chaineval::PraosNonce,
@@ -36,8 +37,8 @@ pub struct Settings {
     /// it expires at the start of epoch 'epoch_p +
     /// proposal_expiration + 1'. FIXME: make updateable.
     pub proposal_expiration: u32,
-    pub reward_params: Option<RewardParams>,
-    pub treasury_params: Option<rewards::TaxType>,
+    reward_params: Option<RewardParams>,
+    treasury_params: Option<rewards::TaxType>,
     pub fees_goes_to: FeesGoesTo,
     pub rewards_limit: rewards::Limit,
     pub pool_participation_capping: Option<(NonZeroU32, NonZeroU32)>,
@@ -308,6 +309,10 @@ impl Settings {
         debug_assert_eq!(self, &Settings::new().try_apply(&params).unwrap());
 
         params
+    }
+
+    pub fn to_treasury_params(&self) -> TaxType {
+        self.treasury_params.unwrap_or_else(rewards::TaxType::zero)
     }
 
     pub fn to_reward_params(&self) -> rewards::Parameters {

--- a/chain-impl-mockchain/src/testing/ledger.rs
+++ b/chain-impl-mockchain/src/testing/ledger.rs
@@ -720,7 +720,13 @@ impl TestLedger {
         stake_pools: Vec<StakePool>,
         fragments: Vec<Fragment>,
     ) -> Result<bool, Error> {
-        let selection = LeadershipData::new(self.date().epoch, &self.ledger);
+        let selection = LeadershipData::new(
+            self.date().epoch,
+            self.ledger.get_stake_distribution(),
+            self.ledger.delegation.clone(),
+            self.ledger.settings.consensus_nonce.clone(),
+            self.ledger.settings.active_slots_coeff,
+        );
         for stake_pool in stake_pools {
             if selection
                 .leader(

--- a/chain-impl-mockchain/src/testing/ledger.rs
+++ b/chain-impl-mockchain/src/testing/ledger.rs
@@ -12,8 +12,8 @@ use crate::{
     key::BftLeaderId,
     leadership::genesis::LeadershipData,
     ledger::{
-        check::CHECK_TX_MAXIMUM_INPUTS, Error, LeadersParticipationRecord, Ledger,
-        LedgerParameters, Pots, RewardsInfoParameters,
+        check::CHECK_TX_MAXIMUM_INPUTS, Error, LeadersParticipationRecord, Ledger, Pots,
+        RewardsInfoParameters,
     },
     milli::Milli,
     rewards::{Ratio, TaxType},
@@ -496,16 +496,12 @@ impl LedgerBuilder {
         fragments.extend_from_slice(&self.certs);
 
         let faucets = self.faucets;
-        Ledger::new(block0_hash, &fragments).map(|ledger| {
-            let parameters = ledger.get_ledger_parameters();
-            TestLedger {
-                cfg,
-                faucets,
-                ledger,
-                block0_hash,
-                utxodb,
-                parameters,
-            }
+        Ledger::new(block0_hash, &fragments).map(|ledger| TestLedger {
+            cfg,
+            faucets,
+            ledger,
+            block0_hash,
+            utxodb,
         })
     }
 }
@@ -515,7 +511,6 @@ pub struct TestLedger {
     pub cfg: ConfigParams,
     pub faucets: Vec<AddressDataValue>,
     pub ledger: Ledger,
-    pub parameters: LedgerParameters,
     pub utxodb: UtxoDb,
 }
 
@@ -524,12 +519,11 @@ impl TestLedger {
         let fragment_id = fragment.hash();
         match fragment {
             Fragment::Transaction(tx) => {
-                match self.ledger.clone().apply_transaction(
-                    &fragment_id,
-                    &tx.as_slice(),
-                    date,
-                    &self.parameters,
-                ) {
+                match self
+                    .ledger
+                    .clone()
+                    .apply_transaction(&fragment_id, &tx.as_slice(), date)
+                {
                     Err(err) => Err(err),
                     Ok((ledger, _)) => {
                         // TODO more bookkeeping for accounts and utxos
@@ -543,20 +537,16 @@ impl TestLedger {
     }
 
     pub fn apply_fragment(&mut self, fragment: &Fragment, date: BlockDate) -> Result<(), Error> {
-        self.ledger = self
-            .ledger
-            .clone()
-            .apply_fragment(&self.parameters, fragment, date)?;
+        self.ledger = self.ledger.clone().apply_fragment(fragment, date)?;
         Ok(())
     }
 
     pub fn apply_block(&mut self, block: Block) -> Result<(), Error> {
         let header_meta = block.header().get_content_eval_context();
-        self.ledger = self.ledger.clone().apply_block(
-            self.ledger.get_ledger_parameters(),
-            block.contents(),
-            &header_meta,
-        )?;
+        self.ledger = self
+            .ledger
+            .clone()
+            .apply_block(block.contents(), &header_meta)?;
         Ok(())
     }
 
@@ -596,7 +586,7 @@ impl TestLedger {
     }
 
     pub fn fee(&self) -> LinearFee {
-        self.parameters.fees
+        self.ledger.settings.linear_fees
     }
 
     pub fn chain_length(&self) -> ChainLength {
@@ -641,7 +631,6 @@ impl TestLedger {
     pub fn distribute_rewards(&mut self) -> Result<(), Error> {
         match self.ledger.distribute_rewards(
             &self.ledger.get_stake_distribution(),
-            &self.ledger.get_ledger_parameters(),
             RewardsInfoParameters::default(),
         ) {
             Err(err) => Err(err),

--- a/chain-impl-mockchain/src/testing/ledger.rs
+++ b/chain-impl-mockchain/src/testing/ledger.rs
@@ -586,7 +586,7 @@ impl TestLedger {
     }
 
     pub fn fee(&self) -> LinearFee {
-        self.ledger.settings.linear_fees
+        self.ledger.settings.linear_fees.clone()
     }
 
     pub fn chain_length(&self) -> ChainLength {

--- a/chain-impl-mockchain/src/testing/scenario/fragment_factory.rs
+++ b/chain-impl-mockchain/src/testing/scenario/fragment_factory.rs
@@ -191,13 +191,14 @@ impl FragmentFactory {
         signer: &Wallet,
         update_proposal: UpdateProposal,
     ) -> Fragment {
-        TestTxCertBuilder::new(self.block0_hash, self.fee).make_transaction_different_signers(
-            valid_until,
-            owner,
-            vec![signer],
-            &update_proposal.into(),
-            self.witness_mode,
-        )
+        TestTxCertBuilder::new(self.block0_hash, self.fee.clone())
+            .make_transaction_different_signers(
+                valid_until,
+                owner,
+                vec![signer],
+                &update_proposal.into(),
+                self.witness_mode,
+            )
     }
 
     pub fn update_vote(
@@ -207,13 +208,14 @@ impl FragmentFactory {
         signer: &Wallet,
         update_vote: UpdateVote,
     ) -> Fragment {
-        TestTxCertBuilder::new(self.block0_hash, self.fee).make_transaction_different_signers(
-            valid_until,
-            owner,
-            vec![signer],
-            &update_vote.into(),
-            self.witness_mode,
-        )
+        TestTxCertBuilder::new(self.block0_hash, self.fee.clone())
+            .make_transaction_different_signers(
+                valid_until,
+                owner,
+                vec![signer],
+                &update_vote.into(),
+                self.witness_mode,
+            )
     }
 
     pub fn mint_token(
@@ -231,7 +233,7 @@ impl FragmentFactory {
         wallets: impl IntoIterator<Item = &'a Wallet>,
         certificate: &Certificate,
     ) -> Fragment {
-        TestTxCertBuilder::new(self.block0_hash, self.fee).make_transaction(
+        TestTxCertBuilder::new(self.block0_hash, self.fee.clone()).make_transaction(
             valid_until,
             wallets,
             certificate,


### PR DESCRIPTION
We have LedgerParameters struct [chain-libs/ledger.rs at 8129ec87d68de7013c5c542ebae1136868912ab6 · input-output-hk/chain-libs](https://github.com/input-output-hk/chain-libs/blob/8129ec87d68de7013c5c542ebae1136868912ab6/chain-impl-mockchain/src/ledger/ledger.rs#L53)  and Settings struct [chain-libs/setting.rs at ff539c523cfd5b9dfd9c42ff128c60c3cbd25b27 · input-output-hk/chain-libs](https://github.com/input-output-hk/chain-libs/blob/ff539c523cfd5b9dfd9c42ff128c60c3cbd25b27/chain-impl-mockchain/src/setting.rs#L23)  . Those two structs have the same fields as 
```
    /// Fees expected for transactions and certificates
2    pub fees: LinearFee,
3    /// Tax cut of the treasury which is applied straight after the reward pot
4    /// is fully known
5    pub treasury_tax: rewards::TaxType,
6    /// Reward contribution parameters for this epoch
7    pub reward_params: rewards::Parameters,
8    /// the block content's max size in bytes
9    pub block_content_max_size: BlockContentSize,
10    /// the epoch stability parameter, the depth, number of blocks, to which
11    /// we consider the blockchain to be stable and prevent rollback beyond
12    /// that depth.
13    pub epoch_stability_depth: u32,
14    /// Where the fees get transfered to during the rewards
15    pub fees_goes_to: setting::FeesGoesTo,
16    /// List of committee members
17    pub committees: Arc<[CommitteeId]>,
```
and these two structs are fields of the ApplyBlockLedger [chain-libs/ledger.rs at 8129ec87d68de7013c5c542ebae1136868912ab6 · input-output-hk/chain-libs](https://github.com/input-output-hk/chain-libs/blob/8129ec87d68de7013c5c542ebae1136868912ab6/chain-impl-mockchain/src/ledger/ledger.rs#L101) , (Settings struct is a field of the Ledger struct) so it is possible to have an inconsistency of these values.

So intention is to simplify code, and remove duplicated `LedgerParameters` struct with its usage