### PR TITLE
fix and refactor validate_ledger test

### DIFF
--- a/chain-impl-mockchain/src/testing/e2e/transactions.rs
+++ b/chain-impl-mockchain/src/testing/e2e/transactions.rs
@@ -52,7 +52,7 @@ pub fn validate_ledger_state_after_transaction(amount: Random1to10, linear_fee: 
 pub fn validate_ledger_state_after_invalid_transaction(amount: Random1to10, linear_fee: LinearFee) {
     let total_fees = linear_fee.calculate(None, 1, 1);
     let valid_transaction_amount = total_fees.0 + amount.0;
-    let alice_initial_balance = amount.0 + valid_transaction_amount + total_fees.0;
+    let alice_initial_balance = valid_transaction_amount + total_fees.0;
     let bob_initial_balance = BASIC_BALANCE;
 
     let (mut ledger, controller) = prepare_scenario()
@@ -68,28 +68,21 @@ pub fn validate_ledger_state_after_invalid_transaction(amount: Random1to10, line
     let bob = controller.wallet("Bob").unwrap();
 
     controller
-        .transfer_funds(
-            &alice,
-            &bob,
-            &mut ledger,
-            valid_transaction_amount + total_fees.0,
-        )
+        .transfer_funds(&alice, &bob, &mut ledger, alice_initial_balance)
         .unwrap();
 
     alice.confirm_transaction();
 
     // this second transaction should fail as alice does not have the balance to cover for it
-    let _ = controller.transfer_funds(
-        &alice,
-        &bob,
-        &mut ledger,
-        valid_transaction_amount + total_fees.0,
-    );
+    let _ = controller.transfer_funds(&alice, &bob, &mut ledger, alice_initial_balance);
 
     alice.confirm_transaction();
 
+    LedgerStateVerifier::new(ledger.clone().into())
+        .address_has_expected_balance(alice.as_account_data(), Value(0));
+
     LedgerStateVerifier::new(ledger.into()).address_has_expected_balance(
-        alice.as_account_data(),
-        Value(alice_initial_balance - (valid_transaction_amount + total_fees.0)),
+        bob.as_account_data(),
+        Value(bob_initial_balance + valid_transaction_amount),
     );
 }


### PR DESCRIPTION
Fixing validate_ledger_test. We initialized alice balance with amount.0 + valid_transaction_amount and valid_transaction_amount is equal to total_fees.0 + amount.0. So looks like alice got twice the amount we are expected in test. Fixed sending all the initial alice balance in the first transaction, leaving alice with 0 balance, and therefore making the second trasaction fail