### PR TITLE
refactoring Ethereum signatures & fixing EvmMapping sign/recover

### DIFF
--- a/chain-evm/src/crypto.rs
+++ b/chain-evm/src/crypto.rs
@@ -1,0 +1,13 @@
+//! Cryptography for Ethereum types.
+pub mod secp256k1 {
+    //! Re-export of types for constructing Ethereum signatures.
+    pub use secp256k1::{
+        ecdsa::{RecoverableSignature, RecoveryId},
+        Message,
+    };
+}
+
+pub mod sha3 {
+    //! Re-export of types and traits for constructing Ethereum hashes used in signatures.
+    pub use sha3::{Digest, Keccak256};
+}

--- a/chain-evm/src/crypto.rs
+++ b/chain-evm/src/crypto.rs
@@ -3,7 +3,7 @@ pub mod secp256k1 {
     //! Re-export of types for constructing Ethereum signatures.
     pub use secp256k1::{
         ecdsa::{RecoverableSignature, RecoveryId},
-        Message,
+        Error, Message,
     };
 }
 

--- a/chain-evm/src/lib.rs
+++ b/chain-evm/src/lib.rs
@@ -2,8 +2,10 @@ pub use ethereum;
 pub use ethereum_types;
 pub use rlp;
 
+pub mod crypto;
 pub mod machine;
 mod precompiles;
+pub mod signature;
 pub mod state;
 pub mod transaction;
 pub mod util;

--- a/chain-evm/src/signature.rs
+++ b/chain-evm/src/signature.rs
@@ -6,7 +6,7 @@ use ethereum_types::H256;
 /// Byte size for 'r' and 's' components of a signature.
 const SIGNATURE_BYTES: usize = 32;
 
-/// Legacy transaction signature as specified in [EIP-155](https://eips.ethereum.org/EIPS/eip-155).
+/// Legacy transaction signature, as specified in [EIP-155](https://eips.ethereum.org/EIPS/eip-155).
 pub fn sign_eip_155(
     tx: &LegacyTransactionMessage,
     secret: &Secret,
@@ -23,7 +23,7 @@ pub fn sign_eip_155(
         .ok_or(secp256k1::Error::InvalidSignature)
 }
 
-/// Type 1 transaction signature as specified in [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930).
+/// Type 1 transaction signature, as specified in [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930).
 pub fn eip_2930_signature(
     tx_hash: &H256,
     secret: &Secret,

--- a/chain-evm/src/signature.rs
+++ b/chain-evm/src/signature.rs
@@ -1,0 +1,48 @@
+//! Ethereum signatures for EIP-191, Legacy Transactions (EIP-155), EIP-2930, and EIP-1559.
+use crate::util::Secret;
+use ethereum::{LegacyTransactionMessage, TransactionSignature};
+use ethereum_types::H256;
+
+/// Byte size for 'r' and 's' components of a signature.
+const SIGNATURE_BYTES: usize = 32;
+
+/// Legacy transaction signature as specified in [EIP-155](https://eips.ethereum.org/EIPS/eip-155).
+pub fn sign_eip_155(
+    tx: &LegacyTransactionMessage,
+    secret: &Secret,
+) -> Result<TransactionSignature, secp256k1::Error> {
+    let sig = super::util::sign_data_hash(&tx.hash(), secret)?;
+    let (recovery_id, sig_bytes) = sig.serialize_compact();
+    let v = if let Some(chain_id) = tx.chain_id {
+        recovery_id.to_i32() as u64 + chain_id * 2 + 35
+    } else {
+        recovery_id.to_i32() as u64 + 27
+    };
+    let (r, s) = sig_bytes.split_at(SIGNATURE_BYTES);
+    TransactionSignature::new(v, H256::from_slice(r), H256::from_slice(s))
+        .ok_or(secp256k1::Error::InvalidSignature)
+}
+
+/// Type 1 transaction signature as specified in [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930).
+pub fn eip_2930_signature(
+    tx_hash: &H256,
+    secret: &Secret,
+) -> Result<TransactionSignature, secp256k1::Error> {
+    let sig = super::util::sign_data_hash(tx_hash, secret)?;
+    let (recovery_id, sig_bytes) = sig.serialize_compact();
+    let (r, s) = sig_bytes.split_at(SIGNATURE_BYTES);
+    TransactionSignature::new(
+        recovery_id.to_i32() as u64 % 2,
+        H256::from_slice(r),
+        H256::from_slice(s),
+    )
+    .ok_or(secp256k1::Error::InvalidSignature)
+}
+
+/// Type 2 transaction signature as specified in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559).
+pub fn eip_1559_signature(
+    tx_hash: &H256,
+    secret: &Secret,
+) -> Result<TransactionSignature, secp256k1::Error> {
+    eip_2930_signature(tx_hash, secret)
+}

--- a/chain-evm/src/transaction.rs
+++ b/chain-evm/src/transaction.rs
@@ -23,6 +23,12 @@ pub enum EthereumUnsignedTransaction {
 }
 
 impl EthereumUnsignedTransaction {
+    /// Decode an unsigned transaction from RLP-encoded bytes.
+    pub fn from_bytes(data: &[u8]) -> Result<Self, DecoderError> {
+        let rlp = Rlp::new(data);
+        EthereumUnsignedTransaction::decode(&rlp)
+    }
+    /// Transaction hash, used for signing.
     pub fn hash(&self) -> H256 {
         match self {
             Self::Legacy(tx) => tx.hash(),

--- a/chain-evm/src/transaction.rs
+++ b/chain-evm/src/transaction.rs
@@ -1,8 +1,9 @@
 use crate::{util::Secret, Address};
 use ethereum::{
-    EIP1559TransactionMessage, EIP2930TransactionMessage, LegacyTransactionMessage, TransactionV2,
+    util::enveloped, EIP1559TransactionMessage, EIP2930TransactionMessage,
+    LegacyTransactionMessage, TransactionV2,
 };
-use ethereum_types::H256;
+use ethereum_types::{H256, U256};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use secp256k1::{
     ecdsa::{RecoverableSignature, RecoveryId},
@@ -84,6 +85,98 @@ impl EthereumUnsignedTransaction {
                     },
                 )))
             }
+        }
+    }
+}
+
+impl Decodable for EthereumUnsignedTransaction {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
+        let slice = rlp.data()?;
+
+        let first = *slice.get(0).ok_or(DecoderError::Custom("empty slice"))?;
+
+        let item_count = rlp.item_count()?;
+
+        if item_count == 6 {
+            return Ok(Self::Legacy(LegacyTransactionMessage {
+                nonce: rlp.val_at(0)?,
+                gas_price: rlp.val_at(1)?,
+                gas_limit: rlp.val_at(2)?,
+                action: rlp.val_at(3)?,
+                value: rlp.val_at(4)?,
+                input: rlp.val_at(5)?,
+                chain_id: None,
+            }));
+        }
+        if item_count == 9 {
+            let r = {
+                let mut bytes = [0u8; 32];
+                rlp.val_at::<U256>(7)?.to_big_endian(&mut bytes);
+                H256::from(bytes)
+            };
+            let s = {
+                let mut bytes = [0u8; 32];
+                rlp.val_at::<U256>(8)?.to_big_endian(&mut bytes);
+                H256::from(bytes)
+            };
+            if r == H256::zero() && s == H256::zero() {
+                return Ok(Self::Legacy(LegacyTransactionMessage {
+                    nonce: rlp.val_at(0)?,
+                    gas_price: rlp.val_at(1)?,
+                    gas_limit: rlp.val_at(2)?,
+                    action: rlp.val_at(3)?,
+                    value: rlp.val_at(4)?,
+                    input: rlp.val_at(5)?,
+                    chain_id: rlp.val_at(6)?,
+                }));
+            }
+        }
+
+        let rlp = Rlp::new(slice.get(1..).ok_or(DecoderError::Custom("no tx body"))?);
+
+        if first == 1u8 {
+            if rlp.item_count()? != 9 {
+                return Err(DecoderError::RlpIncorrectListLen);
+            }
+            return Ok(Self::EIP2930(EIP2930TransactionMessage {
+                chain_id: rlp.val_at(1)?,
+                nonce: rlp.val_at(2)?,
+                gas_price: rlp.val_at(3)?,
+                gas_limit: rlp.val_at(4)?,
+                action: rlp.val_at(5)?,
+                value: rlp.val_at(6)?,
+                input: rlp.val_at(7)?,
+                access_list: rlp.list_at(8)?,
+            }));
+        }
+
+        if first == 2u8 {
+            if rlp.item_count()? != 10 {
+                return Err(DecoderError::RlpIncorrectListLen);
+            }
+            return Ok(Self::EIP1559(EIP1559TransactionMessage {
+                chain_id: rlp.val_at(0)?,
+                nonce: rlp.val_at(1)?,
+                max_priority_fee_per_gas: rlp.val_at(2)?,
+                max_fee_per_gas: rlp.val_at(3)?,
+                gas_limit: rlp.val_at(4)?,
+                action: rlp.val_at(5)?,
+                value: rlp.val_at(6)?,
+                input: rlp.val_at(7)?,
+                access_list: rlp.list_at(8)?,
+            }));
+        }
+
+        Err(DecoderError::Custom("invalid tx type"))
+    }
+}
+
+impl Encodable for EthereumUnsignedTransaction {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        match self {
+            Self::Legacy(tx) => tx.rlp_append(s),
+            Self::EIP2930(tx) => enveloped(1, tx, s),
+            Self::EIP1559(tx) => enveloped(2, tx, s),
         }
     }
 }

--- a/chain-evm/src/util.rs
+++ b/chain-evm/src/util.rs
@@ -60,6 +60,14 @@ pub fn generate_account_secret() -> Secret {
     Secret::from(&keypair)
 }
 
+/// Sign raw data bytes with a secret key.
+pub fn sign_data(data: &[u8], secret: &Secret) -> Result<RecoverableSignature, secp256k1::Error> {
+    let s = Secp256k1::new();
+    let h = Message::from_slice(data)?;
+    let secret = secret.seckey();
+    Ok(s.sign_ecdsa_recoverable(&h, secret))
+}
+
 /// Sign a given hash of data with a secret key.
 pub fn sign_data_hash(
     tx_hash: &H256,

--- a/chain-impl-mockchain/src/evm/mod.rs
+++ b/chain-impl-mockchain/src/evm/mod.rs
@@ -4,7 +4,7 @@ use chain_core::{
     property::{Deserialize, ReadError, Serialize, WriteError},
 };
 #[cfg(feature = "evm")]
-pub use chain_evm::Config;
+pub use chain_evm::{crypto, signature, util, Config};
 #[cfg(feature = "evm")]
 use chain_evm::{
     ethereum::{TransactionAction, TransactionV2},

--- a/chain-impl-mockchain/src/ledger/ledger.rs
+++ b/chain-impl-mockchain/src/ledger/ledger.rs
@@ -15,6 +15,7 @@ use crate::chaineval::HeaderContentEvalContext;
 use crate::chaintypes::{ChainLength, ConsensusType, HeaderId};
 use crate::config::{self, ConfigParam};
 use crate::date::{BlockDate, Epoch};
+#[cfg(feature = "evm")]
 use crate::evm::EvmTransaction;
 use crate::fee::{FeeAlgorithm, LinearFee};
 use crate::fragment::{BlockContentHash, Contents, Fragment, FragmentId};
@@ -37,6 +38,8 @@ use crate::{
 };
 use chain_addr::{Address, Discrimination, Kind};
 use chain_crypto::Verification;
+#[cfg(feature = "evm")]
+use chain_evm::state::ByteCode;
 use chain_time::{Epoch as TimeEpoch, SlotDuration, TimeEra, TimeFrame, Timeline};
 use std::collections::HashSet;
 use std::mem::swap;
@@ -1415,6 +1418,16 @@ impl Ledger {
 
     pub fn consensus_version(&self) -> ConsensusType {
         self.settings.consensus_version
+    }
+
+    #[cfg(feature = "evm")]
+    pub fn call_evm_transaction(&self, tx: EvmTransaction) -> Result<ByteCode, Error> {
+        Ok(evm::Ledger::call_evm_transaction(
+            self.evm.clone(),
+            self.accounts.clone(),
+            tx,
+            self.settings.evm_config,
+        )?)
     }
 
     #[cfg(feature = "evm")]


### PR DESCRIPTION
This PR intends to refactor Ethereum signatures for the relevant EIPs, in order to implement in a well-documented fashion the different types of hashes used for signatures used in the EVM.

This PR also solves signature/recovery for EvmMapping certificates.